### PR TITLE
Add C UDF Support

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -186,7 +186,7 @@ macro filter(data, func) = (
 
 ## User Defined Functions
 
-Weld supports invoking C-style UDFs from a Weld program. The `cudf[name,ty](arg1, arg2,...argN)` node enables this; `name` is a C symbol name which points to a function (e.g., a function in a dynamically loaded library), `ty` is the Weld return type of the UDF, and `arg1, arg2,...,argN` is a list of zero or more argument expressions.
+Weld supports invoking C-style UDFs from a Weld program. The `cudf[name,ty](arg1, arg2,...argN)` node enables this; `name` is a C symbol name which refers to a function in the same address space (e.g., a function in a dynamically loaded library), `ty` is the Weld return type of the UDF, and `arg1, arg2,...,argN` is a list of zero or more argument expressions.
 
 C UDFs require a special format within C code. In particular, a valid C UDF must meet the following requirements:
  * The function has a `void` return type

--- a/examples/cpp/udfs/Makefile
+++ b/examples/cpp/udfs/Makefile
@@ -1,0 +1,12 @@
+CC=clang++
+LDFLAGS=-L../../../target/release/
+LIBS=-lweld
+
+.PHONY: all clean
+
+all:
+	${CC} ${LDFLAGS} ${LIBS} udfs.cpp -o run
+
+clean:
+	rm -rf run
+

--- a/examples/cpp/udfs/README.md
+++ b/examples/cpp/udfs/README.md
@@ -1,0 +1,3 @@
+Uses the C Weld interface to create a Weld module which adds 5 to a number.
+Uses a C UDF from Weld to perform the addition.
+

--- a/examples/cpp/udfs/udfs.cpp
+++ b/examples/cpp/udfs/udfs.cpp
@@ -1,0 +1,64 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <string.h>
+
+// Include the Weld API.
+#include "../../../c/weld.h"
+
+extern "C" void add_five(int64_t *x, int64_t *result) {
+    *result = *x + 5;
+    printf("called add_five: %lld + 5 = %lld\n", *x, *result);
+}
+
+int main() {
+    // Compile Weld module.
+    weld_error_t e = weld_error_new();
+    weld_conf_t conf = weld_conf_new();
+    weld_module_t m = weld_module_compile("|x:i64| cudf[add_five,i64](x)", conf, e);
+    weld_conf_free(conf);
+
+    if (weld_error_code(e)) {
+        const char *err = weld_error_message(e);
+        printf("Error message: %s\n", err);
+        exit(1);
+    }
+
+    while(true) {
+        char buf[4096];
+        char *c;
+        printf(">>> ");
+        fgets(buf, sizeof(buf), stdin);
+
+        if (strncmp(buf, "quit", sizeof(buf)) == 0) {
+            break;
+        }
+
+        unsigned long x = strtoul(buf, &c, 10);
+        if (c == buf) {
+            printf("nope, try again.\n");
+            continue;
+        }
+
+        int64_t input = (int64_t)x;
+        weld_value_t arg = weld_value_new(&input);
+
+        // Run the module and get the result.
+        weld_conf_t conf = weld_conf_new();
+        weld_value_t result = weld_module_run(m, conf, arg, e);
+        void *result_data = weld_value_data(result);
+        printf("Answer: %lld\n", *(int64_t *)result_data);
+
+        // Free the values.
+        weld_value_free(result);
+        weld_value_free(arg);
+        weld_conf_free(conf);
+    }
+
+    weld_error_free(e);
+    weld_module_free(m);
+    printf("Freeing data and quiting!\n");
+
+    return 0;
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -157,6 +157,28 @@ fn negated_arithmetic() {
     unsafe { weld_value_free(ret_value) };
 }
 
+// For the C UDF integration test.
+#[no_mangle]
+pub unsafe extern "C" fn add_five(x: *const i64, result: *mut i64) {
+    *result = *x + 5;
+}
+
+fn c_udf() {
+    let code = "|x:i64| cudf[add_five,i64](x)";
+    let conf = default_conf();
+
+    let ref mut input_data: i64 = 0;
+    // To prevent it from compiling out.
+    unsafe { add_five(input_data, input_data) };
+
+    let ret_value = compile_and_run(code, conf, input_data);
+    let data = unsafe { weld_value_data(ret_value) as *const i64 };
+    let result = unsafe { *data };
+    assert_eq!(result, 10);
+
+    unsafe { weld_value_free(ret_value) };
+}
+
 fn f64_cast() {
     let code = "|| f64(40 + 2)";
     let conf = default_conf();
@@ -1139,6 +1161,7 @@ fn main() {
              ("negation", negation),
              ("negation_double", negation_double),
              ("negated_arithmetic", negated_arithmetic),
+             ("c_udf", c_udf),
              ("f64_cast", f64_cast),
              ("i32_cast", i32_cast),
              ("program_with_args", program_with_args),

--- a/weld/ast.rs
+++ b/weld/ast.rs
@@ -160,6 +160,11 @@ pub enum ExprKind<T: TypeBounds> {
         func: Box<Expr<T>>,
         params: Vec<Expr<T>>,
     },
+    CUDF {
+        sym_name: String,
+        arg_tys: Vec<T>,
+        return_ty: Box<T>,
+    },
     NewBuilder(Option<Box<Expr<T>>>),
     For {
         iters: Vec<Iter<T>>,
@@ -308,6 +313,7 @@ impl<T: TypeBounds> Expr<T> {
                         vec![]
                     }
                 }
+                CUDF { .. } => vec![],
                 Negate(ref t) => vec![t.as_ref()],
                 // Explicitly list types instead of doing _ => ... to remember to add new types.
                 Literal(_) | Ident(_) => vec![],
@@ -370,6 +376,7 @@ impl<T: TypeBounds> Expr<T> {
                         vec![]
                     }
                 }
+                CUDF { .. } => vec![],
                 Negate(ref mut t) => vec![t.as_mut()],
                 // Explicitly list types instead of doing _ => ... to remember to add new types.
                 Literal(_) | Ident(_) => vec![],
@@ -439,6 +446,17 @@ impl<T: TypeBounds> Expr<T> {
                 (&For { .. }, &For { .. }) => Ok(true),
                 (&If { .. }, &If { .. }) => Ok(true),
                 (&Apply { .. }, &Apply { .. }) => Ok(true),
+                (&CUDF { sym_name: ref sym_name1,
+                         arg_tys: ref arg_tys1,
+                         return_ty: ref return_ty1 },
+                 &CUDF { sym_name: ref sym_name2,
+                         arg_tys: ref arg_tys2,
+                         return_ty: ref return_ty2 }) => {
+                    let mut matches = sym_name1 == sym_name2;
+                    matches = matches && arg_tys1 == arg_tys2;
+                    matches = matches && return_ty1 == return_ty2;
+                    Ok(matches)
+                }
                 (&Literal(ref l), &Literal(ref r)) if l == r => Ok(true),
                 (&Ident(ref l), &Ident(ref r)) => {
                     if let Some(lv) = sym_map.get(l) {

--- a/weld/ast.rs
+++ b/weld/ast.rs
@@ -162,7 +162,7 @@ pub enum ExprKind<T: TypeBounds> {
     },
     CUDF {
         sym_name: String,
-        arg_tys: Vec<T>,
+        args: Vec<Expr<T>>,
         return_ty: Box<T>,
     },
     NewBuilder(Option<Box<Expr<T>>>),
@@ -313,7 +313,7 @@ impl<T: TypeBounds> Expr<T> {
                         vec![]
                     }
                 }
-                CUDF { .. } => vec![],
+                CUDF { ref args, .. } => args.iter().collect(),
                 Negate(ref t) => vec![t.as_ref()],
                 // Explicitly list types instead of doing _ => ... to remember to add new types.
                 Literal(_) | Ident(_) => vec![],
@@ -376,7 +376,7 @@ impl<T: TypeBounds> Expr<T> {
                         vec![]
                     }
                 }
-                CUDF { .. } => vec![],
+                CUDF { ref mut args, .. } => args.iter_mut().collect(),
                 Negate(ref mut t) => vec![t.as_mut()],
                 // Explicitly list types instead of doing _ => ... to remember to add new types.
                 Literal(_) | Ident(_) => vec![],
@@ -446,14 +446,9 @@ impl<T: TypeBounds> Expr<T> {
                 (&For { .. }, &For { .. }) => Ok(true),
                 (&If { .. }, &If { .. }) => Ok(true),
                 (&Apply { .. }, &Apply { .. }) => Ok(true),
-                (&CUDF { sym_name: ref sym_name1,
-                         arg_tys: ref arg_tys1,
-                         return_ty: ref return_ty1 },
-                 &CUDF { sym_name: ref sym_name2,
-                         arg_tys: ref arg_tys2,
-                         return_ty: ref return_ty2 }) => {
+                (&CUDF { sym_name: ref sym_name1, return_ty: ref return_ty1, .. },
+                 &CUDF { sym_name: ref sym_name2, return_ty: ref return_ty2, .. }) => {
                     let mut matches = sym_name1 == sym_name2;
-                    matches = matches && arg_tys1 == arg_tys2;
                     matches = matches && return_ty1 == return_ty2;
                     Ok(matches)
                 }

--- a/weld/bin/repl.rs
+++ b/weld/bin/repl.rs
@@ -197,7 +197,7 @@ fn main() {
                     println!("Error during LLVM code gen:\n{}\n", e);
                 } else {
                     let llvm_code = llvm_gen.result();
-                    // println!("LLVM code:\n{}\n", llvm_code);
+                    println!("LLVM code:\n{}\n", llvm_code);
 
                     if let Err(e) = load_runtime_library() {
                         println!("Couldn't load runtime: {}", e);

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -1024,7 +1024,47 @@ impl LlvmGenerator {
                                              ll_ty,
                                              llvm_symbol(output)));
                     }
-                    CUDF { .. } => panic!("unimplemented"),
+                    CUDF { ref output, ref symbol_name, ref args } => {
+                        // TODO If function not declared
+                        if true {
+                            // First, declare the function.
+                            let mut arg_tys = vec![];
+                            for ref arg in args {
+                                arg_tys.push(format!("{}*",
+                                                     self.llvm_type(get_sym_ty(func, arg)?)?
+                                                         .to_string()));
+                            }
+                            arg_tys.push(format!("{}*",
+                                                 self.llvm_type(get_sym_ty(func, output)?)?
+                                                     .to_string()));
+                            let arg_sig = arg_tys.join(", ");
+
+                            println!("{}", arg_sig);
+
+                            self.prelude_code
+                                .add(format!("declare void @{name}({arg_sig});",
+                                             name = symbol_name,
+                                             arg_sig = arg_sig));
+                        }
+
+                        // Prepare the parameter list for the function
+                        let mut arg_tys = vec![];
+                        for ref arg in args {
+                            let ll_ty = self.llvm_type(get_sym_ty(func, arg)?)?.to_string();
+                            let arg_str =
+                                format!("{ll_ty}* {arg}", arg = llvm_symbol(arg), ll_ty = ll_ty);
+                            arg_tys.push(arg_str);
+                        }
+                        arg_tys.push(format!("{}* {}",
+                                             self.llvm_type(get_sym_ty(func, output)?)?
+                                                 .to_string(),
+                                             llvm_symbol(output)));
+                        let param_sig = arg_tys.join(", ");
+
+                        ctx.code.add(format!("call void @{name}({param_sig})",
+                                             name = symbol_name,
+                                             param_sig = param_sig));
+                    }
                     MakeVector { ref output, ref elems, ref elem_ty } => {
                         let elem_ll_ty = self.llvm_type(elem_ty)?.to_string();
                         let vec_ll_ty = self.llvm_type(&Vector(Box::new(elem_ty.clone())))?

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -1039,8 +1039,6 @@ impl LlvmGenerator {
                                                      .to_string()));
                             let arg_sig = arg_tys.join(", ");
 
-                            println!("{}", arg_sig);
-
                             self.prelude_code
                                 .add(format!("declare void @{name}({arg_sig});",
                                              name = symbol_name,

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -1024,6 +1024,7 @@ impl LlvmGenerator {
                                              ll_ty,
                                              llvm_symbol(output)));
                     }
+                    CUDF { .. } => panic!("unimplemented"),
                     MakeVector { ref output, ref elems, ref elem_ty } => {
                         let elem_ll_ty = self.llvm_type(elem_ty)?.to_string();
                         let vec_ll_ty = self.llvm_type(&Vector(Box::new(elem_ty.clone())))?

--- a/weld/parser.rs
+++ b/weld/parser.rs
@@ -586,6 +586,27 @@ impl<'t> Parser<'t> {
                 }))
             }
 
+            TCUDF => {
+                let mut arg_tys = vec![];
+                try!(self.consume(TOpenBracket));
+                let sym_name = try!(self.symbol());
+                try!(self.consume(TComma));
+                let return_ty = try!(self.type_());
+                try!(self.consume(TCloseBracket));
+                try!(self.consume(TOpenParen));
+                while *self.peek() != TCloseParen {
+                    let arg_ty = try!(self.type_());
+                    arg_tys.push(arg_ty);
+                    try!(self.consume(TComma));
+                }
+                try!(self.consume(TCloseParen));
+                Ok(expr_box(CUDF {
+                    sym_name: sym_name.name,
+                    return_ty: Box::new(return_ty),
+                    arg_tys: arg_tys,
+                }))
+            }
+
             TZip => {
                 try!(self.consume(TOpenParen));
                 let mut vectors = vec![];

--- a/weld/parser.rs
+++ b/weld/parser.rs
@@ -587,7 +587,7 @@ impl<'t> Parser<'t> {
             }
 
             TCUDF => {
-                let mut arg_tys = vec![];
+                let mut args = vec![];
                 try!(self.consume(TOpenBracket));
                 let sym_name = try!(self.symbol());
                 try!(self.consume(TComma));
@@ -595,15 +595,17 @@ impl<'t> Parser<'t> {
                 try!(self.consume(TCloseBracket));
                 try!(self.consume(TOpenParen));
                 while *self.peek() != TCloseParen {
-                    let arg_ty = try!(self.type_());
-                    arg_tys.push(arg_ty);
-                    try!(self.consume(TComma));
+                    let arg = try!(self.expr());
+                    args.push(*arg);
+                    if *self.peek() == TComma {
+                        try!(self.consume(TComma));
+                    }
                 }
                 try!(self.consume(TCloseParen));
                 Ok(expr_box(CUDF {
                     sym_name: sym_name.name,
                     return_ty: Box::new(return_ty),
-                    arg_tys: arg_tys,
+                    args: args,
                 }))
             }
 

--- a/weld/partial_types.rs
+++ b/weld/partial_types.rs
@@ -170,6 +170,26 @@ impl PartialExpr {
             Literal(F64Literal(v)) => Literal(F64Literal(v)),
             Ident(ref name) => Ident(name.clone()),
 
+            CUDF { ref sym_name, ref arg_tys, ref return_ty } => {
+                let sym_name: String = sym_name.clone();
+                let return_ty: Box<Type> = Box::new(try!(return_ty.to_type()));
+                let mut arg_tys_new = vec![];
+                for ref partial_ty in arg_tys {
+                    if let Ok(t) = partial_ty.to_type() {
+                        arg_tys_new.push(t);
+                    }
+                }
+                if arg_tys.len() != arg_tys_new.len() {
+                    return weld_err!("to_typed failed for CUDF");
+                } else {
+                    CUDF {
+                        sym_name: sym_name,
+                        arg_tys: arg_tys_new,
+                        return_ty: return_ty,
+                    }
+                }
+            }
+
             BinOp { kind, ref left, ref right } => {
                 BinOp {
                     kind: kind,

--- a/weld/partial_types.rs
+++ b/weld/partial_types.rs
@@ -170,23 +170,14 @@ impl PartialExpr {
             Literal(F64Literal(v)) => Literal(F64Literal(v)),
             Ident(ref name) => Ident(name.clone()),
 
-            CUDF { ref sym_name, ref arg_tys, ref return_ty } => {
+            CUDF { ref sym_name, ref args, ref return_ty } => {
                 let sym_name: String = sym_name.clone();
+                let args: WeldResult<Vec<_>> = args.iter().map(|e| e.to_typed()).collect();
                 let return_ty: Box<Type> = Box::new(try!(return_ty.to_type()));
-                let mut arg_tys_new = vec![];
-                for ref partial_ty in arg_tys {
-                    if let Ok(t) = partial_ty.to_type() {
-                        arg_tys_new.push(t);
-                    }
-                }
-                if arg_tys.len() != arg_tys_new.len() {
-                    return weld_err!("to_typed failed for CUDF");
-                } else {
-                    CUDF {
-                        sym_name: sym_name,
-                        arg_tys: arg_tys_new,
-                        return_ty: return_ty,
-                    }
+                CUDF {
+                    sym_name: sym_name,
+                    args: try!(args),
+                    return_ty: return_ty,
                 }
             }
 

--- a/weld/pretty_print.rs
+++ b/weld/pretty_print.rs
@@ -191,6 +191,13 @@ fn print_expr_impl<T: PrintableType>(expr: &Expr<T>,
 
         Negate(ref e) => format!("(-{})", print_expr_impl(e, typed, indent, should_indent)),
 
+        CUDF { ref sym_name, ref arg_tys, ref return_ty } => {
+            format!("cudf[{},{}]{}",
+                    sym_name,
+                    return_ty.print(),
+                    join("(", ",", ")", arg_tys.iter().map(|t| t.print())))
+        }
+
         Cast { kind, ref child_expr } => {
             format!("({}({}))",
                     kind,

--- a/weld/pretty_print.rs
+++ b/weld/pretty_print.rs
@@ -191,11 +191,15 @@ fn print_expr_impl<T: PrintableType>(expr: &Expr<T>,
 
         Negate(ref e) => format!("(-{})", print_expr_impl(e, typed, indent, should_indent)),
 
-        CUDF { ref sym_name, ref arg_tys, ref return_ty } => {
+        CUDF { ref sym_name, ref args, ref return_ty } => {
             format!("cudf[{},{}]{}",
                     sym_name,
                     return_ty.print(),
-                    join("(", ",", ")", arg_tys.iter().map(|t| t.print())))
+                    join("(",
+                         ",",
+                         ")",
+                         args.iter()
+                             .map(|e| print_expr_impl(e, typed, indent, should_indent))))
         }
 
         Cast { kind, ref child_expr } => {

--- a/weld/tokenizer.rs
+++ b/weld/tokenizer.rs
@@ -43,6 +43,7 @@ pub enum Token {
     TKeyExists,
     TSlice,
     TExp,
+    TCUDF,
     TAppender,
     TMerger,
     TDictMerger,
@@ -90,7 +91,7 @@ pub fn tokenize(input: &str) -> WeldResult<Vec<Token>> {
 
         // Regular expressions for various types of tokens.
         static ref KEYWORD_RE: Regex = Regex::new(
-            "if|for|zip|len|lookup|keyexists|slice|exp|iter|merge|result|let|true|false|macro|\
+            "if|for|zip|len|lookup|keyexists|slice|exp|cudf|iter|merge|result|let|true|false|macro|\
              i8|i32|i64|f32|f64|bool|vec|appender|merger|vecmerger|dictmerger|tovec").unwrap();
 
         static ref IDENT_RE: Regex = Regex::new(r"^[A-Za-z$_][A-Za-z0-9$_]*$").unwrap();
@@ -147,6 +148,7 @@ pub fn tokenize(input: &str) -> WeldResult<Vec<Token>> {
                 "keyexists" => TKeyExists,
                 "slice" => TSlice,
                 "exp" => TExp,
+                "cudf" => TCUDF,
                 "true" => TBoolLiteral(true),
                 "false" => TBoolLiteral(false),
                 _ => return weld_err!("Invalid input token: {}", text),
@@ -271,6 +273,7 @@ impl fmt::Display for Token {
                            TKeyExists => "keyexists",
                            TSlice => "slice",
                            TExp => "exp",
+                           TCUDF => "cudf",
                            TOpenParen => "(",
                            TCloseParen => ")",
                            TOpenBracket => "[",

--- a/weld/type_inference.rs
+++ b/weld/type_inference.rs
@@ -156,7 +156,6 @@ fn infer_locally(expr: &mut PartialExpr, env: &mut TypeMap) -> WeldResult<bool> 
 
         Negate(ref c) => push_type(&mut expr.ty, &c.ty, "Negate"),
 
-        // TODO the arg_tys should actually just be args...
         CUDF { ref return_ty, .. } => push_complete_type(&mut expr.ty, *return_ty.clone(), "CUDF"),
 
         Let { ref mut body, .. } => sync_types(&mut expr.ty, &mut body.ty, "Let body"),

--- a/weld/type_inference.rs
+++ b/weld/type_inference.rs
@@ -156,6 +156,9 @@ fn infer_locally(expr: &mut PartialExpr, env: &mut TypeMap) -> WeldResult<bool> 
 
         Negate(ref c) => push_type(&mut expr.ty, &c.ty, "Negate"),
 
+        // TODO the arg_tys should actually just be args...
+        CUDF { ref return_ty, .. } => push_complete_type(&mut expr.ty, *return_ty.clone(), "CUDF"),
+
         Let { ref mut body, .. } => sync_types(&mut expr.ty, &mut body.ty, "Let body"),
 
         MakeVector { ref mut elems } => {
@@ -808,7 +811,7 @@ fn infer_types_let() {
 
     let mut e = parse_expr(code).unwrap();
     assert!(infer_types(&mut e).is_ok());
-    assert_eq!(e.ty,  Scalar(Bool));
+    assert_eq!(e.ty, Scalar(Bool));
 
     let mut e = parse_expr("let a = slice([1.0f, 2.0f, 3.0f], 0L, 2L);a").unwrap();
     assert!(infer_types(&mut e).is_ok());


### PR DESCRIPTION
This PR adds support for calling C-style UDFs from within an Weld program. C UDFs are functions with with C-style symbol names. As long as the symbol name is linked with the executable, Weld can call into it.

* See `language.md` for a detailed discussion on the semantics of the UDF node.
* See `examples/cpp/udfs/` for an example of using UDFs in a C++ program.

TODO: Still need to figure out how to add integration tests for the UDFs; we somehow need to link a C-callable function into the integration test suite. Alternative designs for the UDF node are also welcome.