### PR TITLE
Char type

### DIFF
--- a/weld/ast.rs
+++ b/weld/ast.rs
@@ -52,7 +52,7 @@ pub enum Type {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum ScalarKind {
     Bool,
-    Char,
+    I8,
     I32,
     I64,
     F32,
@@ -64,7 +64,7 @@ impl fmt::Display for ScalarKind {
         use ast::ScalarKind::*;
         let text = match *self {
             Bool => "bool",
-            Char => "char",
+            I8 => "i8",
             I32 => "i32",
             I64 => "i64",
             F32 => "f32",
@@ -162,7 +162,7 @@ pub enum ExprKind<T: TypeBounds> {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum LiteralKind {
     BoolLiteral(bool),
-    CharLiteral(char),
+    I8Literal(i8),
     I32Literal(i32),
     I64Literal(i64),
     F32Literal(f32),

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -498,7 +498,7 @@ impl LlvmGenerator {
     fn llvm_type(&mut self, ty: &Type) -> WeldResult<&str> {
         match *ty {
             Scalar(Bool) => Ok("i1"),
-            Scalar(Char) => Ok("i8"),
+            Scalar(I8) => Ok("i8"),
             Scalar(I32) => Ok("i32"),
             Scalar(I64) => Ok("i64"),
             Scalar(F32) => Ok("float"),
@@ -874,7 +874,7 @@ impl LlvmGenerator {
                                                      if l { 1 } else { 0 },
                                                      llvm_symbol(output)))
                             }
-                            CharLiteral(l) => {
+                            I8Literal(l) => {
                                 ctx.code.add(format!("store i8 {}, i8* {}", l, llvm_symbol(output)))
                             }
                             I32Literal(l) => {
@@ -1345,7 +1345,7 @@ fn types() {
     assert_eq!(gen.llvm_type(&Scalar(I64)).unwrap(), "i64");
     assert_eq!(gen.llvm_type(&Scalar(F32)).unwrap(), "float");
     assert_eq!(gen.llvm_type(&Scalar(F64)).unwrap(), "double");
-    assert_eq!(gen.llvm_type(&Scalar(Char)).unwrap(), "i8");
+    assert_eq!(gen.llvm_type(&Scalar(I8)).unwrap(), "i8");
     assert_eq!(gen.llvm_type(&Scalar(Bool)).unwrap(), "i1");
 
     let struct1 = parse_type("{i32,bool,i32}").unwrap().to_type().unwrap();

--- a/weld/parser.rs
+++ b/weld/parser.rs
@@ -492,7 +492,7 @@ impl<'t> Parser<'t> {
             TI64Literal(v) => Ok(expr_box(Literal(I64Literal(v)))),
             TF32Literal(v) => Ok(expr_box(Literal(F32Literal(v)))),
             TF64Literal(v) => Ok(expr_box(Literal(F64Literal(v)))),
-            TCharLiteral(v) => Ok(expr_box(Literal(CharLiteral(v)))),
+            TI8Literal(v) => Ok(expr_box(Literal(I8Literal(v)))),
             TBoolLiteral(v) => Ok(expr_box(Literal(BoolLiteral(v)))),
             TI32 => {
                 let expr = try!(self.parse_cast(ScalarKind::I32));
@@ -510,8 +510,8 @@ impl<'t> Parser<'t> {
                 let expr = try!(self.parse_cast(ScalarKind::F64));
                 Ok(expr)
             }
-            TChar => {
-                let expr = try!(self.parse_cast(ScalarKind::Char));
+            TI8 => {
+                let expr = try!(self.parse_cast(ScalarKind::I8));
                 Ok(expr)
             }
             TBool => {
@@ -780,7 +780,7 @@ impl<'t> Parser<'t> {
             TI64 => Ok(Scalar(ScalarKind::I64)),
             TF32 => Ok(Scalar(ScalarKind::F32)),
             TF64 => Ok(Scalar(ScalarKind::F64)),
-            TChar => Ok(Scalar(ScalarKind::Char)),
+            TI8 => Ok(Scalar(ScalarKind::I8)),
             TBool => Ok(Scalar(ScalarKind::Bool)),
 
             TVec => {
@@ -881,8 +881,8 @@ fn basic_parsing() {
     let e = parse_expr("a: i32 + b").unwrap();
     assert_eq!(print_typed_expr(&e), "(a:i32+b:?)");
 
-    let e = parse_expr("|a:char| a").unwrap();
-    assert_eq!(print_typed_expr(&e), "|a:char|a:?");
+    let e = parse_expr("|a:i8| a").unwrap();
+    assert_eq!(print_typed_expr(&e), "|a:i8|a:?");
     
     assert!(parse_expr("10 * * 2").is_err());
 

--- a/weld/partial_types.rs
+++ b/weld/partial_types.rs
@@ -154,7 +154,7 @@ impl PartialExpr {
 
         let new_kind: ExprKind<Type> = match self.kind {
             Literal(BoolLiteral(v)) => Literal(BoolLiteral(v)),
-            Literal(CharLiteral(v)) => Literal(CharLiteral(v)),
+            Literal(I8Literal(v)) => Literal(I8Literal(v)),
             Literal(I32Literal(v)) => Literal(I32Literal(v)),
             Literal(I64Literal(v)) => Literal(I64Literal(v)),
             Literal(F32Literal(v)) => Literal(F32Literal(v)),

--- a/weld/pretty_print.rs
+++ b/weld/pretty_print.rs
@@ -20,7 +20,7 @@ impl PrintableType for Type {
     fn print(&self) -> String {
         match *self {
             Scalar(Bool) => "bool".to_string(),
-            Scalar(Char) => "char".to_string(),
+            Scalar(I8) => "i8".to_string(),
             Scalar(I32) => "i32".to_string(),
             Scalar(I64) => "i64".to_string(),
             Scalar(F32) => "f32".to_string(),
@@ -51,7 +51,7 @@ impl PrintableType for PartialType {
         match *self {
             Unknown => "?".to_string(),
             Scalar(Bool) => "bool".to_string(),
-            Scalar(Char) => "char".to_string(),
+            Scalar(I8) => "i8".to_string(),
             Scalar(I32) => "i32".to_string(),
             Scalar(I64) => "i64".to_string(),
             Scalar(F32) => "f32".to_string(),
@@ -228,7 +228,7 @@ fn print_expr_impl<T: PrintableType>(expr: &Expr<T>, typed: bool) -> String {
 pub fn print_literal(lit: &LiteralKind) -> String {
     match *lit {
         BoolLiteral(v) => format!("{}", v),
-        CharLiteral(v) => format!("{}", v),
+        I8Literal(v) => format!("{}", v),
         I32Literal(v) => format!("{}", v),
         I64Literal(v) => format!("{}L", v),
         F32Literal(v) => {

--- a/weld/tokenizer.rs
+++ b/weld/tokenizer.rs
@@ -20,7 +20,7 @@ pub enum Token {
     TI64Literal(i64),
     TF32Literal(f32),
     TF64Literal(f64),
-    TCharLiteral(char),
+    TI8Literal(i8),
     TBoolLiteral(bool),
     TIdent(String),
     TIf,
@@ -33,7 +33,7 @@ pub enum Token {
     TI64,
     TF32,
     TF64,
-    TChar,
+    TI8,
     TBool,
     TVec,
     TZip,
@@ -87,7 +87,7 @@ pub fn tokenize(input: &str) -> WeldResult<Vec<Token>> {
         // Regular expressions for various types of tokens.
         static ref KEYWORD_RE: Regex = Regex::new(
             "if|for|zip|len|lookup|iter|merge|result|let|true|false|macro|\
-             i32|i64|f32|f64|bool|char|vec|appender|merger|dictmerger|tovec").unwrap();
+             i8|i32|i64|f32|f64|bool|vec|appender|merger|dictmerger|tovec").unwrap();
 
         static ref IDENT_RE: Regex = Regex::new(r"^[A-Za-z$_][A-Za-z0-9$_]*$").unwrap();
 
@@ -124,7 +124,7 @@ pub fn tokenize(input: &str) -> WeldResult<Vec<Token>> {
                 "i64" => TI64,
                 "f32" => TF32,
                 "f64" => TF64,
-                "char" => TChar,
+                "i8" => TI8,
                 "bool" => TBool,
                 "vec" => TVec,
                 "appender" => TAppender,
@@ -210,7 +210,7 @@ impl fmt::Display for Token {
             TI64Literal(ref value) => write!(f, "{}L", value),
             TF32Literal(ref value) => write!(f, "{}F", value),
             TF64Literal(ref value) => write!(f, "{}", value),  // TODO: force .0?
-            TCharLiteral(ref value) => write!(f, "{}", value),
+            TI8Literal(ref value) => write!(f, "{}", value),
             TBoolLiteral(ref value) => write!(f, "{}", value),
             TIdent(ref value) => write!(f, "{}", value),
 
@@ -224,7 +224,7 @@ impl fmt::Display for Token {
                            TI64Literal(_) => "",
                            TF32Literal(_) => "",
                            TF64Literal(_) => "",
-                           TCharLiteral(_) => "",
+                           TI8Literal(_) => "",
                            TBoolLiteral(_) => "",
                            TIdent(_) => "",
                            // Other cases that return fixed strings
@@ -238,7 +238,7 @@ impl fmt::Display for Token {
                            TI64 => "i64",
                            TF32 => "f32",
                            TF64 => "f64",
-                           TChar => "char",
+                           TI8 => "i8",
                            TBool => "bool",
                            TVec => "vec",
                            TAppender => "appender",
@@ -318,8 +318,8 @@ fn basic_tokenize() {
 
     assert_eq!(tokenize("= == | || & &&").unwrap(),
                vec![TEqual, TEqualEqual, TBar, TLogicalOr, TBitwiseAnd, TLogicalAnd, TEndOfInput]);
-    assert_eq!(tokenize("|a:char| a").unwrap(),
-               vec![TBar, TIdent("a".into()), TColon, TChar, TBar, TIdent("a".into()), TEndOfInput]);
+    assert_eq!(tokenize("|a:i8| a").unwrap(),
+               vec![TBar, TIdent("a".into()), TColon, TI8, TBar, TIdent("a".into()), TEndOfInput]);
     
     assert!(tokenize("0a").is_err());
     assert!(tokenize("#").is_err());

--- a/weld/type_inference.rs
+++ b/weld/type_inference.rs
@@ -96,7 +96,7 @@ fn infer_locally(expr: &mut PartialExpr, env: &mut TypeMap) -> WeldResult<bool> 
 
         Literal(F64Literal(_)) => push_complete_type(&mut expr.ty, Scalar(F64), "F64Literal"),
 
-        Literal(CharLiteral(_)) => push_complete_type(&mut expr.ty, Scalar(Char), "CharLiteral"),
+        Literal(I8Literal(_)) => push_complete_type(&mut expr.ty, Scalar(I8), "I8Literal"),
         
         Literal(BoolLiteral(_)) => push_complete_type(&mut expr.ty, Scalar(Bool), "BoolLiteral"),
 


### PR DESCRIPTION
Support for Char type.
Addresses issue #44 

We can parse lambda expressions involving the char type and generate llvm code for it.

I don't think the CharLiteral is implemented fully.
That is, we cannot parse expressions like
let a:char = 'a',
because the single quotation isn't tokenized.

Should that change go in the pull request as well or do we address that in a separate issue?




