### PR TITLE
Simplify the way WeldError parameter passed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Weld
 
+[![Build Status](https://travis-ci.org/weld-project/weld.svg?branch=master)](https://travis-ci.org/weld-project/weld)
+
 Weld is a language and runtime for improving the performance of data-intensive applications. It optimizes across libraries and functions by expressing the core computations in libraries using a common intermediate representation, and optimizing across each framework.
 
 Modern analytics applications combine multiple functions from different libraries and frameworks to build complex workflows. Even though individual functions can achieve high performance in isolation, the performance of the combined workflow is often an order of magnitude below hardware limits due to extensive data movement across the functions. Weld’s take on solving this problem is to lazily build up a computation for the entire workflow, and then optimizing and evaluating it only when a result is needed.

--- a/c/weld.h
+++ b/c/weld.h
@@ -78,11 +78,11 @@ weld_value_free(weld_value_t);
  *
  * @param code a Weld program to compile
  * @param conf a configuration for the module.
- * @param err a NULL handle to a Weld error.
+ * @param err a Weld erro for this compilation.
  * @return a runnable module.
  */
 extern "C" weld_module_t 
-weld_module_compile(const char *code, weld_conf_t, weld_error_t *err);
+weld_module_compile(const char *code, weld_conf_t, weld_error_t);
 
 /** Runs a module using the given argument.
  *
@@ -93,13 +93,13 @@ weld_module_compile(const char *code, weld_conf_t, weld_error_t *err);
  * @param module the module to run.
  * @param conf a configuration for this run.
  * @param arg the argument for the module's function.
- * @param err a NULL handle to a Weld error.
+ * @param err a Weld error for this run.
  * @return an owned Weld value representing the return value. The caller
  * is responsible for knowing what the type of the return value is based on
  * the module she runs.
  */
 extern "C" weld_value_t 
-weld_module_run(weld_module_t, weld_conf_t, weld_value_t, weld_error_t *err);
+weld_module_run(weld_module_t, weld_conf_t, weld_value_t, weld_error_t);
 
 /** Garbage collects a module.
  *
@@ -109,6 +109,12 @@ extern "C" void
 weld_module_free(weld_module_t);
 
 // ************* Errors ****************
+
+/** Return a new Weld error.
+ *
+ */
+extern "C" weld_error_t
+weld_error_new();
 
 /** Returns an error code, or 0 if there was no error.
  *

--- a/docs/api.md
+++ b/docs/api.md
@@ -105,11 +105,11 @@ typedef void* weld_module_t;
  *
  * @param code a Weld program to compile
  * @param conf a configuration for the module.
- * @param err a NULL handle to a Weld error.
+ * @param err a Weld error for this compilation.
  * @return a runnable module.
  */
 extern "C" weld_module_t 
-weld_module_compile(const char *code, weld_conf_t, weld_error_t *err);
+weld_module_compile(const char *code, weld_conf_t, weld_error_t);
 
 /** Runs a module using the given argument.
  *
@@ -120,13 +120,13 @@ weld_module_compile(const char *code, weld_conf_t, weld_error_t *err);
  * @param module the module to run.
  * @param conf a configuration for this run.
  * @param arg the argument for the module's function.
- * @param err a NULL handle to a Weld error.
+ * @param err a Weld error for this run.
  * @return an owned Weld value representing the return value. The caller
  * is responsible for knowing what the type of the return value is based on
  * the module she runs.
  */
 extern "C" weld_value_t 
-weld_module_run(weld_module_t, weld_conf_t, weld_value_t, weld_error_t *err);
+weld_module_run(weld_module_t, weld_conf_t, weld_value_t, weld_error_t);
 
 /** Garbage collects a module.
  *
@@ -148,6 +148,12 @@ or compilation errors.
 
 /** A handle to a Weld error. */
 typedef void* weld_error_t;
+
+/** Return a new Weld error.
+ *
+ */
+extern "C" weld_error_t
+weld_error_new();
 
 /** Returns an error code, or 0 if there was no error.
  *

--- a/examples/cpp/add_repl/add_repl.cpp
+++ b/examples/cpp/add_repl/add_repl.cpp
@@ -9,9 +9,9 @@
 
 int main() {
     // Compile Weld module.
-    weld_error_t e = NULL;
+    weld_error_t e = weld_error_new();
     weld_conf_t conf = weld_conf_new();
-    weld_module_t m = weld_module_compile("|x:i64| x+5L", conf, &e);
+    weld_module_t m = weld_module_compile("|x:i64| x+5L", conf, e);
     weld_conf_free(conf);
 
     if (weld_error_code(e)) {
@@ -41,7 +41,7 @@ int main() {
 
         // Run the module and get the result.
         weld_conf_t conf = weld_conf_new();
-        weld_value_t result = weld_module_run(m, conf, arg, &e);
+        weld_value_t result = weld_module_run(m, conf, arg, e);
         void *result_data = weld_value_data(result);
         printf("Answer: %lld\n", *(int64_t *)result_data);
 

--- a/python/weld/bindings.py
+++ b/python/weld/bindings.py
@@ -30,6 +30,8 @@ class c_weld_module(c_void_p):
 class c_weld_conf(c_void_p):
     pass
 
+class c_weld_err(c_void_p):
+    pass
 
 class c_weld_value(c_void_p):
     pass
@@ -40,19 +42,19 @@ class WeldModule(c_void_p):
     def __init__(self, code, conf, err):
         weld_module_compile = weld.weld_module_compile
         weld_module_compile.argtypes = [
-            c_char_p, c_weld_conf, POINTER(WeldError)]
+            c_char_p, c_weld_conf, c_weld_err]
         weld_module_compile.restype = c_weld_module
 
         code = c_char_p(code)
-        self.module = weld_module_compile(code, conf.conf, byref(err))
+        self.module = weld_module_compile(code, conf.conf, err.error)
 
     def run(self, conf, arg, err):
         weld_module_run = weld.weld_module_run
         # module, conf, arg, &err
         weld_module_run.argtypes = [
-            c_weld_module, c_weld_conf, c_weld_value, POINTER(WeldError)]
+            c_weld_module, c_weld_conf, c_weld_value, c_weld_err]
         weld_module_run.restype = c_weld_value
-        ret = weld_module_run(self.module, conf.conf, arg.val, byref(err))
+        ret = weld_module_run(self.module, conf.conf, arg.val, err.error)
         return WeldValue(ret, assign=True)
 
     def __del__(self):
@@ -127,21 +129,27 @@ class WeldConf(c_void_p):
 
 class WeldError(c_void_p):
 
+    def __init__(self):
+        weld_error_new = weld.weld_error_new
+        weld_error_new.argtypes = []
+        weld_error_new.restype = c_weld_err
+        self.error = weld_error_new()
+
     def code(self):
         weld_error_code = weld.weld_error_code
-        weld_error_code.argtypes = [WeldError]
+        weld_error_code.argtypes = [c_weld_err]
         weld_error_code.restype = c_uint64
-        return weld_error_code(self)
+        return weld_error_code(self.error)
 
     def message(self):
         weld_error_message = weld.weld_error_message
-        weld_error_message.argtypes = [WeldError]
+        weld_error_message.argtypes = [c_weld_err]
         weld_error_message.restype = c_char_p
-        val = weld_error_message(self)
+        val = weld_error_message(self.error)
         return copy.copy(val)
 
     def __del__(self):
         weld_error_free = weld.weld_error_free
-        weld_error_free.argtypes = [WeldError]
+        weld_error_free.argtypes = [c_weld_err]
         weld_error_free.restype = None
-        weld_error_free(self)
+        weld_error_free(self.error)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -11,7 +11,7 @@ use weld::WeldValue;
 use weld::WeldError;
 use weld::{weld_value_new, weld_value_data, weld_value_free};
 use weld::{weld_module_compile, weld_module_run, weld_module_free};
-use weld::{weld_error_code, weld_error_message, weld_error_free};
+use weld::{weld_error_new, weld_error_code, weld_error_message, weld_error_free};
 use weld::{weld_conf_new, weld_conf_set, weld_conf_free};
 
 use std::ffi::{CStr, CString};
@@ -55,10 +55,10 @@ unsafe fn _compile_and_run<T>(code: &str,
 
     let code = CString::new(code).unwrap();
     let input_value = weld_value_new(ptr as *const _ as *const c_void);
-    let mut err = std::ptr::null_mut();
+    let err = weld_error_new();
     let module = weld_module_compile(code.into_raw() as *const c_char,
                                      conf,
-                                     &mut err as *mut *mut WeldError);
+                                     err);
 
     if weld_error_code(err) != WeldRuntimeErrno::Success {
         weld_conf_free(conf);
@@ -66,8 +66,8 @@ unsafe fn _compile_and_run<T>(code: &str,
     }
     weld_error_free(err);
 
-    err = std::ptr::null_mut();
-    let ret_value = weld_module_run(module, conf, input_value, &mut err as *mut *mut WeldError);
+    let err = weld_error_new();
+    let ret_value = weld_module_run(module, conf, input_value, err);
     if weld_error_code(err) != WeldRuntimeErrno::Success {
         weld_conf_free(conf);
         return Err(err);


### PR DESCRIPTION
The way that `WeldError` parameter passed to `weld_module_compile` and `weld_module_run` looks obscure for now.

This is going to simplify it.