### PR TITLE
Add support for LLVM 4.0 (still supports 3.8+)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,22 @@ python:
 addons:
   apt:
     sources:
+      - sourceline: 'deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.8 main'
+        key_url: 'http://llvm.org/apt/llvm-snapshot.gpg.key'
       - llvm-toolchain-trusty-4.0
     packages:
       - gcc
+      - make
+      - llvm-3.8
+      - llvm-3.8-dev
+      - clang-3.8
       - llvm-4.0
       - llvm-4.0-dev
       - clang-4.0
-      - make
       - lib32z1-dev
 
 install:
-  - sudo rm -rf /usr/bin/llvm-config
-  - sudo rm -rf `which llvm-config`
-  - sudo ln -s /usr/bin/llvm-config-4.0 /usr/bin/llvm-config
+  - sudo rm -f `which llvm-config`
   - export WELD_HOME=`pwd`
   - cd python
   - pip install --upgrade pip setuptools wheel
@@ -29,7 +32,5 @@ install:
   - cd ..
 
 script:
-  - cargo build --release
-  - cargo test
-  - python python/grizzly/tests/grizzly_test.py
-  - python python/grizzly/tests/numpy_weld_test.py
+  - bash build_tools/travis/test_llvm_version.sh 3.8 38.0.1
+  - bash build_tools/travis/test_llvm_version.sh 4.0 40.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,31 @@ language: rust
 sudo: required
 dist: trusty
 
-before_script:
-  - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
-  - echo 'deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.8 main' | sudo tee --append /etc/apt/sources.list
-  - sudo apt-get update
-  - sudo apt-get install gcc
-  - sudo apt-get install llvm-3.8
-  - sudo apt-get install clang-3.8
-  - sudo apt-get install make
-  - sudo apt-get install lib32z1-dev
+python:
+  - 2.7
+
+addons:
+  apt:
+    sources:
+      - llvm-toolchain-trusty-4.0
+    packages:
+      - gcc
+      - llvm-4.0
+      - llvm-4.0-dev
+      - clang-4.0
+      - make
+      - lib32z1-dev
+
+install:
   - sudo rm -rf /usr/bin/llvm-config
   - sudo rm -rf `which llvm-config`
-  - sudo ln -s /usr/bin/llvm-config-3.8 /usr/bin/llvm-config
+  - sudo ln -s /usr/bin/llvm-config-4.0 /usr/bin/llvm-config
   - export WELD_HOME=`pwd`
-  - sudo apt-get install python-pip
-  - virtualenv py; source py/bin/activate
-  - pip install numpy
-  - pip install pandas
-  - cd python; python setup.py install; cd ..
+  - cd python
+  - pip install --upgrade pip setuptools wheel
+  - pip install --only-binary=numpy,pandas -r requirements.txt
+  - python setup.py install
+  - cd ..
 
 script:
   - cargo build --release

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ brew install llvm@3.8
 Weld's dependencies require `llvm-config`, so you may need to create a symbolic link so the correct `llvm-config` is picked up (note that you might need to add `sudo` at the start of this command):
 
 ```bash
-$ ln -s /usr/local/opt/llvm/bin/llvm-config-3.8 /usr/local/bin/llvm-config
+$ ln -s /usr/local/bin/llvm-config-3.8 /usr/local/bin/llvm-config
 ```
 
 To make sure this worked correctly, run `llvm-config --version`. You should see `3.8.x` or newer.
@@ -70,7 +70,12 @@ $ export WELD_HOME=`pwd`
 $ cargo build --release
 ```
 
-**Note:** If you are using a version of LLVM newer than 3.8, you will have to change the `llvm-sys` crate dependency in `easy_ll/Cargo.toml` to match (e.g. `40.0.0` for LLVM 4.0.0).
+**Note:** If you are using a version of LLVM newer than 3.8, you will have to change the `llvm-sys` crate dependency in `easy_ll/Cargo.toml` to match (e.g. `40.0.0` for LLVM 4.0.0). You may also need to create additional symlinks for some packages that omit the version suffix when installing the latest version, e.g. for LLVM 4.0:
+
+```bash
+$ ln -s /usr/local/bin/clang /usr/local/bin/clang-4.0
+$ ln -s /usr/local/bin/llvm-link /usr/local/bin/llvm-link-4.0
+```
 
 Weld builds two dynamically linked libraries (`.so` files on Linux and `.dylib` files on macOS): `libweld` and `libweldrt`. Both of these libraries are found using `WELD_HOME`. By default, the libraries are in `$WELD_HOME/target/release` and `$WELD_HOME/weld_rt/target/release`.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ $ export WELD_HOME=`pwd`
 $ cargo build --release
 ```
 
+**Note:** You may have to change the `llvm-sys` dependency in `easy_ll/Cargo.toml` to match the version of LLVM you are using, e.g. `38.0.1` for LLVM 3.8.1.
+
 Weld builds two dynamically linked libraries (`.so` files on Linux and `.dylib` files on macOS): `libweld` and `libweldrt`. Both of these libraries are found using `WELD_HOME`. By default, the libraries are in `$WELD_HOME/target/release` and `$WELD_HOME/weld_rt/target/release`.
 
 Finally, run the unit and integration tests:

--- a/README.md
+++ b/README.md
@@ -27,17 +27,16 @@ To install Rust, follow the steps [here](https://rustup.rs). You can verify that
 
 #### MacOS LLVM Installation
 
-To install LLVM on macOS, first install [brew](https://brew.sh/). Then:
+To install LLVM on macOS, first install [Homebrew](https://brew.sh/). Then:
 
 ```bash
-$ brew install llvm
-$ export PATH=$PATH:/usr/local/bin
+$ brew install llvm@3.8
 ```
 
 Weld's dependencies require `llvm-config`, so you may need to create a symbolic link so the correct `llvm-config` is picked up (note that you might need to add `sudo` at the start of this command):
 
 ```bash
-$ ln -s /usr/local/opt/llvm/bin/llvm-config /usr/local/bin/llvm-config
+$ ln -s /usr/local/opt/llvm/bin/llvm-config-3.8 /usr/local/bin/llvm-config
 ```
 
 To make sure this worked correctly, run `llvm-config --version`. You should see `3.8.x` or newer.
@@ -47,14 +46,15 @@ To make sure this worked correctly, run `llvm-config --version`. You should see 
 To install LLVM on Ubuntu :
 
 ```bash
-$ sudo apt install llvm
-$ sudo apt install clang
+$ sudo apt-get install llvm-3.8
+$ sudo apt-get install llvm-3.8-dev
+$ sudo apt-get install clang-3.8
 ```
 
 Weld's dependencies require `llvm-config`, so you may need to create a symbolic link so the correct `llvm-config` is picked up:
 
 ```bash
-$ ln -s /usr/bin/llvm-config /usr/local/bin/llvm-config
+$ ln -s /usr/bin/llvm-config-3.8 /usr/local/bin/llvm-config
 ```
 
 To make sure this worked correctly, run `llvm-config --version`. You should see `3.8.x` or newer.
@@ -70,7 +70,7 @@ $ export WELD_HOME=`pwd`
 $ cargo build --release
 ```
 
-**Note:** You may have to change the `llvm-sys` dependency in `easy_ll/Cargo.toml` to match the version of LLVM you are using, e.g. `38.0.1` for LLVM 3.8.1.
+**Note:** If you are using a version of LLVM newer than 3.8, you will have to change the `llvm-sys` crate dependency in `easy_ll/Cargo.toml` to match (e.g. `40.0.0` for LLVM 4.0.0).
 
 Weld builds two dynamically linked libraries (`.so` files on Linux and `.dylib` files on macOS): `libweld` and `libweldrt`. Both of these libraries are found using `WELD_HOME`. By default, the libraries are in `$WELD_HOME/target/release` and `$WELD_HOME/weld_rt/target/release`.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can join the discussion on Weld on our [Google Group](https://groups.google.
 
 ## Building
 
-To build Weld, you need [Rust 1.13 or higher](http://rust-lang.org) and [LLVM](http://llvm.org) 3.8.
+To build Weld, you need [Rust 1.13 or higher](http://rust-lang.org) and [LLVM](http://llvm.org) 3.8 or newer.
 
 To install Rust, follow the steps [here](https://rustup.rs). You can verify that Rust was installed correctly on your system by typing `rustc` into your shell.
 
@@ -30,34 +30,34 @@ To install Rust, follow the steps [here](https://rustup.rs). You can verify that
 To install LLVM on macOS, first install [brew](https://brew.sh/). Then:
 
 ```bash
-$ brew install llvm38
+$ brew install llvm
 $ export PATH=$PATH:/usr/local/bin
 ```
 
 Weld's dependencies require `llvm-config`, so you may need to create a symbolic link so the correct `llvm-config` is picked up (note that you might need to add `sudo` at the start of this command):
 
 ```bash
-$ ln -s /usr/local/bin/llvm-config-3.8 /usr/local/bin/llvm-config
+$ ln -s /usr/local/opt/llvm/bin/llvm-config /usr/local/bin/llvm-config
 ```
 
-To make sure this worked correctly, run `llvm-config --version`. You should see `3.8.x`.
+To make sure this worked correctly, run `llvm-config --version`. You should see `3.8.x` or newer.
 
 #### Ubuntu LLVM Installation
 
 To install LLVM on Ubuntu :
 
 ```bash
-$ sudo apt install llvm-3.8
-$ sudo apt install clang-3.8
+$ sudo apt install llvm
+$ sudo apt install clang
 ```
 
 Weld's dependencies require `llvm-config`, so you may need to create a symbolic link so the correct `llvm-config` is picked up:
 
 ```bash
-$ ln -s /usr/bin/llvm-config-3.8 /usr/local/bin/llvm-config
+$ ln -s /usr/bin/llvm-config /usr/local/bin/llvm-config
 ```
 
-To make sure this worked correctly, run `llvm-config --version`. You should see `3.8.x`.
+To make sure this worked correctly, run `llvm-config --version`. You should see `3.8.x` or newer.
 
 #### Building Weld
 
@@ -96,7 +96,7 @@ Some example workloads that make use of Grizzly are in [`examples/python/grizzly
 ## Running an Interactive REPL
 
 * `cargo test` runs unit and integration tests. A test name substring filter can be used to run a subset of the tests:
-   
+
    ```
    cargo test <substring to match in test name>
    ```

--- a/build_tools/travis/test_llvm_version.sh
+++ b/build_tools/travis/test_llvm_version.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+LLVM_VERSION=$1
+LLVM_SYS_VERSION=$2
+
+# create llvm-config symlink
+sudo rm -f /usr/bin/llvm-config
+sudo ln -s /usr/bin/llvm-config-$LLVM_VERSION /usr/bin/llvm-config
+
+# set llvm-sys crate version
+sed -i "s/llvm-sys = \".*\"/llvm-sys = \"$LLVM_SYS_VERSION\"/g" easy_ll/Cargo.toml
+
+# build and test
+cargo clean
+cargo build --release
+cargo test
+python python/grizzly/tests/grizzly_test.py
+python python/grizzly/tests/numpy_weld_test.py

--- a/easy_ll/Cargo.toml
+++ b/easy_ll/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Matei Zaharia <matei.zaharia@gmail.com>"]
 build = "build.rs"
 
 [dependencies]
-llvm-sys = "38.0.1"
+llvm-sys = ">= 38.0.1"
 libc = "0.2.0"

--- a/easy_ll/Cargo.toml
+++ b/easy_ll/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Matei Zaharia <matei.zaharia@gmail.com>"]
 build = "build.rs"
 
 [dependencies]
-llvm-sys = ">= 38.0.1"
+llvm-sys = "40.0.0"
 libc = "0.2.0"

--- a/easy_ll/Cargo.toml
+++ b/easy_ll/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Matei Zaharia <matei.zaharia@gmail.com>"]
 build = "build.rs"
 
 [dependencies]
-llvm-sys = "40.0.0"
+llvm-sys = "38.0.1"
 libc = "0.2.0"

--- a/easy_ll/src/lib.rs
+++ b/easy_ll/src/lib.rs
@@ -141,10 +141,7 @@ pub fn compile_module(code: &str, bc_file: Option<&[u8]>) -> Result<CompiledModu
 
         if let Some(s) = bc_file {
             let bc_module = try!(parse_module_bytes(context, s));
-            llvm::linker::LLVMLinkModules(module,
-                                          bc_module,
-                                          llvm::linker::LLVMLinkerMode::LLVMLinkerDestroySource,
-                                          std::ptr::null_mut());
+            llvm::linker::LLVMLinkModules2(module, bc_module);
         }
 
         // Validate and optimize the module

--- a/python/grizzly/Makefile
+++ b/python/grizzly/Makefile
@@ -1,5 +1,5 @@
 OS=$(shell uname -s)
-LLVM_VERSION=3.8
+LLVM_VERSION=$(shell llvm-config --version | cut -d . -f 1,2)
 
 PYTHON_HEADER_INCLUDE = $(shell python-config --includes)
 NUMPY_HEADER_INCLUDE = -I$(shell python -c "import numpy; print numpy.get_include()")

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+pandas

--- a/weld_rt/cpp/Makefile
+++ b/weld_rt/cpp/Makefile
@@ -1,5 +1,5 @@
 OS = $(shell uname -s)
-LLVM_VERSION = 3.8
+LLVM_VERSION = $(shell llvm-config --version | cut -d . -f 1,2)
 
 CFLAGS_RT = -O3 -Wall -fno-use-cxa-atexit -fPIC
 CFLAGS_BUILDER = ${CFLAGS_RT} -flto


### PR DESCRIPTION
- Use `LLVMLinkModules2` added in 3.8 (currently supported version) in place of deprecated `LLVMLinkModules`.
- Get LLVM version from `llvm-config` instead of hardcoding.
- Update README
- Update .travis.yml to:
  - Install binary versions of `numpy` and `pandas` to speed up Travis CI builds
  - Test against both LLVM 3.8 and 4.0