### PR TITLE
Use WELD_HOME for finding libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ bench.csv
 python/build/
 python/dist
 python/grizzly.egg-info/
+examples/python/grizzly/data

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ before_script:
   - sudo rm -rf `which llvm-config`
   - sudo ln -s /usr/bin/llvm-config-3.8 /usr/bin/llvm-config
   - export WELD_HOME=`pwd`
-  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/target/release:`pwd`/weld_rt/target/release
 
 script:
   - cargo build --release

--- a/README.md
+++ b/README.md
@@ -70,11 +70,7 @@ $ export WELD_HOME=`pwd`
 $ cargo build --release
 ```
 
-Weld builds two dynamically linked libraries (`.so` files on Linux and `.dylib` files on macOS): `libweld` and `libweldrt`. Both of these libraries must be on the `LD_LIBRARY_PATH`. By default, the libraries are in `$WELD_HOME/target/release` and `$WELD_HOME/weld_rt/target/release`. Set up the `LD_LIBRARY_PATH` as follows:
-
-```bash
-$ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$WELD_HOME/weld_rt/target/release:$WELD_HOME/target/release
-```
+Weld builds two dynamically linked libraries (`.so` files on Linux and `.dylib` files on macOS): `libweld` and `libweldrt`. Both of these libraries are found using `WELD_HOME`. By default, the libraries are in `$WELD_HOME/target/release` and `$WELD_HOME/weld_rt/target/release`.
 
 Finally, run the unit and integration tests:
 

--- a/c/README.md
+++ b/c/README.md
@@ -14,10 +14,6 @@ and when building:
 $ clang -lweld my_program.c
 ```
 
-Make sure `libweld` is on the `LD_LIBRARY_PATH`:
-
-```bash
-$ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/path/to/libweld
-```
+Make sure `WELD_HOME` is set to the root Weld directory.
 
 See the [API documentation](https://github.com/weld-project/weld/blob/master/docs/api.md) for details on the API.

--- a/docs/python.md
+++ b/docs/python.md
@@ -14,8 +14,7 @@ Otherwise, run the following from `$WELD_HOME/python`:
 $ python setup.py install
 ```
 
-You should also follow the setup instructions [here](https://github.com/weld-project/weld/blob/master/README.md) (in particular, build Weld and make sure its dynamic libraries are on the `LD_LIBRARY_PATH`). 
-
+You should also follow the setup instructions [here](https://github.com/weld-project/weld/blob/master/README.md) (in particular, make sure `WELD_HOME` is set so the libraries Weld uses can be found). 
 ### Bindings
 
 The `weld.bindings` module contains bindings for the [C API](https://github.com/weld-project/weld/blob/master/docs/api.md). Each type in the C API is wrapped as a Python object. Methods on the Python objects call the corresponding C API functions.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -257,7 +257,7 @@ $ python $WELD_HOME/python/setup.py install
 
 #### ValueError: Could not compile function ...
 
-Take a look at the (language docs)[about:blank]; this is a compile error stating that the Weld code could not be compiled.
+Take a look at the (language docs)[https://github.com/sppalkia/weld/blob/master/docs/language.md]; this is a compile error stating that the Weld code could not be compiled.
 
 ---
 

--- a/examples/cpp/add_repl/add_repl.cpp
+++ b/examples/cpp/add_repl/add_repl.cpp
@@ -5,7 +5,7 @@
 #include <string.h>
 
 // Include the Weld API.
-#include "../../../api/c/weld.h"
+#include "../../../c/weld.h"
 
 int main() {
     // Compile Weld module.

--- a/python/README.md
+++ b/python/README.md
@@ -20,8 +20,6 @@ Otherwise, run:
 $ python setup.py install
 ```
 
-Also, make sure that `libweld` and `libweldrt` are on  the `LD_LIBRARY_PATH`.
-
 ### Updating Weld and Grizzly
 
 If you installed Weld's Python API and Grizzly in 'development' mode, run:

--- a/python/weld/bindings.py
+++ b/python/weld/bindings.py
@@ -4,6 +4,7 @@
 
 from ctypes import *
 
+import os
 import platform
 import copy
 
@@ -17,23 +18,26 @@ elif system == 'Darwin':
 else:
     raise OSError("Unsupported platform {}", system)
 
+if "WELD_HOME" not in os.environ:
+    raise Exception("Set the WELD_HOME environment variable")
+home = os.environ["WELD_HOME"]
+if home[-1] != "/":
+    home += "/"
+path = home + "target/debug/" + path
+
 # Load the Weld Dynamic Library.
 weld = CDLL(path)
 
 # Used for some type checking carried out by ctypes
 
-
 class c_weld_module(c_void_p):
     pass
-
 
 class c_weld_conf(c_void_p):
     pass
 
-
 class c_weld_value(c_void_p):
     pass
-
 
 class WeldModule(c_void_p):
 

--- a/python/weld/bindings.py
+++ b/python/weld/bindings.py
@@ -23,6 +23,7 @@ if "WELD_HOME" not in os.environ:
 home = os.environ["WELD_HOME"]
 if home[-1] != "/":
     home += "/"
+
 path = home + "target/debug/" + path
 
 # Load the Weld Dynamic Library.

--- a/weld/util.rs
+++ b/weld/util.rs
@@ -113,7 +113,7 @@ pub fn get_weld_home() -> Result<String, ()> {
 /// Loads the Weld runtime library.
 pub fn load_runtime_library() -> Result<(), String> {
     let weld_home = get_weld_home().unwrap_or("./".to_string());
-    let path = format!("{}{}", weld_home, lib_path);
+    let path = format!("{}{}", weld_home, "weld_rt/target/release/libweldrt");
     if let Err(_) = easy_ll::load_library(&path) {
         let err_message = unsafe { std::ffi::CStr::from_ptr(libc::dlerror()) };
         let err_message = err_message.to_owned().into_string().unwrap();

--- a/weld/util.rs
+++ b/weld/util.rs
@@ -112,8 +112,7 @@ pub fn get_weld_home() -> Result<String, ()> {
 
 /// Loads the Weld runtime library.
 pub fn load_runtime_library() -> Result<(), String> {
-    let weld_home = get_weld_home().unwrap_or(".".to_string());
-    let lib_path = "weld_rt/target/release/libweldrt";
+    let weld_home = get_weld_home().unwrap_or("./".to_string());
     let path = format!("{}{}", weld_home, lib_path);
     if let Err(_) = easy_ll::load_library(&path) {
         let err_message = unsafe { std::ffi::CStr::from_ptr(libc::dlerror()) };

--- a/weld/util.rs
+++ b/weld/util.rs
@@ -7,10 +7,13 @@ use std;
 use std::cmp::max;
 use std::collections::HashMap;
 
+use std::env;
+
 use super::ast::*;
 use super::ast::ExprKind::*;
 
 pub const MERGER_BC: &'static [u8] = include_bytes!("../weld_rt/cpp/libparbuilder.bc");
+const WELD_HOME: &'static str = "WELD_HOME";
 
 /// Utility struct that can track and generate unique IDs and symbols for use in an expression.
 /// Each SymbolGenerator tracks the maximum ID used for every symbol name, and can be used to
@@ -89,9 +92,30 @@ impl IdGenerator {
     }
 }
 
+/// Returns the value of the WELD_HOME environment variable,
+/// or an error if the variable is not set.
+///
+/// The returned path has a trailing `/`.
+pub fn get_weld_home() -> Result<String, ()> {
+    match env::var(WELD_HOME) {
+        Ok(path) => {
+            let path = if path.chars().last().unwrap() != '/' {
+                path + &"/"
+            } else {
+                path
+            };
+            Ok(path)
+        }
+        Err(_) => Err(()),
+    }
+}
+
 /// Loads the Weld runtime library.
 pub fn load_runtime_library() -> Result<(), String> {
-    if let Err(_) = easy_ll::load_library(&"libweldrt") {
+    let weld_home = get_weld_home().unwrap_or(".".to_string());
+    let lib_path = "weld_rt/target/release/libweldrt";
+    let path = format!("{}{}", weld_home, lib_path);
+    if let Err(_) = easy_ll::load_library(&path) {
         let err_message = unsafe { std::ffi::CStr::from_ptr(libc::dlerror()) };
         let err_message = err_message.to_owned().into_string().unwrap();
         Err(err_message)


### PR DESCRIPTION
This changes the build process to require that the `libweld` and `libweldrt` libraries live under `$WELD_HOME/target/debug` and `$WELD_HOME/target/release` respectively. The purpose of this is that `LD_LIBRARY_PATH` seems to require changing the system integrity protection on macOS for use with Python, which is undesirable.

@mateiz @deepakn94 