### PR TITLE
Clean up organization of llvm.rs

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -156,7 +156,7 @@ fn float_literals() {
 }
 
 fn negation() {
-    let code = "|| -1";
+    let code = "|| -(1)";
     let conf = default_conf();
 
     let ref input_data = 0;
@@ -170,7 +170,7 @@ fn negation() {
 }
 
 fn negation_double() {
-    let code = "|| -1.0";
+    let code = "|| -(1.0)";
     let conf = default_conf();
 
     let ref input_data = 0;

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -1925,16 +1925,16 @@ impl LlvmGenerator {
                 let res_tmp = ctx.var_ids.next();
 
                 ctx.code.add(format!("{} = call {} {}({} {})",
-                                        res_tmp,
-                                        bld_ty_str,
-                                        func_str,
-                                        kv_vec_builder_ty,
-                                        bld_tmp));
+                                      res_tmp,
+                                      bld_ty_str,
+                                      func_str,
+                                      kv_vec_builder_ty,
+                                      bld_tmp));
                 ctx.code.add(format!("store {} {}, {}* {}",
-                                        res_ty_str,
-                                        res_tmp,
-                                        res_ty_str,
-                                        llvm_symbol(output)));
+                                     res_ty_str,
+                                     res_tmp,
+                                     res_ty_str,
+                                     llvm_symbol(output)));
             }
 
             VecMerger(ref t, ref op) => {
@@ -1982,8 +1982,7 @@ impl LlvmGenerator {
                 let done_label = label_ids.next();
                 let raw_ptr = ctx.var_ids.next();
 
-                ctx.code
-                    .add(format!(include_str!("resources/vecmerger/vecmerger_result_start.ll"),
+                ctx.code.add(format!(include_str!("resources/vecmerger/vecmerger_result_start.ll"),
                                     nworkers = nworkers,
                                     t0 = t0,
                                     buildPtr = bld_ptr,


### PR DESCRIPTION
This keeps the code doing the same thing, except in one area: I noticed that floating point literals were only printed to 3 decimal places in the LLVM code, which is bad, so I increased that. In the long term we should use LLVM's hex notation there or use its API to generate code instead of using strings.