### PR TITLE
Simplify GetField(MakeStruct(*)) expressions during loop fusion

### DIFF
--- a/weld/passes.rs
+++ b/weld/passes.rs
@@ -58,7 +58,8 @@ lazy_static! {
                  Pass::new(vec![transforms::inline_zips], "inline-zip"));
         m.insert("loop-fusion",
                  Pass::new(vec![transforms::fuse_loops_horizontal,
-                                transforms::fuse_loops_vertical],
+                                transforms::fuse_loops_vertical,
+                                transforms::simplify_get_field],
                  "loop-fusion"));
         m.insert("vectorize",
                  Pass::new(vec![vectorizer::vectorize],


### PR DESCRIPTION
These often appear when processing many columns of data with a zip. We just want to replace `GetField(MakeStruct(e_0, e_1, e_2, ..., e_n), k)` with `e_k`.