### PR TITLE
[WIP] Faster hashing and equality functions

### DIFF
--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -787,7 +787,7 @@ impl LlvmGenerator {
 
                     // Generate hash function for the struct.
                     self.prelude_code
-                        .add_line(format!("define i64 {}.hash({} %value) {{", name.replace("%", "@"), name));
+                        .add_line(format!("define i32 {}.hash({} %value) {{", name.replace("%", "@"), name));
                     let mut res = "0".to_string();
                     for i in 0..field_types.len() {
                         // TODO(shoumik): hack to prevent incorrect code gen for vectors.
@@ -800,16 +800,16 @@ impl LlvmGenerator {
                         let field_ty_str = &field_types[i];
                         let field_prefix_str = format!("@{}", field_ty_str.replace("%", ""));
                         self.prelude_code.add_line(format!("{} = extractvalue {} %value, {}", field, name, i));
-                        self.prelude_code.add_line(format!("{} = call i64 {}.hash({} {})",
+                        self.prelude_code.add_line(format!("{} = call i32 {}.hash({} {})",
                                                            hash,
                                                            field_prefix_str,
                                                            field_ty_str,
                                                            field));
                         self.prelude_code
-                            .add_line(format!("{} = call i64 @hash_combine(i64 {}, i64 {})", new_res, res, hash));
+                            .add_line(format!("{} = call i32 @hash_combine(i32 {}, i32 {})", new_res, res, hash));
                         res = new_res;
                     }
-                    self.prelude_code.add_line(format!("ret i64 {}", res));
+                    self.prelude_code.add_line(format!("ret i32 {}", res));
                     self.prelude_code.add_line(format!("}}"));
                     self.prelude_code.add_line(format!(""));
 

--- a/weld/resources/dictionary.ll
+++ b/weld/resources/dictionary.ll
@@ -103,8 +103,8 @@ entry:
   %entries = extractvalue %$NAME %dict, 0
   %capacity = extractvalue %$NAME %dict, 2
   %mask = sub i64 %capacity, 1
-  %hash = call i64 $KEY_PREFIX.hash($KEY %key)
-  ; TODO: mix hash further here?
+  %raw_hash = call i64 $KEY_PREFIX.hash($KEY %key)
+  %hash = call i64 @hash_finalize(i64 %raw_hash)
   br label %body
 
 body:

--- a/weld/resources/dictionary.ll
+++ b/weld/resources/dictionary.ll
@@ -68,6 +68,11 @@ define i32 @$NAME.cmp(%$NAME %dict1, %$NAME %dict2) {
   ret i32 -1
 }
 
+; Dummy equality function (should call cmp when that is fully implemented)
+define i1 @$NAME.eq(%$NAME %dict1, %$NAME %dict2) {
+  ret i1 0
+}
+
 ; Get the size of a dictionary.
 define i64 @$NAME.size(%$NAME %dict) {
   %size = extractvalue %$NAME %dict, 1
@@ -120,8 +125,7 @@ body:
 body2:
   %keyPtr = getelementptr %$NAME.entry, %$NAME.entry* %ptr, i64 0, i32 1
   %elemKey = load $KEY, $KEY* %keyPtr
-  %cmp = call i32 $KEY_PREFIX.cmp($KEY %key, $KEY %elemKey)
-  %eq = icmp eq i32 %cmp, 0
+  %eq = call i1 $KEY_PREFIX.eq($KEY %key, $KEY %elemKey)
   %h2 = add i64 %h, 1
   br i1 %eq, label %done, label %body
 

--- a/weld/resources/dictionary.ll
+++ b/weld/resources/dictionary.ll
@@ -58,8 +58,8 @@ define %$NAME @$NAME.clone(%$NAME %dict) {
 
 ; Dummy hash function; this is needed for structs that use these dictionaries as fields,
 ; but it doesn't yet work! (Or technically it does, but is a very poor function.)
-define i64 @$NAME.hash(%$NAME %dict) {
-  ret i64 0
+define i32 @$NAME.hash(%$NAME %dict) {
+  ret i32 0
 }
 
 ; Dummy comparison function; this is needed for structs that use these dictionaries as fields,
@@ -103,8 +103,9 @@ entry:
   %entries = extractvalue %$NAME %dict, 0
   %capacity = extractvalue %$NAME %dict, 2
   %mask = sub i64 %capacity, 1
-  %raw_hash = call i64 $KEY_PREFIX.hash($KEY %key)
-  %hash = call i64 @hash_finalize(i64 %raw_hash)
+  %raw_hash = call i32 $KEY_PREFIX.hash($KEY %key)
+  %finalized_hash = call i32 @hash_finalize(i32 %raw_hash)
+  %hash = zext i32 %raw_hash to i64
   br label %body
 
 body:

--- a/weld/resources/dictmerger.ll
+++ b/weld/resources/dictmerger.ll
@@ -153,8 +153,8 @@ endLabel:
 }
 
 ; Dummy hash function; this is needed for structs that use these dictmergers as fields.
-define i64 @$NAME.bld.hash(%$NAME.bld %bld) {
-  ret i64 0
+define i32 @$NAME.bld.hash(%$NAME.bld %bld) {
+  ret i32 0
 }
 
 ; Dummy comparison function; this is needed for structs that use these dictmergers as fields.

--- a/weld/resources/dictmerger.ll
+++ b/weld/resources/dictmerger.ll
@@ -161,3 +161,8 @@ define i32 @$NAME.bld.hash(%$NAME.bld %bld) {
 define i32 @$NAME.bld.cmp(%$NAME.bld %bld1, %$NAME.bld %bld2) {
   ret i32 -1
 }
+
+; Dummy equality function
+define i1 @$NAME.bld.eq(%$NAME.bld %bld1, %$NAME.bld %bld2) {
+  ret i1 0
+}

--- a/weld/resources/groupbuilder.ll
+++ b/weld/resources/groupbuilder.ll
@@ -48,8 +48,8 @@ innerLoop:
 innerLoop2:
   %keyPtr2 = getelementptr %$KV_STRUCT, %$KV_STRUCT* %elements, i64 %endPos2, i32 0
   %key2 = load $KEY, $KEY* %keyPtr2
-  %cmp = call i32 $KEY_PREFIX.cmp($KEY %key, $KEY %key2)
-  %ne = icmp ne i32 %cmp, 0
+  %eq = call i1 $KEY_PREFIX.eq($KEY %key, $KEY %key2)
+  %ne = icmp ne i1 %eq, 1
   %endPos3 = add i64 %endPos2, 1
   br i1 %ne, label %innerLoopDone, label %innerLoop
 

--- a/weld/resources/merger/merger.ll
+++ b/weld/resources/merger/merger.ll
@@ -46,7 +46,7 @@ define <$VECSIZE x $ELEM>* @$NAME.bld.vectorMergePtr(%$NAME.bld %bldPtr) {
   ret <$VECSIZE x $ELEM>* %bldVectorPtr
 }
 
-; Clear the vector by assigning each vector element to a user defined identity value. 
+; Clear the vector by assigning each vector element to a user defined identity value.
 define void @$NAME.bld.clearVector(%$NAME.bld %bldPtr, $ELEM %identity) {
     %vectorPtr = call <$VECSIZE x $ELEM>* @$NAME.bld.vectorMergePtr(%$NAME.bld %bldPtr)
     %vector = load <$VECSIZE x $ELEM>, <$VECSIZE x $ELEM>* %vectorPtr
@@ -56,20 +56,20 @@ entry:
   br i1 %cond, label %body, label %done
 body:
   %i = phi i32 [ 0, %entry ], [ %i2, %body ]
-  %vector2 = phi <$VECSIZE x $ELEM> [ %vector, %entry], [ %vector3, %body ] 
+  %vector2 = phi <$VECSIZE x $ELEM> [ %vector, %entry], [ %vector3, %body ]
   %vector3 = insertelement <$VECSIZE x $ELEM> %vector2, $ELEM %identity, i32 %i
   %i2 = add i32 %i, 1
   %cond2 = icmp ult i32 %i2, $VECSIZE
   br i1 %cond2, label %body, label %done
 done:
-  %vector4 = phi <$VECSIZE x $ELEM> [ %vector, %entry ], [ %vector3, %body ] 
+  %vector4 = phi <$VECSIZE x $ELEM> [ %vector, %entry ], [ %vector3, %body ]
   store <$VECSIZE x $ELEM> %vector4, <$VECSIZE x $ELEM>* %vectorPtr
   ret void
 }
 
 ; Dummy hash function; this is needed for structs that use these mergers as fields.
-define i64 @$NAME.bld.hash(%$NAME.bld %bld) {
-  ret i64 0
+define i32 @$NAME.bld.hash(%$NAME.bld %bld) {
+  ret i32 0
 }
 
 ; Dummy comparison function; this is needed for structs that use these mergers as fields.

--- a/weld/resources/merger/merger.ll
+++ b/weld/resources/merger/merger.ll
@@ -76,3 +76,8 @@ define i32 @$NAME.bld.hash(%$NAME.bld %bld) {
 define i32 @$NAME.bld.cmp(%$NAME.bld %bld1, %$NAME.bld %bld2) {
   ret i32 -1
 }
+
+; Dummy equality function; this is needed for structs that use these mergers as fields.
+define i1 @$NAME.bld.eq(%$NAME.bld %bld1, %$NAME.bld %bld2) {
+  ret i1 0
+}

--- a/weld/resources/prelude.ll
+++ b/weld/resources/prelude.ll
@@ -83,16 +83,27 @@ define i64 @run_memory_usage(i64 %run_id) {
 
 ; Hash functions
 
-; Same as Boost's hash_combine; obtained by compiling that with clang
-define i64 @hash_combine(i64 %seed, i64 %value) {
-  ; return seed ^ (value + 0x9e3779b9 + (seed << 6) + (seed >> 2));
-  %1 = add i64 %value, 2654435769   ; TODO: should this be 64-bit?
-  %2 = shl i64 %seed, 6
-  %3 = add i64 %1, %2
-  %4 = lshr i64 %seed, 2
-  %5 = add i64 %3, %4
-  %6 = xor i64 %5, %seed
-  ret i64 %6
+; Combines two hash values using the method in Effective Java
+define i64 @hash_combine(i64 %start, i64 %value) alwaysinline {
+  ; return 31 * start + value
+  %1 = mul i64 %start, 31
+  %2 = add i64 %1, %value
+  ret i64 %2
+}
+
+; Mixes the bits in a hash code, similar to Java's HashMap
+define i64 @hash_finalize(i64 %hash) {
+  ; h ^= (h >>> 20) ^ (h >>> 12);
+  ; return h ^ (h >>> 7) ^ (h >>> 4);
+  %1 = lshr i64 %hash, 20
+  %2 = lshr i64 %hash, 12
+  %3 = xor i64 %hash, %1
+  %h2 = xor i64 %3, %2
+  %4 = lshr i64 %h2, 7
+  %5 = lshr i64 %h2, 4
+  %6 = xor i64 %h2, %4
+  %res = xor i64 %6, %5
+  ret i64 %res
 }
 
 define i64 @i64.hash(i64 %arg) {

--- a/weld/resources/prelude.ll
+++ b/weld/resources/prelude.ll
@@ -84,56 +84,59 @@ define i64 @run_memory_usage(i64 %run_id) {
 ; Hash functions
 
 ; Combines two hash values using the method in Effective Java
-define i64 @hash_combine(i64 %start, i64 %value) alwaysinline {
+define i32 @hash_combine(i32 %start, i32 %value) alwaysinline {
   ; return 31 * start + value
-  %1 = mul i64 %start, 31
-  %2 = add i64 %1, %value
-  ret i64 %2
+  %1 = mul i32 %start, 31
+  %2 = add i32 %1, %value
+  ret i32 %2
 }
 
 ; Mixes the bits in a hash code, similar to Java's HashMap
-define i64 @hash_finalize(i64 %hash) {
+define i32 @hash_finalize(i32 %hash) {
   ; h ^= (h >>> 20) ^ (h >>> 12);
   ; return h ^ (h >>> 7) ^ (h >>> 4);
-  %1 = lshr i64 %hash, 20
-  %2 = lshr i64 %hash, 12
-  %3 = xor i64 %hash, %1
-  %h2 = xor i64 %3, %2
-  %4 = lshr i64 %h2, 7
-  %5 = lshr i64 %h2, 4
-  %6 = xor i64 %h2, %4
-  %res = xor i64 %6, %5
-  ret i64 %res
+  %1 = lshr i32 %hash, 20
+  %2 = lshr i32 %hash, 12
+  %3 = xor i32 %hash, %1
+  %h2 = xor i32 %3, %2
+  %4 = lshr i32 %h2, 7
+  %5 = lshr i32 %h2, 4
+  %6 = xor i32 %h2, %4
+  %res = xor i32 %6, %5
+  ret i32 %res
 }
 
-define i64 @i64.hash(i64 %arg) {
-  ret i64 %arg
+define i32 @i64.hash(i64 %arg) {
+  ; return (i32) ((arg >>> 32) ^ arg)
+  %1 = lshr i64 %arg, 32
+  %2 = xor i64 %arg, %1
+  %3 = trunc i64 %2 to i32
+  ret i32 %3
 }
 
-define i64 @i32.hash(i32 %arg) {
-  %1 = zext i32 %arg to i64
-  ret i64 %1
+define i32 @i32.hash(i32 %arg) {
+  ret i32 %arg
 }
 
-define i64 @i8.hash(i8 %arg) {
-  %1 = zext i8 %arg to i64
-  ret i64 %1
+define i32 @i8.hash(i8 %arg) {
+  %1 = zext i8 %arg to i32
+  ret i32 %1
 }
 
-define i64 @i1.hash(i1 %arg) {
-  %1 = zext i1 %arg to i64
-  ret i64 %1
+define i32 @i1.hash(i1 %arg) {
+  %1 = zext i1 %arg to i32
+  ret i32 %1
 }
 
-define i64 @float.hash(float %arg) {
+define i32 @float.hash(float %arg) {
   %1 = bitcast float %arg to i32
-  %2 = zext i32 %1 to i64
-  ret i64 %2
+  ret i32 %1
 }
 
-define i64 @double.hash(double %arg) {
+define i32 @double.hash(double %arg) {
   %1 = bitcast double %arg to i64
-  ret i64 %1
+  %2 = call i32 @i64.hash(i64 %1)
+  ret i32 %2
 }
 
 ; Comparison functions

--- a/weld/resources/prelude.ll
+++ b/weld/resources/prelude.ll
@@ -205,3 +205,35 @@ ne:
   %3 = select i1 %2, i32 -1, i32 1
   ret i32 %3
 }
+
+; Equality functions
+
+define i1 @i64.eq(i64 %a, i64 %b) {
+  %1 = icmp eq i64 %a, %b
+  ret i1 %1
+}
+
+define i1 @i32.eq(i32 %a, i32 %b) {
+  %1 = icmp eq i32 %a, %b
+  ret i1 %1
+}
+
+define i1 @i8.eq(i8 %a, i8 %b) {
+  %1 = icmp eq i8 %a, %b
+  ret i1 %1
+}
+
+define i1 @i1.eq(i1 %a, i1 %b) {
+  %1 = icmp eq i1 %a, %b
+  ret i1 %1
+}
+
+define i1 @float.eq(float %a, float %b) {
+  %1 = fcmp oeq float %a, %b
+  ret i1 %1
+}
+
+define i1 @double.eq(double %a, double %b) {
+  %1 = fcmp oeq double %a, %b
+  ret i1 %1
+}

--- a/weld/resources/vector.ll
+++ b/weld/resources/vector.ll
@@ -295,3 +295,20 @@ define i32 @$NAME.bld.cmp(%$NAME.bld %bld1, %$NAME.bld %bld2) {
 define i32 @$NAME.vm.bld.cmp(%$NAME.vm.bld %bld1, %$NAME.vm.bld %bld2) {
   ret i32 -1
 }
+
+; Compare two vectors for equality.
+define i1 @$NAME.eq(%$NAME %a, %$NAME %b) {
+  %cmp = call i32 @$NAME.cmp(%$NAME %a, %$NAME %b)
+  %res = icmp eq i32 %cmp, 0
+  ret i1 %res
+}
+
+; Dummy comparison function for builders.
+define i1 @$NAME.bld.eq(%$NAME.bld %a, %$NAME.bld %b) {
+  ret i1 0
+}
+
+; Dummy comparison function for builders.
+define i1 @$NAME.vm.bld.eq(%$NAME.vm.bld %a, %$NAME.vm.bld %b) {
+  ret i1 0
+}

--- a/weld/resources/vector.ll
+++ b/weld/resources/vector.ll
@@ -218,7 +218,7 @@ define $ELEM* @$NAME.bld.at(%$NAME.bld %bldPtr, i64 %index, i32 %myId) {
 
 ; Compute the hash code of a vector.
 ; TODO: We should hash more bytes at a time if elements are non-pointer types.
-define i64 @$NAME.hash(%$NAME %vec) {
+define i32 @$NAME.hash(%$NAME %vec) {
 entry:
   %elements = extractvalue %$NAME %vec, 0
   %size = extractvalue %$NAME %vec, 1
@@ -227,28 +227,28 @@ entry:
 
 body:
   %i = phi i64 [ 0, %entry ], [ %i2, %body ]
-  %prevHash = phi i64 [ 0, %entry ], [ %newHash, %body ]
+  %prevHash = phi i32 [ 0, %entry ], [ %newHash, %body ]
   %ptr = getelementptr $ELEM, $ELEM* %elements, i64 %i
   %elem = load $ELEM, $ELEM* %ptr
-  %elemHash = call i64 $ELEM_PREFIX.hash($ELEM %elem)
-  %newHash = call i64 @hash_combine(i64 %prevHash, i64 %elemHash)
+  %elemHash = call i32 $ELEM_PREFIX.hash($ELEM %elem)
+  %newHash = call i32 @hash_combine(i32 %prevHash, i32 %elemHash)
   %i2 = add i64 %i, 1
   %cond2 = icmp ult i64 %i2, %size
   br i1 %cond2, label %body, label %done
 
 done:
-  %res = phi i64 [ 0, %entry ], [ %newHash, %body ]
-  ret i64 %res
+  %res = phi i32 [ 0, %entry ], [ %newHash, %body ]
+  ret i32 %res
 }
 
 ; Dummy hash function; this is needed for structs that use these vecbuilders as fields.
-define i64 @$NAME.bld.hash(%$NAME.bld %bld) {
-  ret i64 0
+define i32 @$NAME.bld.hash(%$NAME.bld %bld) {
+  ret i32 0
 }
 
 ; Dummy hash function; this is needed for structs that use these vecbuilders as fields.
-define i64 @$NAME.vm.bld.hash(%$NAME.vm.bld %bld) {
-  ret i64 0
+define i32 @$NAME.vm.bld.hash(%$NAME.vm.bld %bld) {
+  ret i32 0
 }
 
 ; Compare two vectors lexicographically.


### PR DESCRIPTION
This makes a few changes that improve performance in workloads with hashing of multi-field structures:

* Change `hash_combine` method to `(31 * seed) + value`, which is faster than what we had so far and is used by lots of Java classes, etc. I also added a `hash_finalize` step to the dictionary code that mixes the bits within this more.
* Change hash functions to 32 bits instead of 64 -- this made a ~10% difference and there is no reason to have 64 bits here.
* Add an explicit equality function to all types that can be faster than their `cmp` function (by not branching as often as `cmp`).