### PR TITLE
Switch logging to use the log crate and add it to more places

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ easy_ll = { path = "easy_ll", version = "^0.1.0" }
 weld_common = { path = "weld_common", version = "^0.1.0" }
 libc = "0.2.0"
 csv = "0.15.0"
+log = "*"
+env_logger = "*"
+chrono = "*"
 
 [lib]
 path = "weld/lib.rs"

--- a/c/weld.h
+++ b/c/weld.h
@@ -9,6 +9,18 @@
 
 #include <stdint.h>
 
+// Log level constants -- should match WeldLogLevel.
+
+/** A Weld log level. */
+typedef uint64_t weld_log_level_t;
+
+weld_log_level_t WELD_LOG_LEVEL_OFF = 0;
+weld_log_level_t WELD_LOG_LEVEL_ERROR = 1;
+weld_log_level_t WELD_LOG_LEVEL_WARN = 2;
+weld_log_level_t WELD_LOG_LEVEL_INFO = 3;
+weld_log_level_t WELD_LOG_LEVEL_DEBUG = 4;
+weld_log_level_t WELD_LOG_LEVEL_TRACE = 5;
+
 // Types
 
 /** A type encapsulating a Weld value. */
@@ -206,6 +218,16 @@ weld_conf_free(weld_conf_t conf);
  */
 extern "C" void
 weld_load_library(const char *filename, weld_error_t err);
+
+/**
+ * Enables logging to stderr in Weld with the given level (one of the WELD_LOG_* constants).
+ * This function is ignored if it has already been called once, or if some other code in the
+ * process has initialized logging using Rust's `log` crate.
+ *
+ * @param level the log level to use.
+ */
+extern "C" void
+weld_set_log_level(weld_log_level_t level);
 
 #endif
 

--- a/easy_ll/Cargo.toml
+++ b/easy_ll/Cargo.toml
@@ -7,3 +7,4 @@ build = "build.rs"
 [dependencies]
 llvm-sys = "38.0.1"
 libc = "0.2.0"
+log = "*"

--- a/easy_ll/src/lib.rs
+++ b/easy_ll/src/lib.rs
@@ -3,6 +3,9 @@
 extern crate llvm_sys as llvm;
 extern crate libc;
 
+#[macro_use]
+extern crate log;
+
 use std::error::Error;
 use std::ffi::{CStr, CString, NulError};
 use std::fmt;
@@ -124,6 +127,7 @@ pub fn compile_module(code: &str, bc_file: Option<&[u8]>) -> Result<CompiledModu
         if context.is_null() {
             return Err(LlvmError::new("LLVMContextCreate returned null"));
         }
+        debug!("Done creating LLVM context");
 
         // Create a CompiledModule to wrap the context and our result (will clean it on Drop).
         let mut result = CompiledModule {
@@ -134,22 +138,29 @@ pub fn compile_module(code: &str, bc_file: Option<&[u8]>) -> Result<CompiledModu
 
         // Parse the IR to get an LLVMModuleRef
         let module = parse_module_str(context, code)?;
+        debug!("Done parsing module");
 
         if let Some(s) = bc_file {
             let bc_module = parse_module_bytes(context, s)?;
+            debug!("Done parsing bytecode file");
             llvm::linker::LLVMLinkModules2(module, bc_module);
+            debug!("Done linking bytecode file");
         }
 
         // Validate and optimize the module
         verify_module(module)?;
         check_run_function(module)?;
+        debug!("Done validating module");
         optimize_module(module)?;
+        debug!("Done optimizing module");
 
         // Create an execution engine for the module and find its run function
         let engine = create_exec_engine(module)?;
+        debug!("Done creating execution engine");
 
         result.engine = Some(engine);
         result.run_function = Some(find_function(engine, "run")?);
+        debug!("Done finding run function");
 
         Ok(result)
     }

--- a/easy_ll/src/lib.rs
+++ b/easy_ll/src/lib.rs
@@ -160,7 +160,7 @@ pub fn compile_module(code: &str, bc_file: Option<&[u8]>) -> Result<CompiledModu
 
         result.engine = Some(engine);
         result.run_function = Some(find_function(engine, "run")?);
-        debug!("Done finding run function");
+        debug!("Done generating/finding run function");
 
         Ok(result)
     }

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -12,7 +12,6 @@ use super::ast::LiteralKind::*;
 use super::ast::ScalarKind::*;
 use super::ast::BuilderKind::*;
 use super::code_builder::CodeBuilder;
-use super::conf::LogLevel;
 use super::error::*;
 use super::macro_processor;
 use super::passes::*;
@@ -54,48 +53,39 @@ pub struct WeldOutputArgs {
 }
 
 /// Generate a compiled LLVM module from a program whose body is a function.
-pub fn compile_program(program: &Program,
-                       opt_passes: &Vec<Pass>,
-                       log_level: LogLevel)
-                       -> WeldResult<easy_ll::CompiledModule> {
+pub fn compile_program(program: &Program, opt_passes: &Vec<Pass>) -> WeldResult<easy_ll::CompiledModule> {
     let mut expr = macro_processor::process_program(program)?;
-    if log_level >= LogLevel::Debug {
-        println!("After macro substitution:\n{}\n", print_typed_expr(&expr));
-    }
+    debug!("After macro substitution:\n{}\n", print_typed_expr(&expr));
 
     let _ = transforms::uniquify(&mut expr)?;
     type_inference::infer_types(&mut expr)?;
     let mut expr = expr.to_typed()?;
-    if log_level >= LogLevel::Debug {
-        println!("After type inference:\n{}\n", print_typed_expr(&expr));
-    }
+    debug!("After type inference:\n{}\n", print_typed_expr(&expr));
 
     for pass in opt_passes {
         pass.transform(&mut expr)?;
-        if log_level >= LogLevel::Debug {
-            println!("After {} pass:\n{}", pass.pass_name(), print_typed_expr(&expr));
-        }
+        debug!("After {} pass:\n{}", pass.pass_name(), print_typed_expr(&expr));
     }
 
     transforms::uniquify(&mut expr)?;
-    if log_level >= LogLevel::Debug {
-        println!("After uniquify:\n{}\n", print_typed_expr(&expr));
-    }
+    debug!("After uniquify:\n{}\n", print_typed_expr(&expr));
 
     let sir_prog = sir::ast_to_sir(&expr)?;
-    if log_level >= LogLevel::Debug {
-        println!("SIR program:\n{}\n", &sir_prog);
-    }
+    debug!("SIR program:\n{}\n", &sir_prog);
 
     let mut gen = LlvmGenerator::new();
     gen.add_function_on_pointers("run", &sir_prog)?;
     let llvm_code = gen.result();
-    if log_level >= LogLevel::Debug {
-        println!("LLVM program:\n{}\n", &llvm_code);
-    }
+    debug!("LLVM program:\n{}\n", &llvm_code);
 
+    debug!("Started compiling LLVM");
     let module = try!(easy_ll::compile_module(&llvm_code, Some(LIB_WELD_RT)));
+    debug!("Finished compiling LLVM");
+
+    debug!("Started runtime_init call");
     module.run_named("runtime_init", 0).unwrap();
+    debug!("Finished runtime_init call");
+
     Ok(module)
 }
 

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -80,11 +80,11 @@ pub fn compile_program(program: &Program, opt_passes: &Vec<Pass>) -> WeldResult<
 
     debug!("Started compiling LLVM");
     let module = try!(easy_ll::compile_module(&llvm_code, Some(LIB_WELD_RT)));
-    debug!("Finished compiling LLVM");
+    debug!("Done compiling LLVM");
 
     debug!("Started runtime_init call");
     module.run_named("runtime_init", 0).unwrap();
-    debug!("Finished runtime_init call");
+    debug!("Done runtime_init call");
 
     Ok(module)
 }

--- a/weld_common/src/lib.rs
+++ b/weld_common/src/lib.rs
@@ -24,3 +24,22 @@ impl fmt::Display for WeldRuntimeErrno {
         write!(f, "{:?}", self)
     }
 }
+
+/// A logging level in the Weld API.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd)]
+#[repr(u64)]
+pub enum WeldLogLevel {
+    Off = 0,    // Log level values must match weld.h.
+    Error = 1,
+    Warn = 2,
+    Info = 3,
+    Debug = 4,
+    Trace = 5
+}
+
+impl fmt::Display for WeldLogLevel {
+    /// Just return the enum item's name.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}


### PR DESCRIPTION
This allows us to get fine-grained logging of each step in LLVM, code generation, etc without having to pass our own Log object around. The `log` crate was proposed as a standard facade to logging libraries in Rust (https://doc.rust-lang.org/log/log/index.html).