### PR TITLE
[WIP] Support Python 3 in addition to Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: required
 dist: trusty
 
 python:
-  - 2.7
+  - "2.7"
+  - "3.6"
 
 addons:
   apt:

--- a/python/grizzly/Makefile
+++ b/python/grizzly/Makefile
@@ -2,7 +2,7 @@ OS=$(shell uname -s)
 LLVM_VERSION=$(shell llvm-config --version | cut -d . -f 1,2)
 
 PYTHON_HEADER_INCLUDE = $(shell python-config --includes)
-NUMPY_HEADER_INCLUDE = -I$(shell python -c "import numpy; print numpy.get_include()")
+NUMPY_HEADER_INCLUDE = -I$(shell python -c "from __future__ import print_function; import numpy; print(numpy.get_include())")
 PYTHON_LDFLAGS = $(shell python-config --ldflags)
 ifeq (${OS}, Darwin)
   # OS X

--- a/python/grizzly/encoders.py
+++ b/python/grizzly/encoders.py
@@ -8,7 +8,8 @@ from weld.weldobject import *
 import numpy as np
 import os
 import sys
-
+import six
+from six.moves import xrange
 
 numpy_to_weld_type_mapping = {
     'str': WeldVec(WeldChar()),
@@ -80,7 +81,7 @@ class NumPyEncoder(WeldObjectEncoder):
                 base = WeldVec(WeldChar())  # TODO: Fix this
             for i in xrange(obj.ndim):
                 base = WeldVec(base)
-        elif isinstance(obj, str):
+        elif isinstance(obj, six.binary_type) or isinstance(obj, six.text_type):
             base = WeldVec(WeldChar())
         else:
             raise Exception("Invalid object type: unable to infer NVL type")
@@ -115,7 +116,10 @@ class NumPyEncoder(WeldObjectEncoder):
                 numpy_to_weld = self.utils.numpy_to_weld_bool_arr
             else:
                 numpy_to_weld = self.utils.numpy_to_weld_char_arr_arr
-        elif isinstance(obj, str):
+        elif isinstance(obj, six.binary_type):
+            numpy_to_weld = self.utils.numpy_to_weld_char_arr
+        elif isinstance(obj, six.text_type):
+            obj = obj.encode()
             numpy_to_weld = self.utils.numpy_to_weld_char_arr
         else:
             raise Exception("Unable to encode; invalid object type")

--- a/python/grizzly/grizzly.py
+++ b/python/grizzly/grizzly.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pandas as pd
 
-import grizzly_impl
-from lazy_op import LazyOpResult
+from . import grizzly_impl
+from .lazy_op import LazyOpResult
 from weld.weldobject import *
 
 

--- a/python/grizzly/grizzly_impl.py
+++ b/python/grizzly/grizzly_impl.py
@@ -4,8 +4,9 @@ Attributes:
     decoder_ (NumPyEncoder): Description
     encoder_ (NumPyDecoder): Description
 """
-from encoders import *
+from .encoders import *
 from weld.weldobject import *
+from six.moves import xrange
 
 
 encoder_ = NumPyEncoder()

--- a/python/grizzly/lazy_op.py
+++ b/python/grizzly/lazy_op.py
@@ -1,6 +1,7 @@
 """Summary
 """
 from weld.weldobject import *
+from six.moves import xrange
 
 
 def to_weld_type(weld_type, dim):

--- a/python/grizzly/numpy_weld.py
+++ b/python/grizzly/numpy_weld.py
@@ -1,7 +1,7 @@
 import numpy as np
 
-import numpy_weld_impl
-from lazy_op import LazyOpResult
+from . import numpy_weld_impl
+from .lazy_op import LazyOpResult
 from weld.weldobject import *
 
 

--- a/python/grizzly/numpy_weld_convertor.cpp
+++ b/python/grizzly/numpy_weld_convertor.cpp
@@ -49,10 +49,10 @@ weld::vec<double> numpy_to_weld_double_arr(PyObject* in) {
  */
 extern "C"
 weld::vec<uint8_t> numpy_to_weld_char_arr(PyObject* in) {
-    int64_t dimension = (int64_t) PyString_Size(in);
+    int64_t dimension = (int64_t) PyBytes_Size(in);
     weld::vec<uint8_t> t;
     t.size = dimension;
-    t.ptr = (uint8_t*) PyString_AsString(in);
+    t.ptr = (uint8_t*) PyBytes_AsString(in);
     return t;
 }
 
@@ -281,7 +281,7 @@ PyObject* weld_to_numpy_char_arr_arr(weld::vec< weld::vec<uint8_t> > inp) {
 
     for (int i = 0; i < num_rows; i++) {
         int size = inp.ptr[i].size;
-        PyObject* buffer = PyString_FromStringAndSize((const char*) inp.ptr[i].ptr, size);
+        PyObject* buffer = PyBytes_FromStringAndSize((const char*) inp.ptr[i].ptr, size);
         ptr_array[i] = buffer;
     }
     npy_intp size = num_rows;

--- a/python/grizzly/numpy_weld_impl.py
+++ b/python/grizzly/numpy_weld_impl.py
@@ -5,7 +5,7 @@ Attributes:
     encoder_ (TYPE): Description
     norm_factor_id_ (int): Unique IDs given to norm factor literals
 """
-from encoders import *
+from .encoders import *
 from weld.weldobject import *
 
 norm_factor_id_ = 1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,3 @@
 numpy
 pandas
+six

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,4 +6,4 @@ setup(name='grizzly',
       author='Weld Developers',
       author_email='weld-group@lists.stanford.edu',
       packages=['grizzly', 'weld'],
-      install_requires=['pandas', 'numpy'])
+      install_requires=['pandas', 'numpy', 'six'])

--- a/python/weld/bindings.py
+++ b/python/weld/bindings.py
@@ -51,7 +51,7 @@ class WeldModule(c_void_p):
             c_char_p, c_weld_conf, c_weld_err]
         weld_module_compile.restype = c_weld_module
 
-        code = c_char_p(code)
+        code = c_char_p(code.encode())
         self.module = weld_module_compile(code, conf.conf, err.error)
 
     def run(self, conf, arg, err):
@@ -111,7 +111,7 @@ class WeldConf(c_void_p):
         self.conf = weld_conf_new()
 
     def get(self, key):
-        key = c_char_p(key)
+        key = c_char_p(key.encode())
         weld_conf_get = weld.weld_conf_get
         weld_conf_get.argtypes = [c_weld_conf, c_char_p]
         weld_conf_get.restype = c_char_p
@@ -119,8 +119,8 @@ class WeldConf(c_void_p):
         return copy.copy(val.value)
 
     def set(self, key, value):
-        key = c_char_p(key)
-        value = c_char_p(value)
+        key = c_char_p(key.encode())
+        value = c_char_p(value.encode())
         weld_conf_set = weld.weld_conf_set
         weld_conf_set.argtypes = [c_weld_conf, c_char_p, c_char_p]
         weld_conf_set.restype = None

--- a/python/weld/encoders.py
+++ b/python/weld/encoders.py
@@ -3,9 +3,9 @@ Implements some common standard encoders and decoders mapping
 Python types to Weld types.
 """
 
-from types import *
+from .types import *
 
-from weldobject import WeldObjectEncoder, WeldObjectDecoder
+from .weldobject import WeldObjectEncoder, WeldObjectDecoder
 
 import numpy as np
 import ctypes

--- a/python/weld/weldobject.py
+++ b/python/weld/weldobject.py
@@ -4,13 +4,15 @@
 # Holds an object that can be evaluated.
 #
 
+from __future__ import print_function
+
 import ctypes
 
 import os
 import time
 
-import bindings as cweld
-from types import *
+from . import bindings as cweld
+from .types import *
 
 
 class WeldObjectEncoder(object):
@@ -121,7 +123,7 @@ class WeldObject(object):
 
     def toWeldFunc(self):
         names = self.context.keys()
-        names.sort()
+        names = sorted(names)
         arg_strs = ["{0}: {1}".format(str(name),
                                       str(self.encoder.pyToWeldType(self.context[name])))
                     for name in names]
@@ -142,7 +144,7 @@ class WeldObject(object):
         # Encode each input argument. This is the positional argument list
         # which will be wrapped into a Weld struct and passed to the Weld API.
         names = self.context.keys()
-        names.sort()
+        names = sorted(names)
 
         start = time.time()
         encoded = []
@@ -157,7 +159,7 @@ class WeldObject(object):
                 encoded.append(self.encoder.encode(self.context[name]))
         end = time.time()
         if verbose:
-            print "Total time encoding:", end - start
+            print("Total time encoding:", end - start)
 
         start = time.time()
         Args = args_factory(zip(names, argtypes))
@@ -187,7 +189,7 @@ class WeldObject(object):
         data = ctypes.cast(weld_ret.data(), ptrtype)
         end = time.time()
         if verbose:
-            print "Total time running:", end - start
+            print("Total time running:", end - start)
 
         start = time.time()
         if decode:
@@ -198,6 +200,6 @@ class WeldObject(object):
                 ctypes.c_int64)).contents.value
         end = time.time()
         if verbose:
-            print "Total time decoding:", end - start
+            print("Total time decoding:", end - start)
 
         return result


### PR DESCRIPTION
# Work in Progress; Do Not Merge

Add support to work in both Python 2 and Python 3

**TODO:**
 - Get Travis CI to run for multiple python versions. May have to change `language:` to `python` and install rust during the `install:` phase since testing is only done against latest rust anyway.
 - String operations (e.g. `WeldSeries.str.slice`) are still wonky and not working quite right in Python 3 with unicode strings. Differing numpy dtypes between Python 2.7 (`'S'`) and 3.6 (`'U'`) when loading CSVs. Need to determine work to be done to either:
    1.  Fully support unicode in both python 2.7 and 3.6 (perhaps as `UCS4`/`WeldInt`/`i32`), but how do we know when decoding if it's an array of ints or an array of UCS4 codepoints?
    2. Encode unicode as UTF-8 bytestrings between numpy and weld, though this will still cause string operations such as `slice` to function incorrectly on strings containing non-ASCII characters (e.g. chopping a 2-byte codepoint in half).