### PR TITLE
Remove unkown clang argument

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -8,7 +8,6 @@ ifeq (${OS}, Darwin)
 else ifeq (${OS}, Linux)
   # Linux
   CLANG ?= /usr/bin/clang-${LLVM_VERSION}
-  CFLAGS += -fno-use-cxa-get-exception-ptr
 else
   $(error Unsupported platform: ${OS})
 endif


### PR DESCRIPTION
Looks like this may have been an unnecessary argument. 

/usr/bin/clang-3.6 -Wall -fno-use-cxa-atexit -fno-use-cxa-get-exception-ptr -c -emit-llvm parlib.cpp
clang: error: unknown argument: '-fno-use-cxa-get-exception-ptr'
Makefile:20: recipe for target 'parlib.bc' failed
make: *** [parlib.bc] Error 1

The same thing happens if I change it to clang++-3.6.

I think the fixing change was the line of code loading libweld in [sir.rs](https://github.com/weld-project/weld/blob/24478b5e55837f8821cbd4623936d6d446a1212f/weld/lib.rs#L186).
At the time we probably kept seeing the error because I didn't re-build.

I'm able to run the python repl successfully now without this argument. 