### PR TITLE
Optimizations for Appender

### DIFF
--- a/weld/ast.rs
+++ b/weld/ast.rs
@@ -916,6 +916,18 @@ impl<T: TypeBounds> Expr<T> {
         }
     }
 
+    pub fn contains_symbol(&self, sym: &Symbol) -> bool {
+        let mut found = false;
+        self.traverse(&mut |ref mut e| {
+            if let ExprKind::Ident(ref s) = e.kind {
+                if *sym == *s {
+                    found = true;
+                }
+            }
+        });
+        found
+    }
+
     /// Recursively transforms an expression in place by running a function on it and optionally replacing it with another expression.
     pub fn transform_and_continue<F>(&mut self, func: &mut F)
         where F: FnMut(&mut Expr<T>) -> (Option<Expr<T>>, bool)

--- a/weld/ast.rs
+++ b/weld/ast.rs
@@ -916,6 +916,7 @@ impl<T: TypeBounds> Expr<T> {
         }
     }
 
+    /// Returns `true` if this expression contains the symbol `sym` in an `Ident`.
     pub fn contains_symbol(&self, sym: &Symbol) -> bool {
         let mut found = false;
         self.traverse(&mut |ref mut e| {

--- a/weld/conf.rs
+++ b/weld/conf.rs
@@ -17,7 +17,7 @@ pub const DEFAULT_MEMORY_LIMIT: i64 = 1000000000;
 pub const DEFAULT_THREADS: i64 = 1;
 lazy_static! {
     pub static ref DEFAULT_OPTIMIZATION_PASSES: Vec<Pass> = {
-        let m = ["inline-apply", "inline-let", "inline-zip", "loop-fusion", "vectorize"];
+        let m = ["inline-apply", "inline-let", "inline-zip", "loop-fusion", "infer-size", "vectorize"];
         m.iter().map(|e| (*OPTIMIZATION_PASSES.get(e).unwrap()).clone()).collect()
     };
 }

--- a/weld/exprs.rs
+++ b/weld/exprs.rs
@@ -316,6 +316,15 @@ pub fn newbuilder_expr(kind: BuilderKind, expr: Option<Expr<Type>>) -> WeldResul
             }
             passed
         }
+        Appender(_) => {
+            let mut passed = false;
+            if let Some(ref e) = expr {
+                if let Scalar(ScalarKind::I64) = e.ty {
+                    passed = true;
+                }
+            }
+            passed
+        }
         _ => expr.is_none(),
     };
 

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -1725,6 +1725,18 @@ impl LlvmGenerator {
                     self.gen_merge_op(&bld_ptr, &elem_tmp, &val_ll_ty, op, value_ty, ctx)?;
                 }
 
+                Appender(_) => {
+                    let bld_tmp = self.gen_load_var(&bld_ll_sym, &bld_ll_ty, ctx)?;
+                    let val_tmp = self.gen_load_var(&val_ll_sym, &val_ll_ty, ctx)?;
+                    ctx.code.add(format!("call {} {}.vmerge({} {}, {} {}, i32 %cur.tid)",
+                    bld_ll_ty,
+                    bld_prefix,
+                    bld_ll_ty,
+                    bld_tmp,
+                    val_ll_ty,
+                    val_tmp));
+                }
+
                 _ => {
                     // For all other builders, extract each value in the vector and merge it separately
                     let value_tmp = self.gen_load_var(&val_ll_sym, &val_ll_ty, ctx)?;

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -2168,13 +2168,20 @@ impl LlvmGenerator {
         match *builder_kind {
             Appender(_) => {
                 let bld_tmp = ctx.var_ids.next();
+                let size_tmp = if let Some(ref sym) = *arg {
+                    let (arg_ll_ty, arg_ll_sym) = self.llvm_type_and_name(func, sym)?;
+                    self.gen_load_var(&arg_ll_sym, &arg_ll_ty, ctx)?
+                } else {
+                    format!("{}", builder_size)
+                };
+
                 ctx.code.add(format!(
                     "{} = call {} {}.new(i64 {}, %work_t* \
                                     %cur.work)",
                     bld_tmp,
                     bld_ty_str,
                     bld_prefix,
-                    builder_size
+                    size_tmp
                 ));
                 self.gen_store_var(&bld_tmp, &llvm_symbol(output), &bld_ty_str, ctx);
             }

--- a/weld/parser.rs
+++ b/weld/parser.rs
@@ -1269,6 +1269,9 @@ fn basic_parsing() {
     let e = parse_expr("appender[i32]").unwrap();
     assert_eq!(print_expr_without_indent(&e), "appender[i32]");
 
+    let e = parse_expr("appender[i32](1000L)").unwrap();
+    assert_eq!(print_expr_without_indent(&e), "appender[i32](1000L)");
+
     let e = parse_expr("@(impl:local) dictmerger[i32,i32,+]").unwrap();
     assert_eq!(print_expr_without_indent(&e),
                "@(impl:local)dictmerger[i32,i32,+]");

--- a/weld/parser.rs
+++ b/weld/parser.rs
@@ -895,7 +895,16 @@ impl<'t> Parser<'t> {
                     try!(self.consume(TCloseBracket));
                 }
 
-                let mut expr = expr_box(NewBuilder(None));
+                let arg = if *self.peek() == TOpenParen {
+                    self.consume(TOpenParen)?;
+                    let arg = self.expr()?;
+                    self.consume(TCloseParen)?;
+                    Some(arg)
+                } else {
+                    None
+                };
+
+                let mut expr = expr_box(NewBuilder(arg));
                 expr.ty = Builder(Appender(Box::new(elem_type)), annotations);
                 Ok(expr)
             }
@@ -1086,6 +1095,7 @@ impl<'t> Parser<'t> {
                 try!(self.consume(TOpenBracket));
                 let elem_type = try!(self.type_());
                 try!(self.consume(TCloseBracket));
+
 
                 Ok(Builder(Appender(Box::new(elem_type)), annotations))
             }

--- a/weld/passes.rs
+++ b/weld/passes.rs
@@ -61,6 +61,9 @@ lazy_static! {
                                 transforms::fuse_loops_vertical,
                                 transforms::simplify_get_field],
                  "loop-fusion"));
+        m.insert("infer-size",
+                 Pass::new(vec![transforms::infer_size],
+                 "infer-size"));
         m.insert("predicate",
                  Pass::new(vec![vectorizer::predicate],
                  "predicate"));

--- a/weld/resources/vvector.ll
+++ b/weld/resources/vvector.ll
@@ -12,3 +12,38 @@ define <{VECSIZE} x {ELEM}>* @{NAME}.vat(%{NAME} %vec, i64 %index) {{
   %retPtr = bitcast {ELEM}* %ptr to <{VECSIZE} x {ELEM}>*
   ret <{VECSIZE} x {ELEM}>* %retPtr
 }}
+
+; Append a value into a builder, growing its space if needed.
+define %{NAME}.bld @{NAME}.bld.vmerge(%{NAME}.bld noalias %bldPtr, <{VECSIZE} x {ELEM}> %value, i32 %myId) {{
+entry:
+  %curPiecePtr = call %vb.vp* @weld_rt_cur_vb_piece(i8* %bldPtr, i32 %myId)
+  %curPiece = load %vb.vp, %vb.vp* %curPiecePtr
+  %size = extractvalue %vb.vp %curPiece, 1
+  %capacity = extractvalue %vb.vp %curPiece, 2
+  %adjusted = add i64 %size, {VECSIZE}
+  %full = icmp sge i64 %adjusted, %capacity
+  br i1 %full, label %onFull, label %finish
+
+onFull:
+  %newCapacity = mul i64 %capacity, 2
+  %elemSizePtr = getelementptr {ELEM}, {ELEM}* null, i32 1
+  %elemSize = ptrtoint {ELEM}* %elemSizePtr to i64
+  %bytes = extractvalue %vb.vp %curPiece, 0
+  %allocSize = mul i64 %elemSize, %newCapacity
+  %runId = call i64 @weld_rt_get_run_id()
+  %newBytes = call i8* @weld_run_realloc(i64 %runId, i8* %bytes, i64 %allocSize)
+  %curPiece1 = insertvalue %vb.vp %curPiece, i8* %newBytes, 0
+  %curPiece2 = insertvalue %vb.vp %curPiece1, i64 %newCapacity, 2
+  br label %finish
+
+finish:
+  %curPiece3 = phi %vb.vp [ %curPiece, %entry ], [ %curPiece2, %onFull ]
+  %bytes1 = extractvalue %vb.vp %curPiece3, 0
+  %elements = bitcast i8* %bytes1 to <{VECSIZE} x {ELEM}>*
+  %insertPtr = getelementptr <{VECSIZE} x {ELEM}>, <{VECSIZE} x {ELEM}>* %elements, i64 %size
+  store <{VECSIZE} x {ELEM}> %value, <{VECSIZE} x {ELEM}>* %insertPtr
+  %newSize = add i64 %size, {VECSIZE}
+  %curPiece4 = insertvalue %vb.vp %curPiece3, i64 %newSize, 1
+  store %vb.vp %curPiece4, %vb.vp* %curPiecePtr
+  ret %{NAME}.bld %bldPtr
+}}

--- a/weld/resources/vvector.ll
+++ b/weld/resources/vvector.ll
@@ -21,7 +21,7 @@ entry:
   %size = extractvalue %vb.vp %curPiece, 1
   %capacity = extractvalue %vb.vp %curPiece, 2
   %adjusted = add i64 %size, {VECSIZE}
-  %full = icmp sge i64 %adjusted, %capacity
+  %full = icmp sgt i64 %adjusted, %capacity
   br i1 %full, label %onFull, label %finish
 
 onFull:

--- a/weld/resources/vvector.ll
+++ b/weld/resources/vvector.ll
@@ -14,7 +14,7 @@ define <{VECSIZE} x {ELEM}>* @{NAME}.vat(%{NAME} %vec, i64 %index) {{
 }}
 
 ; Append a value into a builder, growing its space if needed.
-define %{NAME}.bld @{NAME}.bld.vmerge(%{NAME}.bld noalias %bldPtr, <{VECSIZE} x {ELEM}> %value, i32 %myId) {{
+define %{NAME}.bld @{NAME}.bld.vmerge(%{NAME}.bld %bldPtr, <{VECSIZE} x {ELEM}> %value, i32 %myId) {{
 entry:
   %curPiecePtr = call %vb.vp* @weld_rt_cur_vb_piece(i8* %bldPtr, i32 %myId)
   %curPiece = load %vb.vp, %vb.vp* %curPiecePtr
@@ -39,9 +39,10 @@ onFull:
 finish:
   %curPiece3 = phi %vb.vp [ %curPiece, %entry ], [ %curPiece2, %onFull ]
   %bytes1 = extractvalue %vb.vp %curPiece3, 0
-  %elements = bitcast i8* %bytes1 to <{VECSIZE} x {ELEM}>*
-  %insertPtr = getelementptr <{VECSIZE} x {ELEM}>, <{VECSIZE} x {ELEM}>* %elements, i64 %size
-  store <{VECSIZE} x {ELEM}> %value, <{VECSIZE} x {ELEM}>* %insertPtr
+  %elements = bitcast i8* %bytes1 to {ELEM}*
+  %insertPtr = getelementptr {ELEM}, {ELEM}* %elements, i64 %size
+  %vecInsertPtr = bitcast {ELEM}* %insertPtr to <{VECSIZE} x {ELEM}>*
+  store <{VECSIZE} x {ELEM}> %value, <{VECSIZE} x {ELEM}>* %vecInsertPtr, align 1
   %newSize = add i64 %size, {VECSIZE}
   %curPiece4 = insertvalue %vb.vp %curPiece3, i64 %newSize, 1
   store %vb.vp %curPiece4, %vb.vp* %curPiecePtr

--- a/weld/transforms.rs
+++ b/weld/transforms.rs
@@ -647,7 +647,7 @@ fn simple_merge(sym: &Symbol, expr: &Expr<Type>) -> bool {
             return false;
         }
         If { ref cond, ref on_true, ref on_false } => {
-            cond.contains_symbol(sym) && simple_merge(sym, on_true) &&
+            !cond.contains_symbol(sym) && simple_merge(sym, on_true) &&
                 simple_merge(sym, on_false)
         }
         _ => false,

--- a/weld/transforms.rs
+++ b/weld/transforms.rs
@@ -596,3 +596,60 @@ pub fn simplify_get_field<T: TypeBounds>(expr: &mut Expr<T>) {
         None
     });
 }
+
+/// Infers the size of an `Appender` in a `For` loop.
+pub fn infer_size(expr: &mut Expr<Type>) {
+    expr.transform_and_continue_res(&mut |ref mut expr| {
+        if let For { ref iters, ref builder, ref func } = expr.kind {
+            // This constraint prevents copying expensive iters.
+            if let Ident(_) = iters[0].data.kind {
+                if let NewBuilder(None) = builder.kind {
+                    if let Builder(Appender(ref ek), _) = builder.ty {
+                        if let Lambda {ref params, ref body } = func.kind {
+                            let ref builder_symbol = params[0].name.clone();
+                            if simple_merge(builder_symbol, body) {
+                                // Compute the inferred length based on the iter.
+                                let length = if let Some(ref start) = iters[0].start {
+                                    let e = exprs::binop_expr(BinOpKind::Subtract,
+                                                              *iters[0].end.as_ref().unwrap().clone(),
+                                                              *start.clone())?;
+                                    exprs::binop_expr(BinOpKind::Divide, e, *iters[0].stride.as_ref().unwrap().clone())?
+                                } else {
+                                    exprs::length_expr(*iters[0].data.clone())?
+                                };
+
+                                let new_loop = exprs::for_expr(
+                                    iters.clone(),
+                                    exprs::newbuilder_expr(Appender(ek.clone()), Some(length))?,
+                                    func.as_ref().clone(),
+                                    false)?;
+                                return Ok((Some(new_loop), false));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok((None, true))
+    })
+}
+
+/// Checks that `expr` performs only one `Merge` per control path - this guarantees
+/// that the loop containing `expr`'s size can be inferred.
+fn simple_merge(sym: &Symbol, expr: &Expr<Type>) -> bool {
+    match expr.kind {
+        Merge { ref builder, ref value } => {
+            if let Ident(ref s) = builder.kind {
+                if s == sym {
+                    return !value.contains_symbol(sym);
+                }
+            }
+            return false;
+        }
+        If { ref cond, ref on_true, ref on_false } => {
+            cond.contains_symbol(sym) && simple_merge(sym, on_true) &&
+                simple_merge(sym, on_false)
+        }
+        _ => false,
+    }
+}

--- a/weld/type_inference.rs
+++ b/weld/type_inference.rs
@@ -514,6 +514,16 @@ fn infer_locally(expr: &mut PartialExpr, env: &mut TypeMap) -> WeldResult<bool> 
                             None => {}
                         }
                     }
+                    Appender(_) => {
+                        match *e {
+                            Some(ref mut arg) => {
+                                changed |= try!(push_type(&mut arg.ty,
+                                                          &Scalar(I64),
+                                                          "NewBuilder(Appender)"));
+                            }
+                            None => {}
+                        }
+                    }
                     _ => {}
                 }
             }


### PR DESCRIPTION
This implements two important optimizations for the appender:

1. vector stores when merging into an appender
2. Size inference for the appender, so space can be pre-allocated before execution. 