### PR TITLE
Removing stdlib=libstdc++ from Makefile

### DIFF
--- a/weld_rt/cpp/Makefile
+++ b/weld_rt/cpp/Makefile
@@ -1,7 +1,7 @@
 OS = $(shell uname -s)
 LLVM_VERSION = $(shell llvm-config --version | cut -d . -f 1,2)
 
-CFLAGS = -O3 -std=c++11 -stdlib=libstdc++ -Wall -fno-use-cxa-atexit -fPIC -flto
+CFLAGS = -O3 -std=c++11 -Wall -fno-use-cxa-atexit -fPIC -flto
 ifeq (${OS}, Darwin)
   # OS X
   CLANG ?= clang++-${LLVM_VERSION}


### PR DESCRIPTION
Fixes llvm linking issue (LLVM ERROR: Program used external function
'__ZSt28_Rb_tree...') for my osx, El Capitan, 10.11.6, (libc++ seems
to be the default on it)