### PR TITLE
Support SIMD For Unary Ops

### DIFF
--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -1323,12 +1323,38 @@ impl LlvmGenerator {
         let (child_ll_ty, child_ll_sym) = self.llvm_type_and_name(func, child)?;
         let (output_ll_ty, output_ll_sym) = self.llvm_type_and_name(func, output)?;
         let child_ty = func.symbol_type(child)?;
+
+        let child_tmp = self.gen_load_var(&child_ll_sym, &child_ll_ty, ctx)?;
+
         if let Scalar(ref ty) = *child_ty {
-            let child_tmp = self.gen_load_var(&child_ll_sym, &child_ll_ty, ctx)?;
             let res_tmp = ctx.var_ids.next();
-            let op_name = llvm_unaryop(op_kind, ty)?;
+            let op_name = llvm_scalar_unaryop(op_kind, ty)?;
             ctx.code.add(format!("{} = call {} {} ({} {})", res_tmp, child_ll_ty, op_name, child_ll_ty, child_tmp));
             self.gen_store_var(&res_tmp, &output_ll_sym, &output_ll_ty, ctx);
+        } 
+        else if let Simd(ref ty) = *child_ty {
+            let width = llvm_simd_size(child_ty)?;
+            // If an intrinsic exists for this SIMD op, use it.
+            if let Ok(op_name) = llvm_simd_unaryop(op_kind, ty, width) {
+                let res_tmp = ctx.var_ids.next();
+                ctx.code.add(format!("{} = call {} {} ({} {})", res_tmp, child_ll_ty, op_name, child_ll_ty, child_tmp));
+                self.gen_store_var(&res_tmp, &output_ll_sym, &output_ll_ty, ctx);
+            } else {
+                // Unroll and apply the scalar op, and then pack back into vector
+                let scalar_ll_ty = self.llvm_type(&Scalar(*ty))?;
+                let op_name = llvm_scalar_unaryop(op_kind, ty)?;
+                let mut prev_tmp = "undef".to_string();
+                for i in 0..width {
+                    let elem_tmp = self.gen_simd_extract(child_ty, &child_tmp, i, ctx)?;
+                    let val_tmp = ctx.var_ids.next();
+                    ctx.code.add(format!("{} = call {} {} ({} {})", val_tmp, scalar_ll_ty, op_name, scalar_ll_ty, elem_tmp));
+                    let next = ctx.var_ids.next();
+                    ctx.code.add(format!("{} = insertelement {} {}, {} {}, i32 {}",
+                                         next, child_ll_ty, prev_tmp, scalar_ll_ty, val_tmp, i));
+                    prev_tmp = next;
+                }
+                self.gen_store_var(&prev_tmp, &output_ll_sym, &output_ll_ty, ctx);
+            }
         } else {
             weld_err!("Illegal type {} in {}", print_type(child_ty), op_kind)?;
         }
@@ -2610,8 +2636,8 @@ fn llvm_binop(op_kind: BinOpKind, ty: &Type) -> WeldResult<&'static str> {
     }
 }
 
-/// Return the name of the LLVM instruction for the given operation and type.
-fn llvm_unaryop(op_kind: UnaryOpKind, ty: &ScalarKind) -> WeldResult<&'static str> {
+/// Return the name of the scalar LLVM instruction for the given operation and type.
+fn llvm_scalar_unaryop(op_kind: UnaryOpKind, ty: &ScalarKind) -> WeldResult<&'static str> {
     match (op_kind, ty) {
         (UnaryOpKind::Log, &F32) => Ok("@llvm.log.f32"),
         (UnaryOpKind::Log, &F64) => Ok("@llvm.log.f64"),
@@ -2626,6 +2652,15 @@ fn llvm_unaryop(op_kind: UnaryOpKind, ty: &ScalarKind) -> WeldResult<&'static st
         (UnaryOpKind::Erf, &F64) => Ok("@erf"),
 
         _ => weld_err!("Unsupported unary op: {} on {}", op_kind, ty),
+    }
+}
+
+/// Return the name of the SIMD LLVM instruction for the given operation and type.
+fn llvm_simd_unaryop(op_kind: UnaryOpKind, ty: &ScalarKind, width: u32) -> WeldResult<&'static str> {
+    match (op_kind, ty, width) {
+        (UnaryOpKind::Sqrt, &F32, 4) => Ok("@llvm.sqrt.v4f32"),
+        (UnaryOpKind::Sqrt, &F64, 8) => Ok("@llvm.sqrt.v8f64"),
+        _ => weld_err!("Unsupported unary op: {} on <{} x {}>", op_kind, width, ty),
     }
 }
 

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -2660,6 +2660,19 @@ fn llvm_simd_unaryop(op_kind: UnaryOpKind, ty: &ScalarKind, width: u32) -> WeldR
     match (op_kind, ty, width) {
         (UnaryOpKind::Sqrt, &F32, 4) => Ok("@llvm.sqrt.v4f32"),
         (UnaryOpKind::Sqrt, &F32, 8) => Ok("@llvm.sqrt.v8f32"),
+        (UnaryOpKind::Sqrt, &F64, 2) => Ok("@llvm.sqrt.v2f64"),
+        (UnaryOpKind::Sqrt, &F64, 4) => Ok("@llvm.sqrt.v4f64"),
+
+        (UnaryOpKind::Log, &F32, 4) => Ok("@llvm.log.v4f32"),
+        (UnaryOpKind::Log, &F32, 8) => Ok("@llvm.log.v8f32"),
+        (UnaryOpKind::Log, &F64, 2) => Ok("@llvm.log.v2f64"),
+        (UnaryOpKind::Log, &F64, 4) => Ok("@llvm.log.v4f64"),
+
+        (UnaryOpKind::Exp, &F32, 4) => Ok("@llvm.exp.v4f32"),
+        (UnaryOpKind::Exp, &F32, 8) => Ok("@llvm.exp.v8f32"),
+        (UnaryOpKind::Exp, &F64, 2) => Ok("@llvm.exp.v2f64"),
+        (UnaryOpKind::Exp, &F64, 4) => Ok("@llvm.exp.v4f64"),
+
         _ => weld_err!("Unsupported unary op: {} on <{} x {}>", op_kind, width, ty),
     }
 }

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -1329,7 +1329,7 @@ impl LlvmGenerator {
         if let Scalar(ref ty) = *child_ty {
             let res_tmp = ctx.var_ids.next();
             let op_name = llvm_scalar_unaryop(op_kind, ty)?;
-            ctx.code.add(format!("{} = call {} {} ({} {})", res_tmp, child_ll_ty, op_name, child_ll_ty, child_tmp));
+            ctx.code.add(format!("{} = call {} {}({} {})", res_tmp, child_ll_ty, op_name, child_ll_ty, child_tmp));
             self.gen_store_var(&res_tmp, &output_ll_sym, &output_ll_ty, ctx);
         } 
         else if let Simd(ref ty) = *child_ty {
@@ -1337,7 +1337,7 @@ impl LlvmGenerator {
             // If an intrinsic exists for this SIMD op, use it.
             if let Ok(op_name) = llvm_simd_unaryop(op_kind, ty, width) {
                 let res_tmp = ctx.var_ids.next();
-                ctx.code.add(format!("{} = call {} {} ({} {})", res_tmp, child_ll_ty, op_name, child_ll_ty, child_tmp));
+                ctx.code.add(format!("{} = call {} {}({} {})", res_tmp, child_ll_ty, op_name, child_ll_ty, child_tmp));
                 self.gen_store_var(&res_tmp, &output_ll_sym, &output_ll_ty, ctx);
             } else {
                 // Unroll and apply the scalar op, and then pack back into vector
@@ -1347,7 +1347,7 @@ impl LlvmGenerator {
                 for i in 0..width {
                     let elem_tmp = self.gen_simd_extract(child_ty, &child_tmp, i, ctx)?;
                     let val_tmp = ctx.var_ids.next();
-                    ctx.code.add(format!("{} = call {} {} ({} {})", val_tmp, scalar_ll_ty, op_name, scalar_ll_ty, elem_tmp));
+                    ctx.code.add(format!("{} = call {} {}({} {})", val_tmp, scalar_ll_ty, op_name, scalar_ll_ty, elem_tmp));
                     let next = ctx.var_ids.next();
                     ctx.code.add(format!("{} = insertelement {} {}, {} {}, i32 {}",
                                          next, child_ll_ty, prev_tmp, scalar_ll_ty, val_tmp, i));
@@ -2659,7 +2659,7 @@ fn llvm_scalar_unaryop(op_kind: UnaryOpKind, ty: &ScalarKind) -> WeldResult<&'st
 fn llvm_simd_unaryop(op_kind: UnaryOpKind, ty: &ScalarKind, width: u32) -> WeldResult<&'static str> {
     match (op_kind, ty, width) {
         (UnaryOpKind::Sqrt, &F32, 4) => Ok("@llvm.sqrt.v4f32"),
-        (UnaryOpKind::Sqrt, &F64, 8) => Ok("@llvm.sqrt.v8f64"),
+        (UnaryOpKind::Sqrt, &F32, 8) => Ok("@llvm.sqrt.v8f32"),
         _ => weld_err!("Unsupported unary op: {} on <{} x {}>", op_kind, width, ty),
     }
 }

--- a/weld/pretty_print.rs
+++ b/weld/pretty_print.rs
@@ -238,7 +238,7 @@ fn print_expr_impl<T: PrintableType>(expr: &Expr<T>,
             ref value,
         } => {
             format!(
-                "({}{})",
+                "({}({}))",
                 kind,
                 print_expr_impl(value, typed, indent, should_indent)
             )

--- a/weld/resources/prelude.ll
+++ b/weld/resources/prelude.ll
@@ -12,6 +12,9 @@ declare double @llvm.log.f64(double)
 declare float @erff(float)
 declare double @erf(double)
 
+declare <4 x float> @llvm.sqrt.v4f32(<4 x float>)
+declare <8 x float> @llvm.sqrt.v8f32(<8 x float>)
+
 declare float @llvm.sqrt.f32(float)
 declare double @llvm.sqrt.f64(double)
 

--- a/weld/resources/prelude.ll
+++ b/weld/resources/prelude.ll
@@ -14,6 +14,17 @@ declare double @erf(double)
 
 declare <4 x float> @llvm.sqrt.v4f32(<4 x float>)
 declare <8 x float> @llvm.sqrt.v8f32(<8 x float>)
+declare <4 x float> @llvm.log.v4f32(<4 x float>)
+declare <8 x float> @llvm.log.v8f32(<8 x float>)
+declare <4 x float> @llvm.exp.v4f32(<4 x float>)
+declare <8 x float> @llvm.exp.v8f32(<8 x float>)
+
+declare <2 x double> @llvm.sqrt.v2f64(<2 x double>)
+declare <4 x double> @llvm.sqrt.v4f64(<4 x double>)
+declare <2 x double> @llvm.log.v2f64(<2 x double>)
+declare <4 x double> @llvm.log.v4f64(<4 x double>)
+declare <2 x double> @llvm.exp.v2f64(<2 x double>)
+declare <4 x double> @llvm.exp.v4f64(<4 x double>)
 
 declare float @llvm.sqrt.f32(float)
 declare double @llvm.sqrt.f64(double)

--- a/weld/vectorizer.rs
+++ b/weld/vectorizer.rs
@@ -39,6 +39,71 @@ fn vectorizable_iters(iters: &Vec<Iter<Type>>) -> bool {
     true
 }
 
+/// Attempts to predicate an expression whose `ExprKind` is `If`, returning the new expression and
+/// true if subexpressions need to be vectorized or false otherwise.
+fn predicate_if(e: &mut Expr<Type>, broadcast_idens: &HashSet<Symbol>) -> WeldResult<(Option<Expr<Type>>, bool)> {
+    let mut new_expr = None;
+    let mut cont = true;
+
+    // Predication for a value merged into a merger. This pattern checks for if(cond, merge(b, e), b).
+    if let If { ref cond, ref on_true, ref on_false } = e.kind {
+        if let Merge { ref builder, ref value } = on_true.kind {
+            if let Ident(ref name) = on_false.kind {
+                if let Ident(ref name2) = builder.kind {
+                    if name == name2 {
+                        if let Builder(ref bk, _) = builder.ty {
+                            if let BuilderKind::Merger(ref ty, ref op) = *bk {
+                                if let Scalar(ref sk) = *ty.as_ref() {
+                                    let identity = match *op {
+                                        BinOpKind::Add => {
+                                            match *sk {
+                                                ScalarKind::I8 => exprs::literal_expr(LiteralKind::I8Literal(0))?,
+                                                ScalarKind::I32 => exprs::literal_expr(LiteralKind::I32Literal(0))?,
+                                                ScalarKind::I64 => exprs::literal_expr(LiteralKind::I64Literal(0))?,
+                                                ScalarKind::F32 => exprs::literal_expr(LiteralKind::F32Literal(0.0))?,
+                                                ScalarKind::F64 => exprs::literal_expr(LiteralKind::F64Literal(0.0))?,
+                                                _ => {
+                                                    return weld_err!("Predication not supported");
+                                                }
+                                            }
+                                        }
+                                        BinOpKind::Multiply => {
+                                            match *sk {
+                                                ScalarKind::I8 => exprs::literal_expr(LiteralKind::I8Literal(1))?,
+                                                ScalarKind::I32 => exprs::literal_expr(LiteralKind::I32Literal(1))?,
+                                                ScalarKind::I64 => exprs::literal_expr(LiteralKind::I64Literal(1))?,
+                                                ScalarKind::F32 => exprs::literal_expr(LiteralKind::F32Literal(1.0))?,
+                                                ScalarKind::F64 => exprs::literal_expr(LiteralKind::F64Literal(1.0))?,
+                                                _ => {
+                                                    return weld_err!("Predication not supported");
+                                                }
+                                            }
+                                        }
+                                        _ => {
+                                            return weld_err!("Merger type not vectorizable.");
+                                        }
+                                    };
+                                    // Change if(cond, merge(b, e), b) => 
+                                    // merge(b, select(cond, e, identity).
+                                    let mut expr = exprs::merge_expr(*builder.clone(), exprs::select_expr(*cond.clone(), *value.clone(), identity)?)?;
+                                    expr.transform_and_continue(&mut |ref mut e| {
+                                        let cont = vectorize_expr(e, broadcast_idens).unwrap();
+                                        (None, cont)
+                                    });
+                                    new_expr = Some(expr);
+                                    // We already vectorized this subexpression.
+                                    cont = false;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok((new_expr, cont))
+}
+
 /// Vectorizes an expression in-place, also changing its type if needed.
 fn vectorize_expr(e: &mut Expr<Type>, broadcast_idens: &HashSet<Symbol>) -> WeldResult<bool> {
     let mut new_expr = None;
@@ -66,6 +131,9 @@ fn vectorize_expr(e: &mut Expr<Type>, broadcast_idens: &HashSet<Symbol>) -> Weld
         GetField { .. } => {
             e.ty = e.ty.simd_type()?;
         }
+        UnaryOp { .. } => {
+            e.ty = e.ty.simd_type()?;
+        }
         BinOp { .. } => {
             e.ty = e.ty.simd_type()?;
         }
@@ -75,61 +143,10 @@ fn vectorize_expr(e: &mut Expr<Type>, broadcast_idens: &HashSet<Symbol>) -> Weld
         MakeStruct { .. } => {
             e.ty = e.ty.simd_type()?;
         }
-        // Predication for a value merged into a merger. This pattern checks for if(cond, merge(b, e), b).
-        If { ref cond, ref on_true, ref on_false } => {
-            if let Merge { ref builder, ref value } = on_true.kind {
-                if let Ident(ref name) = on_false.kind {
-                    if let Ident(ref name2) = builder.kind {
-                        if name == name2 {
-                            if let Builder(ref bk, _) = builder.ty {
-                                if let BuilderKind::Merger(ref ty, ref op) = *bk {
-                                    if let Scalar(ref sk) = *ty.as_ref() {
-                                        let identity = match *op {
-                                            BinOpKind::Add => {
-                                                match *sk {
-                                                    ScalarKind::I8 => exprs::literal_expr(LiteralKind::I8Literal(0))?,
-                                                    ScalarKind::I32 => exprs::literal_expr(LiteralKind::I32Literal(0))?,
-                                                    ScalarKind::I64 => exprs::literal_expr(LiteralKind::I64Literal(0))?,
-                                                    ScalarKind::F32 => exprs::literal_expr(LiteralKind::F32Literal(0.0))?,
-                                                    ScalarKind::F64 => exprs::literal_expr(LiteralKind::F64Literal(0.0))?,
-                                                    _ => {
-                                                        return weld_err!("Predication not supported");
-                                                    }
-                                                }
-                                            }
-                                            BinOpKind::Multiply => {
-                                                match *sk {
-                                                    ScalarKind::I8 => exprs::literal_expr(LiteralKind::I8Literal(1))?,
-                                                    ScalarKind::I32 => exprs::literal_expr(LiteralKind::I32Literal(1))?,
-                                                    ScalarKind::I64 => exprs::literal_expr(LiteralKind::I64Literal(1))?,
-                                                    ScalarKind::F32 => exprs::literal_expr(LiteralKind::F32Literal(1.0))?,
-                                                    ScalarKind::F64 => exprs::literal_expr(LiteralKind::F64Literal(1.0))?,
-                                                    _ => {
-                                                        return weld_err!("Predication not supported");
-                                                    }
-                                                }
-                                            }
-                                            _ => {
-                                                return weld_err!("Merger type not vectorizable.");
-                                            }
-                                        };
-                                        // Change if(cond, merge(b, e), b) => 
-                                        // merge(b, select(cond, e, identity).
-                                        let mut expr = exprs::merge_expr(*builder.clone(), exprs::select_expr(*cond.clone(), *value.clone(), identity)?)?;
-                                        expr.transform_and_continue(&mut |ref mut e| {
-                                            let cont = vectorize_expr(e, broadcast_idens).unwrap();
-                                            (None, cont)
-                                        });
-                                        new_expr = Some(expr);
-                                        // We already vectorized this subexpression.
-                                        cont = false;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+        If { .. } => {
+            let (e, c) = predicate_if(e, broadcast_idens)?;
+            new_expr = e;
+            cont = c;
         }
         _ => {},
     }

--- a/weld/vectorizer.rs
+++ b/weld/vectorizer.rs
@@ -189,6 +189,7 @@ fn vectorizable(for_loop: &Expr<Type>) -> WeldResult<HashSet<Symbol>> {
                                 }
                             },
 
+                            UnaryOp{ .. } => {},
                             BinOp{ .. } => {},
 
                             Let{ ref name, .. } => {


### PR DESCRIPTION
Unary ops which support LLVM SIMD intrinsics use those. Other ops are unrolled.