### PR TITLE
Disables the Predication Transform by Default

### DIFF
--- a/weld/conf.rs
+++ b/weld/conf.rs
@@ -17,7 +17,7 @@ pub const DEFAULT_MEMORY_LIMIT: i64 = 1000000000;
 pub const DEFAULT_THREADS: i64 = 1;
 lazy_static! {
     pub static ref DEFAULT_OPTIMIZATION_PASSES: Vec<Pass> = {
-        let m = ["inline-apply", "inline-let", "inline-zip", "loop-fusion", "vectorize"];
+        let m = ["inline-apply", "inline-let", "inline-zip", "loop-fusion", "predicate", "vectorize"];
         m.iter().map(|e| (*OPTIMIZATION_PASSES.get(e).unwrap()).clone()).collect()
     };
 }

--- a/weld/conf.rs
+++ b/weld/conf.rs
@@ -17,7 +17,7 @@ pub const DEFAULT_MEMORY_LIMIT: i64 = 1000000000;
 pub const DEFAULT_THREADS: i64 = 1;
 lazy_static! {
     pub static ref DEFAULT_OPTIMIZATION_PASSES: Vec<Pass> = {
-        let m = ["inline-apply", "inline-let", "inline-zip", "loop-fusion", "predicate", "vectorize"];
+        let m = ["inline-apply", "inline-let", "inline-zip", "loop-fusion", "vectorize"];
         m.iter().map(|e| (*OPTIMIZATION_PASSES.get(e).unwrap()).clone()).collect()
     };
 }

--- a/weld/passes.rs
+++ b/weld/passes.rs
@@ -61,6 +61,9 @@ lazy_static! {
                                 transforms::fuse_loops_vertical,
                                 transforms::simplify_get_field],
                  "loop-fusion"));
+        m.insert("predicate",
+                 Pass::new(vec![vectorizer::predicate],
+                 "predicate"));
         m.insert("vectorize",
                  Pass::new(vec![vectorizer::vectorize],
                  "vectorize"));


### PR DESCRIPTION
Also moves predication to its own transform instead of making it a part of vectorization.