### PR TITLE
Add a new config flag for detailed logging

### DIFF
--- a/weld/bin/repl.rs
+++ b/weld/bin/repl.rs
@@ -16,14 +16,7 @@ use std::fmt;
 use std::collections::HashMap;
 
 use weld::*;
-use weld::llvm::LlvmGenerator;
 use weld::parser::*;
-use weld::passes::*;
-use weld::pretty_print::*;
-use weld::type_inference::*;
-use weld::sir::ast_to_sir;
-use weld::util::load_runtime_library;
-use weld::util::MERGER_BC;
 
 enum ReplCommands {
     LoadFile,
@@ -139,8 +132,9 @@ fn main() {
             continue;
         }
 
-        let result = llvm::compile_program(&program.unwrap(),
-            conf::DEFAULT_OPTIMIZATION_PASSES.clone(),
+        let result = llvm::compile_program(
+            &program.unwrap(),
+            &conf::DEFAULT_OPTIMIZATION_PASSES,
             conf::LogLevel::Debug);
         match result {
             Err(e) => println!("Error during compilation:\n{}\n", e),

--- a/weld/bin/repl.rs
+++ b/weld/bin/repl.rs
@@ -111,7 +111,7 @@ fn main() {
 
         let program;
 
-        // Do some basic token parsing here.
+        // Check whether the command is to load a file; if not, treat it as a program to run.
         let mut tokens = trimmed.splitn(2, " ");
         let command = tokens.next().unwrap();
         let arg = tokens.next().unwrap_or("");
@@ -138,80 +138,13 @@ fn main() {
             println!("Error during parsing: {:?}", e);
             continue;
         }
-        let program = program.unwrap();
-        println!("Raw structure:\n{:?}\n", program);
 
-        let expr = macro_processor::process_program(&program);
-        if let Err(ref e) = expr {
-            println!("Error during macro substitution: {}", e);
-            continue;
-        }
-        let mut expr = expr.unwrap();
-        println!("After macro substitution:\n{}\n", print_expr(&expr));
-
-        if let Err(ref e) = transforms::uniquify(&mut expr) {
-            println!("Error during uniquify: {}\n", e);
-            continue;
-        }
-        println!("After uniquify:\n{}\n", print_expr(&expr));
-
-        if let Err(ref e) = infer_types(&mut expr) {
-            println!("Error during type inference: {}\n", e);
-            println!("Partially inferred types:\n{}\n", print_typed_expr(&expr));
-            continue;
-        }
-        println!("After type inference:\n{}\n", print_typed_expr(&expr));
-        println!("Expression type: {}\n", print_type(&expr.ty));
-
-        let mut expr = expr.to_typed().unwrap();
-
-        let passes: Vec<&Pass> = vec![OPTIMIZATION_PASSES.get("inline-apply").unwrap(),
-                                      OPTIMIZATION_PASSES.get("inline-let").unwrap(),
-                                      OPTIMIZATION_PASSES.get("inline-zip").unwrap(),
-                                      OPTIMIZATION_PASSES.get("loop-fusion").unwrap()];
-
-        for i in 0..passes.len() {
-            println!("Applying pass {}", passes[i].pass_name());
-            passes[i].transform(&mut expr).unwrap();
-            println!("After {} pass:\n{}\n",
-                     passes[i].pass_name(),
-                     print_expr(&expr));
-        }
-
-        if let Err(ref e) = transforms::uniquify(&mut expr) {
-            println!("Error during uniquify: {}\n", e);
-            continue;
-        }
-
-        println!("final program : {}", print_typed_expr(&expr));
-        println!("final program raw: {:?}", expr);
-
-        let sir_result = ast_to_sir(&expr);
-        match sir_result {
-            Ok(sir) => {
-                println!("SIR representation:\n{}\n", &sir);
-                let mut llvm_gen = LlvmGenerator::new();
-                if let Err(ref e) = llvm_gen.add_function_on_pointers("run", &sir) {
-                    println!("Error during LLVM code gen:\n{}\n", e);
-                } else {
-                    let llvm_code = llvm_gen.result();
-                    println!("LLVM code:\n{}\n", llvm_code);
-
-                    if let Err(e) = load_runtime_library() {
-                        println!("Couldn't load runtime: {}", e);
-                        continue;
-                    }
-
-                    if let Err(ref e) = easy_ll::compile_module(&llvm_code, Some(MERGER_BC)) {
-                        println!("Error during LLVM compilation:\n{}\n", e);
-                    } else {
-                        println!("LLVM module compiled successfully\n");
-                    }
-                }
-            }
-            Err(ref e) => {
-                println!("Error during SIR code gen:\n{}\n", e);
-            }
+        let result = llvm::compile_program(&program.unwrap(),
+            conf::DEFAULT_OPTIMIZATION_PASSES.clone(),
+            conf::LogLevel::Debug);
+        match result {
+            Err(e) => println!("Error during compilation:\n{}\n", e),
+            Ok(_) => println!("Program compiled successfully to LLVM")
         }
     }
     rl.save_history(&history_file_path).unwrap();

--- a/weld/conf.rs
+++ b/weld/conf.rs
@@ -2,7 +2,12 @@
 
 use std::ffi::CString;
 
-// Keys
+use super::WeldConf;
+use super::error::WeldResult;
+use super::passes::OPTIMIZATION_PASSES;
+use super::passes::Pass;
+
+// Keys used in textual representation of conf
 pub const MEMORY_LIMIT_KEY: &'static str = "weld.memory.limit";
 pub const THREADS_KEY: &'static str = "weld.threads";
 pub const LOG_LEVEL_KEY: &'static str = "weld.log.level";
@@ -15,70 +20,111 @@ pub enum LogLevel {
     None, Debug
 }
 
-// Defaults
+// Default values of each key
 pub const DEFAULT_MEMORY_LIMIT: i64 = 1000000000;
 pub const DEFAULT_THREADS: i64 = 1;
 pub const DEFAULT_LOG_LEVEL: LogLevel = LogLevel::None;
 lazy_static! {
-    pub static ref DEFAULT_OPTIMIZATION_PASSES: Vec<String> = {
+    pub static ref DEFAULT_OPTIMIZATION_PASSES: Vec<Pass> = {
         let m = ["inline-apply", "inline-let", "inline-zip", "loop-fusion"];
-        m.to_vec().iter().map(|e| e.to_string()).collect()
+        m.iter().map(|e| (*OPTIMIZATION_PASSES.get(e).unwrap()).clone()).collect()
     };
 }
 
-/// Parses the number of threads. Returns the default if the string cannot be parsed.
-pub fn parse_threads(s: CString) -> i64 {
-    let s = s.into_string().unwrap();
+// A parsed configuration with correctly typed fields.
+pub struct ParsedConf {
+    pub memory_limit: i64,
+    pub threads: i64,
+    pub log_level: LogLevel,
+    pub optimization_passes: Vec<Pass>
+}
+
+/// Parse a configuration from a WeldConf key-value dictiomary.
+pub fn parse(conf: &WeldConf) -> WeldResult<ParsedConf> {
+    let value = get_value(conf, MEMORY_LIMIT_KEY);
+    let memory_limit = value.map(|s| parse_memory_limit(&s))
+                            .unwrap_or(Ok(DEFAULT_MEMORY_LIMIT))?;
+
+    let value = get_value(conf, THREADS_KEY);
+    let threads = value.map(|s| parse_threads(&s))
+                       .unwrap_or(Ok(DEFAULT_THREADS))?;
+
+    let value = get_value(conf, LOG_LEVEL_KEY);
+    let log_level = value.map(|s| parse_log_level(&s))
+                         .unwrap_or(Ok(DEFAULT_LOG_LEVEL))?;
+
+    let value = get_value(conf, OPTIMIZATION_PASSES_KEY);
+    let passes = value.map(|s| parse_passes(&s))
+                      .unwrap_or(Ok(DEFAULT_OPTIMIZATION_PASSES.clone()))?;
+
+    Ok(ParsedConf {
+        memory_limit: memory_limit,
+        threads: threads,
+        log_level: log_level,
+        optimization_passes: passes
+    })
+}
+
+fn get_value(conf: &WeldConf, key: &str) -> Option<String> {
+    let c_key = CString::new(key).unwrap();
+    let c_value = conf.dict.get(&c_key);
+    c_value.map(|cstr| String::from(cstr.to_string_lossy()))
+}
+
+/// Parse a number of threads.
+fn parse_threads(s: &str) -> WeldResult<i64> {
     match s.parse::<i64>() {
-        Ok(v) if v > 0 => v,
-        _ => DEFAULT_THREADS,
+        Ok(v) if v > 0 => Ok(v),
+        _ => weld_err!("Invalid number of threads: {}", s),
     }
 }
-
-/// Parses the memory limit. Returns the default if the string cannot be parsed.
-pub fn parse_memory_limit(s: CString) -> i64 {
-    let s = s.into_string().unwrap();
+/// Parse a memory limit.
+fn parse_memory_limit(s: &str) -> WeldResult<i64> {
     match s.parse::<i64>() {
-        Ok(v) if v > 0 => v,
-        _ => DEFAULT_MEMORY_LIMIT,
+        Ok(v) if v > 0 => Ok(v),
+        _ => weld_err!("Invalid memory limit: {}", s),
     }
 }
 
-/// Parses the optimization passes. Returns the default if the string cannot be parsed.
-pub fn parse_optimization_passes(s: CString) -> Vec<String> {
-    let s = s.into_string().unwrap();
-    match s.as_ref() {
-        "" => DEFAULT_OPTIMIZATION_PASSES.clone(),
-        _ => s.split(",").map(|e| e.to_string()).collect(),
+/// Parse a list of optimization passes.
+fn parse_passes(s: &str) -> WeldResult<Vec<Pass>> {
+    if s.len() == 0 {
+        return Ok(vec![]); // Special case because split() creates an empty piece here
     }
+    let mut result = vec![];
+    for piece in s.split(",") {
+        match OPTIMIZATION_PASSES.get(piece) {
+            Some(pass) => result.push(pass.clone()),
+            None => return weld_err!("Unknown optimization pass: {}", piece)
+        }
+    }
+    Ok(result)
 }
 
-/// Parses a log level. Returns NONE if it is not recognized.
-pub fn parse_log_level(s: CString) -> LogLevel {
-    let s = s.into_string().unwrap().to_lowercase();
-    match s.as_ref() {
-        "debug" => LogLevel::Debug,
-        _ => LogLevel::None,
+/// Parse a log level.
+fn parse_log_level(s: &str) -> WeldResult<LogLevel> {
+    match s {
+        "debug" => Ok(LogLevel::Debug),
+        "none" => Ok(LogLevel::None),
+        _ => weld_err!("Invalid log level: {}", s)
     }
 }
 
 #[test]
 fn conf_parsing() {
-    assert_eq!(parse_threads(CString::new("").unwrap()), DEFAULT_THREADS);
-    assert_eq!(parse_threads(CString::new("-1").unwrap()), DEFAULT_THREADS);
-    assert_eq!(parse_threads(CString::new("1").unwrap()), 1);
-    assert_eq!(parse_threads(CString::new("2").unwrap()), 2);
+    assert_eq!(parse_threads("1").unwrap(), 1);
+    assert_eq!(parse_threads("2").unwrap(), 2);
+    assert!(parse_threads("").is_err());
 
-    assert_eq!(parse_memory_limit(CString::new("").unwrap()), DEFAULT_MEMORY_LIMIT);
-    assert_eq!(parse_memory_limit(CString::new("1000000").unwrap()), 1000000);
+    assert_eq!(parse_memory_limit("1000000").unwrap(), 1000000);
+    assert!(parse_memory_limit("").is_err());
 
-    assert_eq!(parse_optimization_passes(CString::new("").unwrap()),
-        DEFAULT_OPTIMIZATION_PASSES.clone());
-    assert_eq!(parse_optimization_passes(CString::new("loop-fusion").unwrap()),
-        vec![String::from("loop-fusion")]);
+    assert_eq!(parse_passes("loop-fusion,inline-let").unwrap().len(), 2);
+    assert_eq!(parse_passes("loop-fusion").unwrap().len(), 1);
+    assert_eq!(parse_passes("").unwrap().len(), 0);
+    assert!(parse_passes("non-existent-pass").is_err());
 
-    assert_eq!(parse_log_level(CString::new("debug").unwrap()), LogLevel::Debug);
-    assert_eq!(parse_log_level(CString::new("DEBUG").unwrap()), LogLevel::Debug);
-    assert_eq!(parse_log_level(CString::new("none").unwrap()), LogLevel::None);
-    assert_eq!(parse_log_level(CString::new("").unwrap()), LogLevel::None);
+    assert_eq!(parse_log_level("debug").unwrap(), LogLevel::Debug);
+    assert_eq!(parse_log_level("none").unwrap(), LogLevel::None);
+    assert!(parse_log_level("").is_err());
 }

--- a/weld/conf.rs
+++ b/weld/conf.rs
@@ -5,11 +5,20 @@ use std::ffi::CString;
 // Keys
 pub const MEMORY_LIMIT_KEY: &'static str = "weld.memory.limit";
 pub const THREADS_KEY: &'static str = "weld.threads";
+pub const LOG_LEVEL_KEY: &'static str = "weld.log.level";
 pub const OPTIMIZATION_PASSES_KEY: &'static str = "weld.optimization.passes";
+
+/// Available logging levels; these should be listed in order of verbosity
+/// because code will compare them.
+#[derive(PartialEq,Eq,Clone,PartialOrd,Debug)]
+pub enum LogLevel {
+    None, Debug
+}
 
 // Defaults
 pub const DEFAULT_MEMORY_LIMIT: i64 = 1000000000;
 pub const DEFAULT_THREADS: i64 = 1;
+pub const DEFAULT_LOG_LEVEL: LogLevel = LogLevel::None;
 lazy_static! {
     pub static ref DEFAULT_OPTIMIZATION_PASSES: Vec<String> = {
         let m = ["inline-apply", "inline-let", "inline-zip", "loop-fusion"];
@@ -21,8 +30,8 @@ lazy_static! {
 pub fn parse_threads(s: CString) -> i64 {
     let s = s.into_string().unwrap();
     match s.parse::<i64>() {
-        Ok(v) => v,
-        Err(_) => DEFAULT_THREADS,
+        Ok(v) if v > 0 => v,
+        _ => DEFAULT_THREADS,
     }
 }
 
@@ -30,8 +39,8 @@ pub fn parse_threads(s: CString) -> i64 {
 pub fn parse_memory_limit(s: CString) -> i64 {
     let s = s.into_string().unwrap();
     match s.parse::<i64>() {
-        Ok(v) => v,
-        Err(_) => DEFAULT_MEMORY_LIMIT,
+        Ok(v) if v > 0 => v,
+        _ => DEFAULT_MEMORY_LIMIT,
     }
 }
 
@@ -42,4 +51,34 @@ pub fn parse_optimization_passes(s: CString) -> Vec<String> {
         "" => DEFAULT_OPTIMIZATION_PASSES.clone(),
         _ => s.split(",").map(|e| e.to_string()).collect(),
     }
+}
+
+/// Parses a log level. Returns NONE if it is not recognized.
+pub fn parse_log_level(s: CString) -> LogLevel {
+    let s = s.into_string().unwrap().to_lowercase();
+    match s.as_ref() {
+        "debug" => LogLevel::Debug,
+        _ => LogLevel::None,
+    }
+}
+
+#[test]
+fn conf_parsing() {
+    assert_eq!(parse_threads(CString::new("").unwrap()), DEFAULT_THREADS);
+    assert_eq!(parse_threads(CString::new("-1").unwrap()), DEFAULT_THREADS);
+    assert_eq!(parse_threads(CString::new("1").unwrap()), 1);
+    assert_eq!(parse_threads(CString::new("2").unwrap()), 2);
+
+    assert_eq!(parse_memory_limit(CString::new("").unwrap()), DEFAULT_MEMORY_LIMIT);
+    assert_eq!(parse_memory_limit(CString::new("1000000").unwrap()), 1000000);
+
+    assert_eq!(parse_optimization_passes(CString::new("").unwrap()),
+        DEFAULT_OPTIMIZATION_PASSES.clone());
+    assert_eq!(parse_optimization_passes(CString::new("loop-fusion").unwrap()),
+        vec![String::from("loop-fusion")]);
+
+    assert_eq!(parse_log_level(CString::new("debug").unwrap()), LogLevel::Debug);
+    assert_eq!(parse_log_level(CString::new("DEBUG").unwrap()), LogLevel::Debug);
+    assert_eq!(parse_log_level(CString::new("none").unwrap()), LogLevel::None);
+    assert_eq!(parse_log_level(CString::new("").unwrap()), LogLevel::None);
 }

--- a/weld/lib.rs
+++ b/weld/lib.rs
@@ -208,7 +208,7 @@ pub unsafe extern "C" fn weld_module_compile(code: *const c_char,
 
     if let Err(e) = util::load_runtime_library() {
         err.errno = WeldRuntimeErrno::RuntimeLibraryError;
-        err.message = CString::new(e.description().to_string()).unwrap();
+        err.message = CString::new(e).unwrap();
         return std::ptr::null_mut();
     }
 

--- a/weld/lib.rs
+++ b/weld/lib.rs
@@ -207,8 +207,9 @@ pub unsafe extern "C" fn weld_module_compile(code: *const c_char,
     let code = code.to_str().unwrap().trim();
 
     if let Err(e) = util::load_runtime_library() {
-        // TODO: should this set err_ptr?
-        println!("{}", e);
+        err.errno = WeldRuntimeErrno::RuntimeLibraryError;
+        err.message = CString::new(e.description().to_string()).unwrap();
+        return std::ptr::null_mut();
     }
 
     let parsed = parser::parse_program(code);

--- a/weld/lib.rs
+++ b/weld/lib.rs
@@ -195,6 +195,10 @@ pub unsafe extern "C" fn weld_module_compile(code: *const c_char,
     assert!(!err_ptr.is_null());
 
     let conf = &*conf;
+    let log_level = conf::parse_log_level(conf.dict
+                                              .get(&CString::new(conf::LOG_LEVEL_KEY).unwrap())
+                                              .unwrap_or(&CString::new("").unwrap())
+                                              .clone());
     let opt_passes =
         conf::parse_optimization_passes(conf.dict
                                             .get(&CString::new(conf::OPTIMIZATION_PASSES_KEY)
@@ -217,7 +221,7 @@ pub unsafe extern "C" fn weld_module_compile(code: *const c_char,
         return std::ptr::null_mut();
     }
 
-    let module = llvm::compile_program(&parsed.unwrap(), opt_passes);
+    let module = llvm::compile_program(&parsed.unwrap(), opt_passes, log_level);
 
     if let Err(ref e) = module {
         err.errno = WeldRuntimeErrno::CompileError;

--- a/weld/lib.rs
+++ b/weld/lib.rs
@@ -193,24 +193,21 @@ pub unsafe extern "C" fn weld_module_compile(code: *const c_char,
                                              -> *mut WeldModule {
     assert!(!code.is_null());
     assert!(!err_ptr.is_null());
+    let mut err = &mut *err_ptr;
 
-    let conf = &*conf;
-    let log_level = conf::parse_log_level(conf.dict
-                                              .get(&CString::new(conf::LOG_LEVEL_KEY).unwrap())
-                                              .unwrap_or(&CString::new("").unwrap())
-                                              .clone());
-    let opt_passes =
-        conf::parse_optimization_passes(conf.dict
-                                            .get(&CString::new(conf::OPTIMIZATION_PASSES_KEY)
-                                                      .unwrap())
-                                            .unwrap_or(&CString::new("").unwrap())
-                                            .clone());
+    let conf = conf::parse(&*conf);
+    if let Err(e) = conf {
+        err.errno = WeldRuntimeErrno::ConfigurationError;
+        err.message = CString::new(e.description().to_string()).unwrap();
+        return std::ptr::null_mut();
+    }
+    let conf = conf.unwrap();
 
     let code = CStr::from_ptr(code);
     let code = code.to_str().unwrap().trim();
-    let mut err = &mut *err_ptr;
 
     if let Err(e) = util::load_runtime_library() {
+        // TODO: should this set err_ptr?
         println!("{}", e);
     }
 
@@ -221,7 +218,8 @@ pub unsafe extern "C" fn weld_module_compile(code: *const c_char,
         return std::ptr::null_mut();
     }
 
-    let module = llvm::compile_program(&parsed.unwrap(), opt_passes, log_level);
+    let module = llvm::compile_program(
+        &parsed.unwrap(), &conf.optimization_passes, conf.log_level);
 
     if let Err(ref e) = module {
         err.errno = WeldRuntimeErrno::CompileError;
@@ -247,20 +245,15 @@ pub unsafe extern "C" fn weld_module_run(module: *mut WeldModule,
 
     let module = &mut *module;
     let arg = &*arg;
-    let conf = &*conf;
     let mut err = &mut *err_ptr;
 
-    let mem_limit = conf::parse_memory_limit(conf.dict
-                                                 .get(&CString::new(conf::MEMORY_LIMIT_KEY)
-                                                           .unwrap())
-                                                 .unwrap_or(&CString::new("").unwrap())
-                                                 .clone());
-
-    let threads = conf::parse_threads(conf.dict
-                                          .get(&CString::new(conf::THREADS_KEY).unwrap())
-                                          .unwrap_or(&CString::new("").unwrap())
-                                          .clone());
-
+    let conf = conf::parse(&*conf);
+    if let Err(e) = conf {
+        err.errno = WeldRuntimeErrno::ConfigurationError;
+        err.message = CString::new(e.description().to_string()).unwrap();
+        return std::ptr::null_mut();
+    }
+    let conf = conf.unwrap();
 
     #[derive(Clone)]
     struct I32Vec {
@@ -270,8 +263,8 @@ pub unsafe extern "C" fn weld_module_run(module: *mut WeldModule,
 
     let input = Box::new(llvm::WeldInputArgs {
                              input: arg.data as i64,
-                             nworkers: threads as i32,
-                             mem_limit: mem_limit as i64,
+                             nworkers: conf.threads as i32,
+                             mem_limit: conf.memory_limit,
                          });
     let ptr = Box::into_raw(input) as i64;
     // result_raw is allocated with ordinary malloc, hence the free below

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -2717,12 +2717,15 @@ pub fn compile_program(program: &Program,
                        log_level: LogLevel)
                        -> WeldResult<easy_ll::CompiledModule> {
     let mut expr = try!(macro_processor::process_program(program));
+    if log_level >= LogLevel::Debug {
+        println!("After macro substitution:\n{}\n", print_expr(&expr));
+    }
+
     let _ = try!(transforms::uniquify(&mut expr));
     try!(type_inference::infer_types(&mut expr));
     let mut expr = try!(expr.to_typed());
-
     if log_level >= LogLevel::Debug {
-        println!("Compiling with optimization passes: {:?}\n", opt_passes);
+        println!("After type inference:\n{}\n", print_expr(&expr));
     }
 
     let mut passes: Vec<&Pass> = vec![];
@@ -2737,7 +2740,7 @@ pub fn compile_program(program: &Program,
     for i in 0..passes.len() {
         try!(passes[i].transform(&mut expr));
         if log_level >= LogLevel::Debug {
-            println!("After pass {}:\n{}", passes[i].pass_name(), print_expr(&expr));
+            println!("After {} pass:\n{}", passes[i].pass_name(), print_expr(&expr));
         }
     }
 

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -2713,7 +2713,7 @@ pub fn generate_runtime_interface_module() -> WeldResult<easy_ll::CompiledModule
 
 /// Generate a compiled LLVM module from a program whose body is a function.
 pub fn compile_program(program: &Program,
-                       opt_passes: Vec<String>,
+                       opt_passes: &Vec<Pass>,
                        log_level: LogLevel)
                        -> WeldResult<easy_ll::CompiledModule> {
     let mut expr = try!(macro_processor::process_program(program));
@@ -2728,19 +2728,10 @@ pub fn compile_program(program: &Program,
         println!("After type inference:\n{}\n", print_expr(&expr));
     }
 
-    let mut passes: Vec<&Pass> = vec![];
-    for opt_pass in &opt_passes {
-        let opt_pass_name: &str = &opt_pass;
-        match OPTIMIZATION_PASSES.get(opt_pass_name) {
-            Some(pass) => passes.push(pass),
-            None => return weld_err!("Invalid optimization pass name"),
-        }
-    }
-
-    for i in 0..passes.len() {
-        try!(passes[i].transform(&mut expr));
+    for pass in opt_passes {
+        try!(pass.transform(&mut expr));
         if log_level >= LogLevel::Debug {
-            println!("After {} pass:\n{}", passes[i].pass_name(), print_expr(&expr));
+            println!("After {} pass:\n{}", pass.pass_name(), print_expr(&expr));
         }
     }
 

--- a/weld/passes.rs
+++ b/weld/passes.rs
@@ -4,10 +4,19 @@ use super::transforms;
 
 use std::collections::HashMap;
 
-
 pub struct Pass {
     transforms: Vec<fn(&mut Expr<Type>)>,
     pass_name: String,
+}
+
+/// Manually implement Clone for Pass because it cannot be #derived due to the fn type inside it.
+impl Clone for Pass {
+    fn clone(&self) -> Pass {
+        Pass {
+            transforms: self.transforms.iter().map(|p| *p).collect::<Vec<_>>(),
+            pass_name: self.pass_name.clone()
+        }
+    }
 }
 
 impl Pass {

--- a/weld_common/src/lib.rs
+++ b/weld_common/src/lib.rs
@@ -7,6 +7,7 @@ use std::fmt;
 pub enum WeldRuntimeErrno {
     Success = 0,
     ConfigurationError,
+    RuntimeLibraryError,
     CompileError,
     ArrayOutOfBounds,
     BadIteratorLength,

--- a/weld_common/src/lib.rs
+++ b/weld_common/src/lib.rs
@@ -6,6 +6,7 @@ use std::fmt;
 #[repr(u64)]
 pub enum WeldRuntimeErrno {
     Success = 0,
+    ConfigurationError,
     CompileError,
     ArrayOutOfBounds,
     BadIteratorLength,


### PR DESCRIPTION
This also updates the REPL to use this flag when compiling instead, preventing lots of replication between llvm::compile_program and the REPL.