### PR TITLE
Add a function to determine the memory usage of a weld_value's run

### DIFF
--- a/python/weld/bindings.py
+++ b/python/weld/bindings.py
@@ -93,6 +93,13 @@ class WeldValue(c_void_p):
         weld_value_data.restype = c_void_p
         return weld_value_data(self.val)
 
+    def memory_usage(self):
+        self._check()
+        weld_value_memory_usage = weld.weld_value_memory_usage
+        weld_value_memory_usage.argtypes = [c_weld_value]
+        weld_value_memory_usage.restype = c_int64
+        return weld_value_memory_usage(self.val)
+
     def free(self):
         self._check()
         weld_value_free = weld.weld_value_free

--- a/weld/lib.rs
+++ b/weld/lib.rs
@@ -180,9 +180,28 @@ pub unsafe extern "C" fn weld_value_free(obj: *mut WeldValue) {
         // TODO(shoumik): Cache this? No need to compile it each time.
         let module = llvm::generate_runtime_interface_module().unwrap();
         let arg = run_id;
-        let _ = module.run(arg);
+        let _ = module.run_named("rt_run_free", arg);
     }
     Box::from_raw(obj);
+}
+
+#[no_mangle]
+/// Gets the memory allocated to a Weld value, which generally includes all memory allocated during
+/// the execution of the module that created it (Weld does not currently free intermediate values
+/// while running a module). Returns -1 if the value is not part of a valid Weld run.
+pub unsafe extern "C" fn weld_value_memory_usage(obj: *mut WeldValue) -> i64 {
+    if obj.is_null() {
+        return -1;
+    }
+    let value = &mut *obj;
+    if let Some(run_id) = value.run_id {
+        // TODO: Cache this? No need to compile it each time.
+        let module = llvm::generate_runtime_interface_module().unwrap();
+        let arg = run_id;
+        return module.run_named("rt_memory_usage", arg).unwrap_or(-1);
+    } else {
+        return -1;
+    }
 }
 
 #[no_mangle]

--- a/weld/lib.rs
+++ b/weld/lib.rs
@@ -189,18 +189,18 @@ pub unsafe extern "C" fn weld_value_free(obj: *mut WeldValue) {
 /// Gets the memory allocated to a Weld value, which generally includes all memory allocated during
 /// the execution of the module that created it (Weld does not currently free intermediate values
 /// while running a module). Returns -1 if the value is not part of a valid Weld run.
-pub unsafe extern "C" fn weld_value_memory_usage(obj: *mut WeldValue) -> i64 {
+pub unsafe extern "C" fn weld_value_memory_usage(obj: *mut WeldValue) -> libc::int64_t {
     if obj.is_null() {
-        return -1;
+        return -1 as libc::int64_t;
     }
     let value = &mut *obj;
     if let Some(run_id) = value.run_id {
         // TODO: Cache this? No need to compile it each time.
         let module = llvm::generate_runtime_interface_module().unwrap();
         let arg = run_id;
-        return module.run_named("rt_memory_usage", arg).unwrap_or(-1);
+        return module.run_named("rt_memory_usage", arg).unwrap_or(-1) as libc::int64_t;
     } else {
-        return -1;
+        return -1 as libc::int64_t;
     }
 }
 

--- a/weld/resources/runtime_interface_module.ll
+++ b/weld/resources/runtime_interface_module.ll
@@ -1,8 +1,21 @@
+; Simple LLVM module containing wrappers for the functions in libweldrt, so that we can call them
+; from weld after the library is dynamically linked into the program through easy_ll.
 
-; Requires linking with libweldrt
+; Declarations of functions in libweldrt.
 declare void @weld_rt_run_free(i64 %run_id);
+declare i64 @weld_rt_memory_usage(i64 %run_id);
 
-define i64 @run(i64 %run_id) {
+; A dummy run function to make easy_ll compile this.
+define i64 @run(i64) {
+    ret i64 0
+}
+
+define i64 @rt_run_free(i64 %run_id) {
     call void @weld_rt_run_free(i64 %run_id)
     ret i64 0
-} 
+}
+
+define i64 @rt_memory_usage(i64 %run_id) {
+    %res = call i64 @weld_rt_memory_usage(i64 %run_id)
+    ret i64 %res
+}

--- a/weld_rt/src/lib.rs
+++ b/weld_rt/src/lib.rs
@@ -269,3 +269,14 @@ pub extern "C" fn weld_rt_set_errno(run_id: libc::int64_t, errno: WeldRuntimeErr
     let entry = guarded.entry(run_id).or_insert(errno);
     *entry = errno;
 }
+
+#[no_mangle]
+/// Returns the current memory allocated to a run ID, or -1 if it is an invalid ID.
+pub extern "C" fn weld_rt_memory_usage(run_id: libc::int64_t) -> i64 {
+    let mut guarded = ALLOCATIONS.lock().unwrap();
+    if let Some(mem_info) = guarded.get(&run_id) {
+        return mem_info.mem_allocated;
+    } else {
+        return -1;
+    }
+}

--- a/weld_rt/src/lib.rs
+++ b/weld_rt/src/lib.rs
@@ -272,11 +272,11 @@ pub extern "C" fn weld_rt_set_errno(run_id: libc::int64_t, errno: WeldRuntimeErr
 
 #[no_mangle]
 /// Returns the current memory allocated to a run ID, or -1 if it is an invalid ID.
-pub extern "C" fn weld_rt_memory_usage(run_id: libc::int64_t) -> i64 {
+pub extern "C" fn weld_rt_memory_usage(run_id: libc::int64_t) -> libc::int64_t {
     let mut guarded = ALLOCATIONS.lock().unwrap();
     if let Some(mem_info) = guarded.get(&run_id) {
-        return mem_info.mem_allocated;
+        return mem_info.mem_allocated as libc::int64_t;
     } else {
-        return -1;
+        return -1 as libc::int64_t;
     }
 }


### PR DESCRIPTION
This can be useful for debugging to understand how much memory some code allocated. One awkward thing is that we may free memory while a run is executing in the future, so this needs to be documented carefully so that users notice if it changes.