### PR TITLE
Support different versions of python on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ language: rust
 sudo: required
 dist: trusty
 
-python:
-  - 2.7
-
 addons:
   apt:
     sources:
+      - deadsnakes
       - sourceline: 'deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.8 main'
         key_url: 'http://llvm.org/apt/llvm-snapshot.gpg.key'
       - llvm-toolchain-trusty-4.0
@@ -21,19 +19,25 @@ addons:
       - llvm-4.0-dev
       - clang-4.0
       - lib32z1-dev
+      - python2.7
+      - python3.6
 
 install:
   - sudo rm -f `which llvm-config`
   - export WELD_HOME=`pwd`
   - (cargo install rustfmt || true)
   - PATH=$PATH:/home/travis/.cargo/bin
+  - pip install virtualenv==15.1.0
+  - mkdir -p .virtualenv
+  - export VENV_HOME=`pwd`/.virtualenv
+  - virtualenv $VENV_HOME/py2.7
+  - virtualenv $VENV_HOME/py3.6 --python=`which python3.6`
   - cd python
-  - pip install --upgrade pip setuptools wheel
-  - pip install --only-binary=numpy,pandas -r requirements.txt
-  - python setup.py install
+  - source $VENV_HOME/py2.7/bin/activate; pip install --upgrade pip setuptools wheel; pip install --only-binary=numpy,pandas -r requirements.txt
+  - source $VENV_HOME/py3.6/bin/activate; pip install --upgrade pip setuptools wheel; pip install --only-binary=numpy,pandas -r requirements.txt
   - cd ..
 
 script:
   - bash -e build_tools/travis/test_format.sh
-  - bash -e build_tools/travis/test_llvm_version.sh 3.8 38.0.1
-  - bash -e build_tools/travis/test_llvm_version.sh 4.0 40.0.0
+  - bash -e -x build_tools/travis/test_multi_version.sh 3.8 38.0.1 2.7
+  - bash -e -x build_tools/travis/test_multi_version.sh 4.0 40.0.0 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,7 @@ install:
   - (cargo install rustfmt || true)
   - PATH=$PATH:/home/travis/.cargo/bin
   - pip install virtualenv==15.1.0
-  - mkdir -p .virtualenv
-  - export VENV_HOME=`pwd`/.virtualenv
-  - virtualenv $VENV_HOME/py2.7
-  - virtualenv $VENV_HOME/py3.6 --python=`which python3.6`
-  - cd python
-  - source $VENV_HOME/py2.7/bin/activate; pip install --upgrade pip setuptools wheel; pip install --only-binary=numpy,pandas -r requirements.txt
-  - source $VENV_HOME/py3.6/bin/activate; pip install --upgrade pip setuptools wheel; pip install --only-binary=numpy,pandas -r requirements.txt
-  - cd ..
+  - bash -e build_tools/travis/init_virtualenvs.sh 2.7 3.6
 
 script:
   - bash -e build_tools/travis/test_format.sh

--- a/build_tools/travis/init_virtualenvs.sh
+++ b/build_tools/travis/init_virtualenvs.sh
@@ -1,0 +1,17 @@
+ #!/bin/bash
+
+PYTHON_VERSIONS=$@
+
+pip install -U virtualenv
+mkdir -p .virtualenv
+export VENV_HOME=`pwd`/.virtualenv
+
+pushd python
+for v in $PYTHON_VERSIONS; do
+  virtualenv "$VENV_HOME/python$v" --python="python$v"
+  source "$VENV_HOME/python$v/bin/activate"
+  pip install --upgrade pip setuptools wheel
+  pip install --only-binary=numpy,pandas -r requirements.txt
+  deactivate
+done
+popd

--- a/build_tools/travis/test_multi_version.sh
+++ b/build_tools/travis/test_multi_version.sh
@@ -3,14 +3,14 @@
 LLVM_VERSION=$1
 LLVM_SYS_VERSION=$2
 PYTHON_VERSION=$3
+VENV_HOME=`pwd`/.virtualenv
 
 # create llvm-config symlink
-sudo rm -f `which llvm-config`
 sudo rm -f /usr/bin/llvm-config
 sudo ln -s /usr/bin/llvm-config-$LLVM_VERSION /usr/bin/llvm-config
 export WELD_HOME=`pwd`
 
-source $VENV_HOME/py$PYTHON_VERSION/bin/activate
+source $VENV_HOME/python$PYTHON_VERSION/bin/activate
 cd python
 python setup.py install
 cd ..
@@ -27,3 +27,4 @@ cargo test
 
 python python/grizzly/tests/grizzly_test.py
 python python/grizzly/tests/numpy_weld_test.py
+deactivate

--- a/build_tools/travis/test_multi_version.sh
+++ b/build_tools/travis/test_multi_version.sh
@@ -2,10 +2,18 @@
 
 LLVM_VERSION=$1
 LLVM_SYS_VERSION=$2
+PYTHON_VERSION=$3
 
 # create llvm-config symlink
+sudo rm -f `which llvm-config`
 sudo rm -f /usr/bin/llvm-config
 sudo ln -s /usr/bin/llvm-config-$LLVM_VERSION /usr/bin/llvm-config
+export WELD_HOME=`pwd`
+
+source $VENV_HOME/py$PYTHON_VERSION/bin/activate
+cd python
+python setup.py install
+cd ..
 
 # set llvm-sys crate version
 sed -i "s/llvm-sys = \".*\"/llvm-sys = \"$LLVM_SYS_VERSION\"/g" easy_ll/Cargo.toml
@@ -14,5 +22,7 @@ sed -i "s/llvm-sys = \".*\"/llvm-sys = \"$LLVM_SYS_VERSION\"/g" easy_ll/Cargo.to
 cargo clean
 cargo build --release
 cargo test
+
+
 python python/grizzly/tests/grizzly_test.py
 python python/grizzly/tests/numpy_weld_test.py

--- a/build_tools/travis/test_multi_version.sh
+++ b/build_tools/travis/test_multi_version.sh
@@ -19,10 +19,11 @@ cd ..
 sed -i "s/llvm-sys = \".*\"/llvm-sys = \"$LLVM_SYS_VERSION\"/g" easy_ll/Cargo.toml
 
 # build and test
+# Note that cargo build must, counterintuitively, come after setup.py install,
+# because numpy_weld_convertor.cpp is built by cargo.
 cargo clean
 cargo build --release
 cargo test
-
 
 python python/grizzly/tests/grizzly_test.py
 python python/grizzly/tests/numpy_weld_test.py


### PR DESCRIPTION
Makes progress towards Python 3.6 support (#110). Once codebase is 3.6 compatible (e.g. print, unicode, etc), adding appropriate invocations to `script` in `.travis.yml` will be enough to build and test under both 2.7 and 3.6.

Once unicode & 3.6 support is working, better packaging of weld and grizzly and publishing artifacts to conda-forge would be nice.