### PR TITLE
Fixes from Issues

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -123,17 +123,17 @@ result(b2)    # returns [2, 4, 6]
 ```
 
 ```
-# for expression with composite builder
-let b0 = appender[i32];
+# for with composite builder
 let b1 = appender[i32];
+let b2 = appender[i32];
 let data = [1, 2, 3];
 let bs = for(
   data,
   {b1, b2},
-  (bs: {appender[i32], appender[i32]}, i: i64, n: i32) =>
+  |bs: {appender[i32], appender[i32]}, i: i64, n: i32|
     {merge(bs.$0, n), merge(bs.$1, 2 * n)}
 );
-result(bs)    # returns {[1, 2, 3], [2, 4, 6]}
+{result(bs.$0), result(bs.$1)} # returns {[1, 2, 3], [2, 4, 6]}
 ```
 
 ### Linearity of Builder Types

--- a/examples/cpp/composite_types/Makefile
+++ b/examples/cpp/composite_types/Makefile
@@ -1,0 +1,12 @@
+CC=clang++
+LDFLAGS=-L../../../target/release/
+LIBS=-lweld
+
+.PHONY: all clean
+
+all:
+	${CC} ${LDFLAGS} ${LIBS} composite_types.cpp -o run
+
+clean:
+	rm -rf run
+

--- a/examples/cpp/composite_types/README.md
+++ b/examples/cpp/composite_types/README.md
@@ -1,0 +1,1 @@
+Demonstrates how to pass composite types to Weld.

--- a/examples/cpp/composite_types/composite_types.cpp
+++ b/examples/cpp/composite_types/composite_types.cpp
@@ -1,0 +1,89 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <string.h>
+
+// Include the Weld API.
+#include "../../../c/weld.h"
+
+const char *program = "|x:i32, ys:vec[i64]|\
+let a = result(for(ys, appender[i32], |b, i, y| merge(b, x)));\
+let b = result(for(ys, appender[i64], |b, i, y| merge(b, y)));\
+{a, b}";
+
+template <typename T>
+struct vec {
+    T *data;
+    int64_t length;
+};
+
+struct args {
+    int32_t x;
+    struct vec<int64_t> ys;
+};
+
+struct retval {
+    struct vec<int32_t> a;
+    struct vec<int64_t> b;
+};
+
+int main() {
+    // Compile Weld module.
+    weld_error_t e = weld_error_new();
+    weld_conf_t conf = weld_conf_new();
+    weld_module_t m = weld_module_compile(program, conf, e);
+    weld_conf_free(conf);
+
+    if (weld_error_code(e)) {
+        const char *err = weld_error_message(e);
+        printf("Error message: %s\n", err);
+        exit(1);
+    }
+
+    {
+        struct vec<int64_t> ys;
+        ys.data = (int64_t *)malloc(sizeof(int64_t) * 4);
+        ys.data[0] = ys.data[1] = ys.data[2] = ys.data[3] = 2;
+        ys.length = 4;
+
+        struct args input;
+        input.x = 5;
+        input.ys = ys;
+
+        weld_value_t arg = weld_value_new(&input);
+
+        // Run the module and get the result.
+        weld_conf_t conf = weld_conf_new();
+        weld_value_t result = weld_module_run(m, conf, arg, e);
+        if (weld_error_code(e)) {
+            const char *err = weld_error_message(e);
+            printf("Error message: %s\n", err);
+            exit(1);
+        }
+        struct retval *result_data = (struct retval *)weld_value_data(result);
+
+        printf("Answer lengths: %lld %lld\n", result_data->a.length, result_data->b.length);
+        printf("Answer a values: %d %d %d %d\n", result_data->a.data[0],
+                result_data->a.data[1],
+                result_data->a.data[2],
+                result_data->a.data[3]);
+
+        printf("Answer b values: %lld %lld %lld %lld\n", result_data->b.data[0],
+                result_data->b.data[1],
+                result_data->b.data[2],
+                result_data->b.data[3]);
+
+        // Free the values.
+        weld_value_free(result);
+        weld_value_free(arg);
+        weld_conf_free(conf);
+    }
+
+    weld_error_free(e);
+    weld_module_free(m);
+    printf("Freeing data and quiting!\n");
+
+
+    return 0;
+}

--- a/weld/tests.rs
+++ b/weld/tests.rs
@@ -110,6 +110,12 @@ fn parse_and_print_uniquified_expressions() {
     let _ = uniquify(&mut e);
     assert_eq!(print_expr_without_indent(&e).as_str(),
                "(let a=(2);((|a#1,b|(a#1+b))(1,2)+a))");
+
+    // Lambdas and Lets
+    let mut e = parse_expr("let b = for([1], appender[i32], |b,i,e| merge(b, e)); b").unwrap();
+    let _ = uniquify(&mut e);
+    assert_eq!(print_expr_without_indent(&e).as_str(),
+               "(let b#1=(for([1],appender[i32],|b,i,e|merge(b,e)));b#1)");
 }
 
 #[test]

--- a/weld/type_inference.rs
+++ b/weld/type_inference.rs
@@ -350,27 +350,6 @@ fn infer_locally(expr: &mut PartialExpr, env: &mut TypeMap) -> WeldResult<bool> 
                     let mty = b.merge_type_mut();
                     changed |= try!(sync_types(mty, &mut value.ty, "Merge"));
                 }
-                Struct(ref mut tys) => {
-                    let mut rtys = vec![];
-                    for ty in tys.iter_mut() {
-                        if let &mut Builder(ref mut b, _) = ty {
-                            let rty = b.merge_type();
-                            rtys.push(rty);
-                        }
-                    }
-                    let ref mut mty = Struct(rtys);
-                    changed |= try!(sync_types(&mut value.ty, mty, "Merge"));
-                    // Now sync back the type to the actual builder.
-                    if let Struct(ref value_tys) = value.ty {
-                        for (i, ty) in tys.iter_mut().enumerate() {
-                            let ref val_ty = value_tys[i];
-                            if let &mut Builder(ref mut b, _) = ty {
-                                let mty = b.merge_type_mut();
-                                changed |= try!(push_type(mty, val_ty, "Merge"));
-                            }
-                        }
-                    }
-                }
                 Unknown => (),
                 _ => return weld_err!("Internal error: Merge called on non-builder"),
             }
@@ -384,16 +363,6 @@ fn infer_locally(expr: &mut PartialExpr, env: &mut TypeMap) -> WeldResult<bool> 
                 Builder(ref mut b, _) => {
                     let rty = b.result_type();
                     changed |= try!(push_type(&mut expr.ty, &rty, "Res"));
-                }
-                Struct(ref mut tys) => {
-                    let mut rtys = vec![];
-                    for ty in tys {
-                        if let &mut Builder(ref mut b, _) = ty {
-                            let rty = b.result_type();
-                            rtys.push(rty);
-                        }
-                    }
-                    changed |= try!(push_type(&mut expr.ty, &Struct(rtys), "Res"));
                 }
                 Unknown => (),
                 _ => return weld_err!("Internal error: Result called on non-builder"),


### PR DESCRIPTION
* Fixes issue in #161 and update `langauge.md` with correct syntax.
* Addresses issue in #162 by disallowing `Result` on structs; call `Result` on each element of the struct instead (see updated `language.md` for example).
* Add C++ examples for how to retrieve and pass composite structures from/to Weld (using code from #163)