### PR TITLE
Fix LLVM symbol gen issue in merger

### DIFF
--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -1773,7 +1773,7 @@ impl LlvmGenerator {
                 // Type of element to merge.
                 let elem_ty_str = self.llvm_type(t)?.to_string();
 
-                let output_str = format!("%{}", output);
+                let output_str = llvm_symbol(output);
 
                 // Vector type.
                 let ref vec_type = if let Scalar(ref k) = **t {


### PR DESCRIPTION
The old code didn't work with symbol IDs other than 1 because it kept a `#` character.