### PR TITLE
Fixes issue with Vectorization and work splitting

### DIFF
--- a/examples/cpp/vector_benchmark/vector_benchmark.cpp
+++ b/examples/cpp/vector_benchmark/vector_benchmark.cpp
@@ -17,7 +17,8 @@ struct args {
     int32_t a;
 };
 
-const char *program = "|x:vec[i32], a:i32| result(for(x, merger[i32,+], |b,i,e| merge(b, e+a)))";
+const char *program = "|x:vec[i32], a:i32| result(for(x, merger[i32,+],\
+                       |b,i,e| merge(b, e)))";
 
 int main() {
     // Compile Weld module.
@@ -33,12 +34,12 @@ int main() {
     }
 
     weld_vector v;
-    const uint64_t length = 5;
-    int32_t *data = (int32_t *)malloc(sizeof(int32_t) * length * 2);
-    for (int i = 0; i < length*2; i++) {
+    const uint64_t length = 4093*10000 + 33;
+    int32_t *data = (int32_t *)malloc(sizeof(int32_t) * (length + 100));
+    for (int i = 0; i < length + 100; i++) {
         data[i] = 1;
         if (i >= length) {
-            data[i] = 1;
+            data[i] = 0;
         }
     }
 
@@ -61,6 +62,7 @@ int main() {
     }
     void *result_data = weld_value_data(result);
     printf("Answer: %d\n", *(int32_t *)result_data);
+    printf("Expect: %llu\n", length);
 
     free(data);
 

--- a/weld_rt/cpp/parlib.cpp
+++ b/weld_rt/cpp/parlib.cpp
@@ -16,7 +16,6 @@
 // should be sufficiently high enough to protect against all the common vector lengths (4, 8,
 // 16, 32, 64 - 64 is used for 8-bit values in AVX-512).
 #define MAX_SIMD_SIZE   64
-#define MIN_INNERMOST_GRAIN_SIZE   (MAX_SIMD_SIZE * 4)
 
 typedef int pthread_spinlock_t;
 
@@ -283,7 +282,7 @@ static inline void split_task(work_t *task) {
 
     // The inner loop may be subject to vectorization, so modify the bounds to make the task size
     // divisible by the SIMD vector size.
-    if (task->grain_size > MIN_INNERMOST_GRAIN_SIZE) {
+    if (task->grain_size > 2 * MAX_SIMD_SIZE) {
         mid = (mid / MAX_SIMD_SIZE) * MAX_SIMD_SIZE;
     }
 


### PR DESCRIPTION
This fixes an issue with vectorization and work splitting. Before, work splitting could cause task sizes that were not multiples of the SIMD vector size; this would cause vectorization to miss elements/compute incorrect results, since it assumes all fringing occurs at the _end_ of the loop.

This fixes the issue by making sure the split-point for tasks is always a divisible of the SIMD size (currently, the maximum assumed SIMD size is 64 bytes). An additional check has been added to `parlib.cpp` when splitting: if the `grain_size` is greater than some threshold, the above adjustment is made to the split point for tasks. Otherwise, the adjustment is not made because the task is assumed to be a split for an outer loop.

@jjthomas can you make sure these changes are safe?