### PR TITLE
Support Initial Value and Products for Merger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ target
 Cargo.lock
 .DS_Store
 *.swp
-*.ll
 *.bc
 *.pyc
 *.o

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -2002,8 +2002,19 @@ impl LlvmGenerator {
 
                                         // Generate code to initialize the builder.
                                         let iden_elem = match *op {
-                                            BinOpKind::Add => "0".to_string(),
-                                            BinOpKind::Multiply => "1".to_string(),
+                                            BinOpKind::Add => {
+                                                match **elem_ty {
+                                                    Scalar(F32) | Scalar(F64) => "0.0".to_string(),
+                                                    _ => "0".to_string(),
+                                                }
+                                            }
+                                            BinOpKind::Multiply => {
+                                                match **elem_ty {
+                                                    Scalar(F32) | Scalar(F64) => "1.0".to_string(),
+                                                    _ => "1".to_string(),
+                                                }
+                                            }
+
                                             _ => {
                                                 return weld_err!("Invalid merger binary op in \
                                                                   codegen")

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -1785,27 +1785,34 @@ impl LlvmGenerator {
                                     GroupMerger(ref kt, ref vt) => {
                                         let mut func_gen = IdGenerator::new("%func");
                                         let function_id = func_gen.next();
-                                        let func_str = format!("@{}", &function_id.replace("%", ""));
+                                        let func_str = format!("@{}",
+                                                               &function_id.replace("%", ""));
                                         let bld_ty = Dict(kt.clone(), Box::new(Vector(vt.clone())));
                                         let elem = Box::new(Struct(vec![*kt.clone(), *vt.clone()]));
                                         let bld_ty_str = try!(self.llvm_type(&bld_ty)).to_string();
                                         let kv_struct_ty = try!(self.llvm_type(&elem)).to_string();
                                         let key_ty = try!(self.llvm_type(kt)).to_string();
                                         let value_ty = try!(self.llvm_type(vt)).to_string();
-                                        let value_vec_ty = try!(self.llvm_type(&Box::new(Vector(vt.clone())))).to_string();
+                                        let value_vec_ty =
+                                            try!(self.llvm_type(&Box::new(Vector(vt.clone()))))
+                                                .to_string();
                                         let kv_vec = Box::new(Vector(elem.clone()));
                                         let kv_vec_ty = try!(self.llvm_type(&kv_vec)).to_string();
                                         let kv_vec_builder_ty = format!("{}.bld", &kv_vec_ty);
                                         let key_prefix = format!("@{}", &key_ty.replace("%", ""));
-                                        let kv_vec_prefix = format!("@{}", &kv_vec_ty.replace("%", ""));
-                                        let value_vec_prefix = format!("@{}", &value_vec_ty.replace("%", ""));
-                                        let dict_prefix = format!("@{}", &bld_ty_str.replace("%", ""));
+                                        let kv_vec_prefix = format!("@{}",
+                                                                    &kv_vec_ty.replace("%", ""));
+                                        let value_vec_prefix =
+                                            format!("@{}", &value_vec_ty.replace("%", ""));
+                                        let dict_prefix = format!("@{}",
+                                                                  &bld_ty_str.replace("%", ""));
 
                                         let name_replaced =
                                             GROUPMERGER_CODE.replace("$NAME", &function_id.replace("%", ""));
                                         let key_prefix_replaced =
                                             name_replaced.replace("$KEY_PREFIX", &key_prefix);
-                                        let key_ty_replaced = key_prefix_replaced.replace("$KEY", &key_ty);
+                                        let key_ty_replaced =
+                                            key_prefix_replaced.replace("$KEY", &key_ty);
                                         let value_vec_prefix_ty_replaced =
                                             key_ty_replaced.replace("$VALUE_VEC_PREFIX", &value_vec_prefix);
                                         let value_vec_ty_replaced =
@@ -1813,7 +1820,8 @@ impl LlvmGenerator {
                                         let value_ty_replaced =
                                             value_vec_ty_replaced.replace("$VALUE", &value_ty);
                                         let kv_struct_replaced =
-                                            value_ty_replaced.replace("$KV_STRUCT", &kv_struct_ty.replace("%", ""));
+                                            value_ty_replaced.replace("$KV_STRUCT",
+                                                         &kv_struct_ty.replace("%", ""));
                                         let kv_vec_prefix_replaced =
                                             kv_struct_replaced.replace("$KV_VEC_PREFIX", &kv_vec_prefix);
                                         let kv_vec_ty_replaced =
@@ -1970,7 +1978,7 @@ impl LlvmGenerator {
                                                                  bld_ty_str.replace("%", ""));
                                         let bld_tmp = ctx.var_ids.next();
                                         ctx.code
-                                           .add(format!("{} = call {} {}.new(i64 16, %work_t* \
+                                            .add(format!("{} = call {} {}.new(i64 16, %work_t* \
                                                           %cur.work)",
                                                          bld_tmp,
                                                          bld_ty_str,
@@ -1981,11 +1989,9 @@ impl LlvmGenerator {
                                                              bld_ty_str,
                                                              llvm_symbol(output)));
                                     }
-                                    Merger(_, ref op) => {
-                                        if *op != BinOpKind::Add {
-                                            return weld_err!("Merger only supports +");
-                                        }
-                                        let bld_ty_str = try!(self.llvm_type(ty));
+                                    Merger(ref elem_ty, ref op) => {
+                                        let bld_ty_str = self.llvm_type(ty)?.to_string();
+                                        let elem_type = (self.llvm_type(elem_ty)?).to_string();
                                         let bld_prefix = format!("@{}",
                                                                  bld_ty_str.replace("%", ""));
                                         let bld_tmp = ctx.var_ids.next();
@@ -1993,6 +1999,62 @@ impl LlvmGenerator {
                                                              bld_tmp,
                                                              bld_ty_str,
                                                              bld_prefix));
+
+                                        // Generate code to initialize the builder.
+                                        let iden_elem = match *op {
+                                            BinOpKind::Add => "0".to_string(),
+                                            BinOpKind::Multiply => "1".to_string(),
+                                            _ => {
+                                                return weld_err!("Invalid merger binary op in \
+                                                                  codegen")
+                                            }
+                                        };
+
+                                        let init_elem = match *arg {
+                                            Some(ref s) => {
+                                                let arg_str = self.load_var(llvm_symbol(s).as_str(),
+                                                              &elem_type,
+                                                              ctx)?;
+                                                arg_str
+                                            }
+                                            _ => iden_elem.clone(),
+                                        };
+
+                                        let first = ctx.var_ids.next();
+                                        let nworkers = ctx.var_ids.next();
+                                        let i = ctx.var_ids.next();
+                                        let cur_ptr = ctx.var_ids.next();
+                                        let i2 = ctx.var_ids.next();
+                                        let cond = ctx.var_ids.next();
+                                        let cond2 = ctx.var_ids.next();
+
+                                        // Generate label names.
+                                        let label_base = ctx.var_ids.next();
+                                        let mut label_ids =
+                                            IdGenerator::new(&label_base.replace("%", ""));
+                                        let entry = label_ids.next();
+                                        let body = label_ids.next();
+                                        let done = label_ids.next();
+
+
+                                        ctx.code.add(format!(include_str!("resources/merger/init_merger.ll"),
+                                        first=first,
+                                        nworkers=nworkers,
+                                        bld_ty_str=bld_ty_str,
+                                        bld_prefix=bld_prefix,
+                                        init_elem=init_elem,
+                                        elem_type=elem_type,
+                                        cond=cond,
+                                        iden_elem=iden_elem,
+                                        bld_inp=bld_tmp,
+                                        i=i,
+                                        cur_ptr=cur_ptr,
+                                        i2=i2,
+                                        cond2=cond2,
+                                        entry=entry,
+                                        body=body,
+                                        done=done));
+
                                         ctx.code.add(format!("store {} {}, {}* {}",
                                                              bld_ty_str,
                                                              bld_tmp,
@@ -2015,8 +2077,7 @@ impl LlvmGenerator {
                                                              llvm_symbol(output)));
                                     }
                                     GroupMerger(_, _) => {
-                                        let bld_ty_str = try!(self.llvm_type(ty))
-                                            .to_string();
+                                        let bld_ty_str = try!(self.llvm_type(ty)).to_string();
                                         let bld_prefix = format!("@{}",
                                                                  bld_ty_str.replace("%", ""));
                                         let bld_tmp = ctx.var_ids.next();

--- a/weld/parser.rs
+++ b/weld/parser.rs
@@ -764,7 +764,15 @@ impl<'t> Parser<'t> {
                     }
                 };
                 self.consume(TCloseBracket)?;
-                let mut expr = expr_box(NewBuilder(None));
+
+                let mut value = None;
+                if *self.peek() == TOpenParen {
+                    self.consume(TOpenParen)?;
+                    value = Some(self.expr()?);
+                    self.consume(TCloseParen)?;
+                }
+
+                let mut expr = expr_box(NewBuilder(value));
                 expr.ty = Builder(Merger(Box::new(elem_type), bin_op));
                 Ok(expr)
             }
@@ -814,7 +822,7 @@ impl<'t> Parser<'t> {
                 expr.ty = Builder(GroupMerger(Box::new(key_type.clone()),
                                               Box::new(value_type.clone()),
                                               Box::new(Struct(vec![key_type.clone(),
-                                                                  value_type.clone()]))));
+                                                                   value_type.clone()]))));
                 Ok(expr)
             }
 

--- a/weld/resources/merger/init_merger.ll
+++ b/weld/resources/merger/init_merger.ll
@@ -1,0 +1,19 @@
+  ; Copy the initial value into the first merger
+  {nworkers} = call i32 @get_nworkers()
+  {first} = call {bld_ty_str} {bld_prefix}.getPtrIndexed({bld_ty_str} {bld_inp}, i32 0)
+  store {elem_type} {init_elem}, {bld_ty_str} {first}
+  br label %{entry}
+
+{entry}:
+  {cond} = icmp ult i32 1, {nworkers}
+  br i1 {cond}, label %{body}, label %{done}
+
+{body}:
+  {i} = phi i32 [ 1, %{entry} ], [ {i2}, %{body} ]
+  {cur_ptr} = call {bld_ty_str} {bld_prefix}.getPtrIndexed({bld_ty_str} {bld_inp}, i32 {i})
+  store {elem_type} {iden_elem}, {bld_ty_str} {cur_ptr}
+  {i2} = add i32 {i}, 1
+  {cond2} = icmp ult i32 {i2}, {nworkers}
+  br i1 {cond2}, label %{body}, label %{done}
+
+{done}:

--- a/weld/type_inference.rs
+++ b/weld/type_inference.rs
@@ -438,6 +438,16 @@ fn infer_locally(expr: &mut PartialExpr, env: &mut TypeMap) -> WeldResult<bool> 
                             }
                         }
                     }
+                    Merger(ref elem, _) => {
+                        match *e {
+                            Some(ref mut arg) => {
+                                changed |= try!(push_type(&mut arg.ty,
+                                                          &elem.clone(),
+                                                          "NewBuilder(Merger)"));
+                            }
+                            None => {}
+                        }
+                    }
                     _ => {} // No arguments for the builder.
                 }
             }
@@ -618,9 +628,7 @@ fn push_type(dest: &mut PartialType, src: &PartialType, context: &str) -> WeldRe
             }
         }
 
-        Builder(GroupMerger(ref mut dest_key_ty,
-                            ref mut dest_value_ty,
-                            ref mut dest_merge_ty)) => {
+        Builder(GroupMerger(ref mut dest_key_ty, ref mut dest_value_ty, ref mut dest_merge_ty)) => {
             match *src {
                 Builder(GroupMerger(ref src_key_ty, ref src_value_ty, ref src_merge_ty)) => {
                     let mut changed = false;


### PR DESCRIPTION
Adds support for product-based mergers, and support for an initial value in the merger.

An initial value can be passed into the merger as follows:

```
let a = merger[i32,+](100);
let b = merge(a, 1);
result(b) # returns 101
```

The product merger can be used in a similar manner:

```
let a = merger[i32,*](100);
let b = merge(a, 2);
let c = merge(b, 2);
result(c) # returns 400
```

Mergers are initialized with the identity value of the binary op if an initial value is not specified (1 for products, 0 for sums).

Note: This PR is required for #26. 