### PR TITLE
Added Missing Binary Ops

### DIFF
--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -1327,7 +1327,6 @@ fn llvm_binop(op_kind: BinOpKind, ty: &Type) -> WeldResult<&'static str> {
 
         (BinOpKind::LessThan, &Scalar(I8)) => Ok("icmp slt"),
         (BinOpKind::LessThan, &Scalar(I32)) => Ok("icmp slt"),
-        (BinOpKind::LessThan, &Scalar(I32)) => Ok("icmp slt"),
         (BinOpKind::LessThan, &Scalar(I64)) => Ok("icmp slt"),
         (BinOpKind::LessThan, &Scalar(F32)) => Ok("fcmp olt"),
         (BinOpKind::LessThan, &Scalar(F64)) => Ok("fcmp olt"),


### PR DESCRIPTION
Adds missing binary operations for certain types (particularly `i8`).

Writing exhaustive tests for this is hard, so someone should just inspect this for errors once before merge.