### PR TITLE
Minor fix for examples of appender and merger

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -93,7 +93,7 @@ Here are a few simple examples using builder expressions:
 # basic use of appender
 let b = appender[i32];
 let b2 = merge(b, 5);
-let b3 = merge(b, 6);
+let b3 = merge(b2, 6);
 result(b3)    # returns [5, 6]
 ```
 
@@ -101,7 +101,7 @@ result(b3)    # returns [5, 6]
 # basic use of merger
 let b = merger[i32,+];
 let b2 = merge(b, 5);
-let b3 = merge(b, 6);
+let b3 = merge(b2, 6);
 result(b3)    # returns 11
 ```
 


### PR DESCRIPTION
I think that the argument of second "merge" should be "b2" in examples of appender and merger.
(I understood that the purpose of these examples are to show the usage of each expression step by step.)