### PR TITLE
Add a weld_load_library function for loading shared libraries

### DIFF
--- a/c/weld.h
+++ b/c/weld.h
@@ -25,7 +25,8 @@ typedef void* weld_conf_t;
 
 // ************* Values ****************
 
-/** Returns a Weld-readable value with the given input buffer.
+/**
+ * Returns a Weld-readable value with the given input buffer.
  *
  * A Weld value created using this method is owned by the caller.
  * The caller must ensure that the data buffer remains a valid pointer
@@ -38,7 +39,8 @@ typedef void* weld_conf_t;
 extern "C" weld_value_t
 weld_value_new(void *data);
 
-/** Returns 1 if the value's data is owned by the Weld runtime, or
+/**
+ * Returns 1 if the value's data is owned by the Weld runtime, or
  * 0 otherwise.
  *
  * A value owned by the Weld runtime is freed using the `weld_value_free`
@@ -52,7 +54,8 @@ weld_value_new(void *data);
 extern "C" int
 weld_value_run(weld_value_t obj);
 
-/** Returns this value's data buffer.
+/**
+ * Returns this value's data buffer.
  *
  * @param obj the value whose data buffer should be retrieved.
  * @return a void * data buffer. The caller is responsible for knowing
@@ -61,7 +64,8 @@ weld_value_run(weld_value_t obj);
 extern "C" void*
 weld_value_data(weld_value_t obj);
 
-/* Frees a Weld value.
+/**
+ * Frees a Weld value.
  *
  * Each Weld value must be freed using this call. Owned values also
  * free their data buffers; non-owned values require the caller to free
@@ -84,19 +88,21 @@ weld_value_memory_usage(weld_value_t obj);
 
 // ************* Modules ****************
 
-/** Compiles a Weld module.
+/**
+ * Compiles a Weld module.
  *
  * Takes a string and configuration and returns a runnable module.
  *
- * @param code a Weld program to compile
+ * @param code a Weld program to compile.
  * @param conf a configuration for the module.
- * @param err a Weld erro for this compilation.
+ * @param err will hold any error raised during compilation.
  * @return a runnable module.
  */
 extern "C" weld_module_t
 weld_module_compile(const char *code, weld_conf_t, weld_error_t);
 
-/** Runs a module using the given argument.
+/**
+ * Runs a module using the given argument.
  *
  * Multi-argument Weld functions take a Weld value encapsulating
  * a single struct as an argument. The field at index i in the struct
@@ -105,7 +111,7 @@ weld_module_compile(const char *code, weld_conf_t, weld_error_t);
  * @param module the module to run.
  * @param conf a configuration for this run.
  * @param arg the argument for the module's function.
- * @param err a Weld error for this run.
+ * @param err will hold any error raised during execution.
  * @return an owned Weld value representing the return value. The caller
  * is responsible for knowing what the type of the return value is based on
  * the module she runs.
@@ -113,7 +119,8 @@ weld_module_compile(const char *code, weld_conf_t, weld_error_t);
 extern "C" weld_value_t
 weld_module_run(weld_module_t, weld_conf_t, weld_value_t, weld_error_t);
 
-/** Garbage collects a module.
+/**
+ * Garbage collects a module.
  *
  * @param module the module to garbage collect.
  */
@@ -122,64 +129,83 @@ weld_module_free(weld_module_t);
 
 // ************* Errors ****************
 
-/** Return a new Weld error.
- *
+/**
+ * Return a new Weld error holder.
  */
 extern "C" weld_error_t
 weld_error_new();
 
-/** Returns an error code, or 0 if there was no error.
+/**
+ * Returns an error code, or 0 if there was no error.
  *
  * @param err the error to check
  * @param 0 if the error was a success, or a nonzero error code otherwise.
  */
 extern "C" int
-weld_error_code(weld_error_t);
+weld_error_code(weld_error_t err);
 
-/** Returns an error message for a given error.
+/**
+ * Returns an error message for a given error.
  *
  * @param err the error
  * @return a string error message.
  */
 extern "C" const char *
-weld_error_message(weld_error_t);
+weld_error_message(weld_error_t err);
 
-/** Free a Weld error.
+/**
+ * Free a Weld error.
  *
- * @param err the error
+ * @param err the error to free
  */
 extern "C" void
-weld_error_free(weld_error_t);
+weld_error_free(weld_error_t err);
 
 // ************* Configuration ****************
 
-/** Return a new Weld configuraiton.
- *
+/**
+ * Returns a new Weld configuration.
  */
 extern "C" weld_conf_t
 weld_conf_new();
 
-/** Returns a value for a Weld configuration key.
+/**
+ * Returns a value for a Weld configuration key.
  *
  * @param key the key to look up.
  * @return the string value for the key, or NULL if the key does not exist.
  */
 extern "C" const char*
-weld_conf_get(weld_conf_t, const char *key);
+weld_conf_get(weld_conf_t conf, const char *key);
 
-/** Set a value for a Weld configuration key.
+/**
+ * Set a value for a Weld configuration key.
  *
  * @param key the key
  * @param key the value
  */
 extern "C" void
-weld_conf_set(weld_conf_t, const char *key, const char *value);
+weld_conf_set(weld_conf_t conf, const char *key, const char *value);
 
-/** Free a Weld configuration.
+/**
+ * Free a Weld configuration.
  *
+ * @param conf the configuration to free
  */
 extern "C" weld_conf_t
-weld_conf_free(weld_conf_t);
+weld_conf_free(weld_conf_t conf);
+
+// ************* Other Functions ****************
+
+/**
+ * Loads a dynamically linked library and makes it available to the LLVM compiler and JIT.
+ * This function is safe to call multiple times on the same library file.
+ *
+ * @param filename path of the library to load, including .so extension on Linux
+ * @param err will hold any errors raised during execution
+ */
+extern "C" void
+weld_load_library(const char *filename, weld_error_t err);
 
 #endif
 

--- a/easy_ll/src/lib.rs
+++ b/easy_ll/src/lib.rs
@@ -96,21 +96,11 @@ impl Drop for CompiledModule {
     }
 }
 
-/// Loads a dynamic library by name. It is safe to call this function multiple times. The library
-/// must be on the search path or in one of the build directories for the module.
+/// Loads a dynamic library from a file using LLVMLoadLibraryPermanently. It is safe to call
+/// this function multiple times for the same library.
 pub fn load_library(libname: &str) -> Result<(), LlvmError> {
-    let ext = if cfg!(target_os = "linux") {
-        "so"
-    } else if cfg!(target_os = "macos") {
-        "dylib"
-    } else {
-        return Err(LlvmError::new("Unknown target os"));
-    };
-    let libname = format!("{}.{}", libname, ext);
-
     let c_string = CString::new(libname.clone()).unwrap();
     let c_string_raw = c_string.into_raw() as *const c_char;
-
     if unsafe { LLVMLoadLibraryPermanently(c_string_raw) } == 0 {
         Ok(())
     } else {

--- a/examples/cpp/udfs_from_library/Makefile
+++ b/examples/cpp/udfs_from_library/Makefile
@@ -1,0 +1,26 @@
+CC=clang++
+LDFLAGS=-L../../../target/release/
+LIBS=-lweld
+
+OS = $(shell uname -s)
+ifeq (${OS}, Darwin)
+  LIB_FILE=libudf.dylib
+else ifeq (${OS}, Linux)
+  LIB_FILE=libudf.so
+else
+  $(error Unsupported platform: ${OS})
+endif
+
+.PHONY: all clean
+
+all: run ${LIB_FILE}
+
+run: udfs.cpp
+	${CC} -DUDFLIB="\"${LIB_FILE}\"" ${LDFLAGS} ${LIBS} udfs.cpp -o run
+
+${LIB_FILE}: lib.cpp
+	${CC} -shared -o ${LIB_FILE} lib.cpp
+
+clean:
+	rm -rf run ${LIB_FILE}
+

--- a/examples/cpp/udfs_from_library/README.md
+++ b/examples/cpp/udfs_from_library/README.md
@@ -1,0 +1,3 @@
+Uses the C Weld interface to create a Weld module which adds 5 to a number.
+The C UDF is loaded from a shared library using `weld_load_library`.
+

--- a/examples/cpp/udfs_from_library/lib.cpp
+++ b/examples/cpp/udfs_from_library/lib.cpp
@@ -1,0 +1,10 @@
+// This file will be built as a dynamically loaded library, called
+// libudf.so or libudf.dylib, to show use of weld_load_library in udfs.cpp.
+
+#include <stdint.h>
+#include <stdio.h>
+
+extern "C" void add_five(int64_t *x, int64_t *result) {
+    *result = *x + 5;
+    printf("called add_five: %lld + 5 = %lld\n", *x, *result);
+}

--- a/examples/cpp/udfs_from_library/udfs.cpp
+++ b/examples/cpp/udfs_from_library/udfs.cpp
@@ -1,0 +1,69 @@
+// This program calls a UDF from a shared library loaded using weld_load_library.
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <string.h>
+
+// Include the Weld API.
+#include "../../../c/weld.h"
+
+int main() {
+    // Load our shared library; its name will be passed by make as the macro UDFLIB
+    weld_error_t e = weld_error_new();
+    weld_load_library(UDFLIB, e);
+    if (weld_error_code(e)) {
+        const char *err = weld_error_message(e);
+        printf("Error loading library: %s\n", err);
+        exit(1);
+    }
+
+    // Compile Weld module.
+    weld_conf_t conf = weld_conf_new();
+    weld_module_t m = weld_module_compile("|x:i64| cudf[add_five,i64](x)", conf, e);
+    weld_conf_free(conf);
+
+    if (weld_error_code(e)) {
+        const char *err = weld_error_message(e);
+        printf("Error during compilation: %s\n", err);
+        exit(1);
+    }
+
+    while(true) {
+        char buf[4096];
+        char *c;
+        printf(">>> ");
+        fgets(buf, sizeof(buf), stdin);
+
+        if (strncmp(buf, "quit", sizeof(buf)) == 0) {
+            break;
+        }
+
+        unsigned long x = strtoul(buf, &c, 10);
+        if (c == buf) {
+            printf("nope, try again.\n");
+            continue;
+        }
+
+        int64_t input = (int64_t)x;
+        weld_value_t arg = weld_value_new(&input);
+
+        // Run the module and get the result.
+        weld_conf_t conf = weld_conf_new();
+        weld_value_t result = weld_module_run(m, conf, arg, e);
+        void *result_data = weld_value_data(result);
+        printf("Answer: %lld\n", *(int64_t *)result_data);
+
+        // Free the values.
+        weld_value_free(result);
+        weld_value_free(arg);
+        weld_conf_free(conf);
+    }
+
+    weld_error_free(e);
+    weld_module_free(m);
+    printf("Freeing data and quiting!\n");
+
+    return 0;
+}

--- a/weld/lib.rs
+++ b/weld/lib.rs
@@ -360,5 +360,19 @@ pub unsafe extern "C" fn weld_error_free(err: *mut WeldError) {
     Box::from_raw(err);
 }
 
+#[no_mangle]
+/// Loads a dynamically linked library and makes it available to the LLVM compiler and JIT.
+/// This function is safe to call multiple times on the same library file.
+pub unsafe extern "C" fn weld_load_library(filename: *const c_char, err: *mut WeldError) {
+    assert!(!err.is_null());
+    let mut err = &mut *err;
+    let filename = CStr::from_ptr(filename);
+    let filename = filename.to_str().unwrap();
+    if let Err(e) = easy_ll::load_library(filename) {
+        err.errno = WeldRuntimeErrno::LoadLibraryError;
+        err.message = CString::new(e.description()).unwrap();
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/weld_common/src/lib.rs
+++ b/weld_common/src/lib.rs
@@ -7,7 +7,7 @@ use std::fmt;
 pub enum WeldRuntimeErrno {
     Success = 0, // explicit values for Success and OutOfMemory required due to use by weld_rt C++ code
     ConfigurationError,
-    RuntimeLibraryError,
+    LoadLibraryError,
     CompileError,
     ArrayOutOfBounds,
     BadIteratorLength,


### PR DESCRIPTION
This is useful when loading C UDFs in Java / Python, where they are not already linked into the program.