### PR TITLE
Build native library just once and various updates to reduce compile times

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $ ln -s /usr/local/bin/clang /usr/local/bin/clang-4.0
 $ ln -s /usr/local/bin/llvm-link /usr/local/bin/llvm-link-4.0
 ```
 
-Weld builds two dynamically linked libraries (`.so` files on Linux and `.dylib` files on macOS): `libweld` and `libweldrt`. Both of these libraries are found using `WELD_HOME`. By default, the libraries are in `$WELD_HOME/target/release` and `$WELD_HOME/weld_rt/target/release`.
+Weld builds two dynamically linked libraries (`.so` files on Linux and `.dylib` files on Mac): `libweld` and `libweldrt`. Both of these libraries need to be on your `LD_LIBRARY_PATH` (or `DYLD_LIBRARY_PATH` on a Mac) when running a program that uses Weld. By default, the libraries get placed in in `$WELD_HOME/target/release` or `$WELD_HOME/target/debug`.
 
 Finally, run the unit and integration tests:
 
@@ -96,25 +96,33 @@ The `docs/` directory contains documentation for the different components of Wel
 * [python.md](https://github.com/weld-project/weld/blob/master/docs/python.md) gives an overview of the Python API.
 * [tutorial.md](https://github.com/weld-project/weld/blob/master/docs/tutorial.md) contains a tutorial for how to build a small vector library using Weld.
 
+## Python Bindings
+
+Weld's python bindings are in [`python/weld`](https://github.com/weld-project/weld/tree/master/python/weld), with examples in [`examples/python`](https://github.com/weld-project/weld/tree/master/examples/python).
+To run any these programs, you will need Weld's runtime libraries (`libweld` and `libweldrt`) to be on your `LD_LIBRARY_PATH` or `DYLD_LIBRARY_PATH` (on Macs).
+
 ## Grizzly
 
 **Grizzly** is a subset of [Pandas](http://pandas.pydata.org/) integrated with Weld. Details on how to use Grizzly are in
 [`python/grizzly`](https://github.com/weld-project/weld/tree/master/python/grizzly).
 Some example workloads that make use of Grizzly are in [`examples/python/grizzly`](https://github.com/weld-project/weld/tree/master/examples/python/grizzly).
+To run Grizzly, you will also need the `WELD_HOME` environment variable to be set, because Grizzly needs to find its own native library through this variable.
 
-## Running an Interactive REPL
+## Testing
 
-* `cargo test` runs unit and integration tests. A test name substring filter can be used to run a subset of the tests:
+`cargo test` runs unit and integration tests. A test name substring filter can be used to run a subset of the tests:
 
    ```
    cargo test <substring to match in test name>
    ```
 
-* The `target/release/repl` program is a simple "shell" where one can type Weld programs and see
-  the results of parsing, macro substitution and type inference.
+## Interactive REPL
+
+The `target/release/repl` program is a simple "shell" where one can type Weld programs and see the results of parsing, macro substitution and type inference. Make sure to set `LD_LIBRARY_PATH` or `DYLD_LIBRARY_PATH` (on Macs) to point to your build directory before running it so that it can find the runtime libraries:
 
 Example `repl` session:
 ```
+$ LD_LIBRARY_PATH=target/debug ./target/debug/repl
 > let a = 5 + 2; a + a
 Raw structure: [...]
 

--- a/build.rs
+++ b/build.rs
@@ -2,33 +2,40 @@ use std::env;
 use std::process::Command;
 
 fn main() {
-    Command::new("make")
+    let project_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    let status = Command::new("make")
         .arg("clean")
         .arg("-C")
-        .arg("python/grizzly/")
+        .arg(format!("{}/python/grizzly/", project_dir))
         .status()
         .unwrap();
+    assert!(status.success());
 
-    Command::new("make")
+    let status = Command::new("make")
         .arg("convertor")
         .arg("-C")
-        .arg("python/grizzly/")
+        .arg(format!("{}/python/grizzly/", project_dir))
         .status()
         .unwrap();
+    assert!(status.success());
 
-    Command::new("make")
+    let status = Command::new("make")
         .arg("clean")
         .arg("-C")
-        .arg("weld_rt/cpp/")
+        .arg(format!("{}/weld_rt/cpp/", project_dir))
         .status()
         .unwrap();
+    assert!(status.success());
 
-    Command::new("make")
+    let status = Command::new("make")
         .arg("-C")
-        .arg("weld_rt/cpp/")
+        .arg(format!("{}/weld_rt/cpp/", project_dir))
         .status()
         .unwrap();
+    assert!(status.success());
 
+    // Link C++ standard library and some Mac-specific libraries
     let target = env::var("TARGET").unwrap();
     if target == "x86_64-apple-darwin" {
         let libs = vec!["z", "c++"];
@@ -37,4 +44,8 @@ fn main() {
         }
     }
     println!("cargo:rustc-link-lib=dylib=stdc++");
+
+    // Link the weldrt C++ library
+    println!("cargo:rustc-link-lib=dylib=weldrt");
+    println!("cargo:rustc-link-search=native={}/weld_rt/cpp", project_dir);
 }

--- a/build_tools/travis/test_multi_version.sh
+++ b/build_tools/travis/test_multi_version.sh
@@ -26,6 +26,7 @@ cargo clean
 cargo build --release
 cargo test
 
+export LD_LIBRARY_PATH=`pwd`/target/release
 python python/grizzly/tests/grizzly_test.py
 python python/grizzly/tests/numpy_weld_test.py
 deactivate

--- a/c/weld.h
+++ b/c/weld.h
@@ -229,9 +229,5 @@ weld_load_library(const char *filename, weld_error_t err);
 extern "C" void
 weld_set_log_level(weld_log_level_t level);
 
-extern {
-    pub fn weld_runtime_init();
-}
-
 #endif
 

--- a/c/weld.h
+++ b/c/weld.h
@@ -229,5 +229,9 @@ weld_load_library(const char *filename, weld_error_t err);
 extern "C" void
 weld_set_log_level(weld_log_level_t level);
 
+extern {
+    pub fn weld_runtime_init();
+}
+
 #endif
 

--- a/python/weld/bindings.py
+++ b/python/weld/bindings.py
@@ -10,24 +10,16 @@ import copy
 
 system = platform.system()
 if system == 'Linux':
-    path = "libweld.so"
+    lib_file = "libweld.so"
 elif system == 'Windows':
-    path = "libweld.dll"
+    lib_file = "libweld.dll"
 elif system == 'Darwin':
-    path = "libweld.dylib"
+    lib_file = "libweld.dylib"
 else:
     raise OSError("Unsupported platform {}", system)
 
-if "WELD_HOME" not in os.environ:
-    raise Exception("Set the WELD_HOME environment variable")
-home = os.environ["WELD_HOME"]
-if home[-1] != "/":
-    home += "/"
-
-path = home + "target/release/" + path
-
 # Load the Weld Dynamic Library.
-weld = CDLL(path, mode=RTLD_GLOBAL)
+weld = CDLL(lib_file, mode=RTLD_GLOBAL)
 
 # Used for some type checking carried out by ctypes
 

--- a/weld/conf.rs
+++ b/weld/conf.rs
@@ -98,7 +98,7 @@ fn parse_passes(s: &str) -> WeldResult<Vec<Pass>> {
 /// Parse an LLVM optimization level.
 fn parse_llvm_optimization_level(s: &str) -> WeldResult<u32> {
     match s.parse::<u32>() {
-        Ok(v) if v <= 2 => Ok(v),
+        Ok(v) if v <= 3 => Ok(v),
         _ => weld_err!("Invalid LLVM optimization level: {}", s),
     }
 }

--- a/weld/conf.rs
+++ b/weld/conf.rs
@@ -11,10 +11,12 @@ use super::passes::Pass;
 pub const MEMORY_LIMIT_KEY: &'static str = "weld.memory.limit";
 pub const THREADS_KEY: &'static str = "weld.threads";
 pub const OPTIMIZATION_PASSES_KEY: &'static str = "weld.optimization.passes";
+pub const LLVM_OPTIMIZATION_LEVEL_KEY: &'static str = "weld.llvm.optimization.level";
 
 // Default values of each key
 pub const DEFAULT_MEMORY_LIMIT: i64 = 1000000000;
-pub const DEFAULT_THREADS: i64 = 1;
+pub const DEFAULT_THREADS: i32 = 1;
+pub const DEFAULT_LLVM_OPTIMIZATION_LEVEL: u32 = 2;
 lazy_static! {
     pub static ref DEFAULT_OPTIMIZATION_PASSES: Vec<Pass> = {
         let m = ["inline-apply", "inline-let", "inline-zip", "loop-fusion", "infer-size", "predicate", "vectorize"];
@@ -25,8 +27,9 @@ lazy_static! {
 // A parsed configuration with correctly typed fields.
 pub struct ParsedConf {
     pub memory_limit: i64,
-    pub threads: i64,
-    pub optimization_passes: Vec<Pass>
+    pub threads: i32,
+    pub optimization_passes: Vec<Pass>,
+    pub llvm_optimization_level: u32
 }
 
 /// Parse a configuration from a WeldConf key-value dictiomary.
@@ -43,10 +46,15 @@ pub fn parse(conf: &WeldConf) -> WeldResult<ParsedConf> {
     let passes = value.map(|s| parse_passes(&s))
                       .unwrap_or(Ok(DEFAULT_OPTIMIZATION_PASSES.clone()))?;
 
+    let value = get_value(conf, LLVM_OPTIMIZATION_LEVEL_KEY);
+    let level = value.map(|s| parse_llvm_optimization_level(&s))
+                      .unwrap_or(Ok(DEFAULT_LLVM_OPTIMIZATION_LEVEL))?;
+
     Ok(ParsedConf {
         memory_limit: memory_limit,
         threads: threads,
-        optimization_passes: passes
+        optimization_passes: passes,
+        llvm_optimization_level: level
     })
 }
 
@@ -57,12 +65,13 @@ fn get_value(conf: &WeldConf, key: &str) -> Option<String> {
 }
 
 /// Parse a number of threads.
-fn parse_threads(s: &str) -> WeldResult<i64> {
-    match s.parse::<i64>() {
+fn parse_threads(s: &str) -> WeldResult<i32> {
+    match s.parse::<i32>() {
         Ok(v) if v > 0 => Ok(v),
         _ => weld_err!("Invalid number of threads: {}", s),
     }
 }
+
 /// Parse a memory limit.
 fn parse_memory_limit(s: &str) -> WeldResult<i64> {
     match s.parse::<i64>() {
@@ -86,17 +95,31 @@ fn parse_passes(s: &str) -> WeldResult<Vec<Pass>> {
     Ok(result)
 }
 
+/// Parse an LLVM optimization level.
+fn parse_llvm_optimization_level(s: &str) -> WeldResult<u32> {
+    match s.parse::<u32>() {
+        Ok(v) if v <= 2 => Ok(v),
+        _ => weld_err!("Invalid LLVM optimization level: {}", s),
+    }
+}
+
 #[test]
 fn conf_parsing() {
     assert_eq!(parse_threads("1").unwrap(), 1);
     assert_eq!(parse_threads("2").unwrap(), 2);
+    assert!(parse_threads("-1").is_err());
     assert!(parse_threads("").is_err());
 
     assert_eq!(parse_memory_limit("1000000").unwrap(), 1000000);
+    assert!(parse_memory_limit("-1").is_err());
     assert!(parse_memory_limit("").is_err());
 
     assert_eq!(parse_passes("loop-fusion,inline-let").unwrap().len(), 2);
     assert_eq!(parse_passes("loop-fusion").unwrap().len(), 1);
     assert_eq!(parse_passes("").unwrap().len(), 0);
     assert!(parse_passes("non-existent-pass").is_err());
+
+    assert_eq!(parse_llvm_optimization_level("0").unwrap(), 0);
+    assert_eq!(parse_llvm_optimization_level("2").unwrap(), 2);
+    assert!(parse_llvm_optimization_level("5").is_err());
 }

--- a/weld/easy_ll/tests.rs
+++ b/weld/easy_ll/tests.rs
@@ -1,7 +1,6 @@
 use std::error::Error;
 
 use easy_ll::compile_module;
-pub const LIB_WELD_RT: &'static [u8] = include_bytes!("../../weld_rt/cpp/libweldrt.bc");
 
 #[test]
 fn basic_use() {

--- a/weld/easy_ll/tests.rs
+++ b/weld/easy_ll/tests.rs
@@ -15,7 +15,7 @@ fn basic_use() {
            %2 = call i64 @bar(i64 %1)
            ret i64 %2
        }
-    ", None);
+    ", 2, None);
     assert!(module.is_ok());
     assert_eq!(module.unwrap().run(42), 44);
 }
@@ -26,7 +26,7 @@ fn compile_error() {
        define ZZZZZZZZ @run(i64 %arg) {
            ret i64 0
        }
-    ", None);
+    ", 2, None);
     assert!(!module.is_ok());
     assert!(module.unwrap_err().description().contains("Compile"));
 }
@@ -37,7 +37,7 @@ fn no_run_function() {
        define i64 @ZZZZZZZ(i64 %arg) {
            ret i64 0
        }
-    ", None);
+    ", 2, None);
     assert!(!module.is_ok());
     assert!(module.unwrap_err().description().contains("run function"));
 }
@@ -48,7 +48,7 @@ fn wrong_function_type() {
        define i64 @run() {
            ret i64 0
        }
-    ", None);
+    ", 2, None);
     assert!(!module.is_ok());
     assert!(module.unwrap_err().description().contains("wrong type"));
 }

--- a/weld/lib.rs
+++ b/weld/lib.rs
@@ -261,7 +261,10 @@ pub unsafe extern "C" fn weld_module_compile(code: *const c_char,
     }
 
     info!("Started compiling program");
-    let module = llvm::compile_program(&parsed.unwrap(), &conf.optimization_passes);
+    let module = llvm::compile_program(
+        &parsed.unwrap(),
+        &conf.optimization_passes,
+        conf.llvm_optimization_level);
     info!("Done compiling program");
 
     if let Err(ref e) = module {
@@ -307,7 +310,7 @@ pub unsafe extern "C" fn weld_module_run(module: *mut WeldModule,
 
     let input = Box::new(llvm::WeldInputArgs {
                              input: arg.data as i64,
-                             nworkers: conf.threads as i32,
+                             nworkers: conf.threads,
                              mem_limit: conf.memory_limit,
                          });
     let ptr = Box::into_raw(input) as i64;
@@ -418,18 +421,6 @@ pub extern "C" fn weld_set_log_level(level: WeldLogLevel) {
     builder.format(format);
     builder.filter(None, filter);
     builder.init().unwrap_or(());
-}
-
-extern {
-    pub fn weld_run_get_errno(run_id: i64) -> i64;
-    pub fn weld_runtime_init();
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn foo() {
-    println!("{:?}", weld_runtime_init());
-    println!("{:?}", weld_run_get_errno(0));
-    println!("{:?}", weld_run_get_errno(0));
 }
 
 #[cfg(test)]

--- a/weld/lib.rs
+++ b/weld/lib.rs
@@ -245,6 +245,8 @@ pub unsafe extern "C" fn weld_module_compile(code: *const c_char,
     // Let LLVM find symbols in libweldrt; it's okay to call this multiple times
     let libweldrt = if cfg!(target_os="macos") {
         "libweldrt.dylib"
+    } else if cfg!(target_os="windows") {
+        "libweltrt.dll"
     } else {
         "libweldrt.so"
     };

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -1383,7 +1383,7 @@ impl LlvmGenerator {
                     let (elem_ll_ty, elem_ll_sym) = self.llvm_type_and_name(func, elem)?;
                     let elem_value = self.gen_load_var(&elem_ll_sym, &elem_ll_ty, ctx)?;
                     let ptr_tmp = ctx.var_ids.next();
-                    ctx.code.add(format!("{} = getelementptr {}, {}* {}, i32 0, i32 {}",
+                    ctx.code.add(format!("{} = getelementptr inbounds {}, {}* {}, i32 0, i32 {}",
                         ptr_tmp, output_ll_ty, output_ll_ty, output_ll_sym, index));
                     self.gen_store_var(&elem_value, &ptr_tmp, &elem_ll_ty, ctx);
                 }
@@ -1638,7 +1638,7 @@ impl LlvmGenerator {
                 let (output_ll_ty, output_ll_sym) = self.llvm_type_and_name(func, output)?;
                 let (value_ll_ty, value_ll_sym) = self.llvm_type_and_name(func, value)?;
                 let ptr_tmp = ctx.var_ids.next();
-                ctx.code.add(format!("{} = getelementptr {}, {}* {}, i32 0, i32 {}",
+                ctx.code.add(format!("{} = getelementptr inbounds {}, {}* {}, i32 0, i32 {}",
                     ptr_tmp, value_ll_ty, value_ll_ty, value_ll_sym, index));
                 let res_tmp = self.gen_load_var(&ptr_tmp, &output_ll_ty, ctx)?;
                 self.gen_store_var(&res_tmp, &output_ll_sym, &output_ll_ty, ctx);

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -61,7 +61,8 @@ pub fn apply_opt_passes(expr: &mut TypedExpr, opt_passes: &Vec<Pass>) -> WeldRes
 }
 
 /// Generate a compiled LLVM module from a program whose body is a function.
-pub fn compile_program(program: &Program, opt_passes: &Vec<Pass>) -> WeldResult<easy_ll::CompiledModule> {
+pub fn compile_program(program: &Program, opt_passes: &Vec<Pass>, llvm_opt_level: u32)
+        -> WeldResult<easy_ll::CompiledModule> {
     let mut expr = macro_processor::process_program(program)?;
     debug!("After macro substitution:\n{}\n", print_typed_expr(&expr));
 
@@ -84,7 +85,10 @@ pub fn compile_program(program: &Program, opt_passes: &Vec<Pass>) -> WeldResult<
     debug!("LLVM program:\n{}\n", &llvm_code);
 
     debug!("Started compiling LLVM");
-    let module = try!(easy_ll::compile_module(&llvm_code, Some(WELD_INLINE_LIB)));
+    let module = try!(easy_ll::compile_module(
+        &llvm_code,
+        llvm_opt_level,
+        Some(WELD_INLINE_LIB)));
     debug!("Done compiling LLVM");
 
     debug!("Started runtime_init call");

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -24,7 +24,7 @@ use super::sir::Terminator::*;
 use super::transforms;
 use super::type_inference;
 use super::util::IdGenerator;
-use super::util::LIB_WELD_RT;
+use super::util::WELD_INLINE_LIB;
 
 #[cfg(test)]
 use super::parser::*;
@@ -84,7 +84,7 @@ pub fn compile_program(program: &Program, opt_passes: &Vec<Pass>) -> WeldResult<
     debug!("LLVM program:\n{}\n", &llvm_code);
 
     debug!("Started compiling LLVM");
-    let module = try!(easy_ll::compile_module(&llvm_code, Some(LIB_WELD_RT)));
+    let module = try!(easy_ll::compile_module(&llvm_code, Some(WELD_INLINE_LIB)));
     debug!("Done compiling LLVM");
 
     debug!("Started runtime_init call");

--- a/weld/util.rs
+++ b/weld/util.rs
@@ -9,7 +9,7 @@ use std::env;
 use super::ast::*;
 use super::ast::ExprKind::*;
 
-pub const LIB_WELD_RT: &'static [u8] = include_bytes!("../weld_rt/cpp/libweldrt.bc");
+pub const WELD_INLINE_LIB: &'static [u8] = include_bytes!("../weld_rt/cpp/inline.bc");
 const WELD_HOME: &'static str = "WELD_HOME";
 
 /// Utility struct that can track and generate unique IDs and symbols for use in an expression.

--- a/weld_rt/cpp/Makefile
+++ b/weld_rt/cpp/Makefile
@@ -1,19 +1,26 @@
 OS = $(shell uname -s)
 LLVM_VERSION = $(shell llvm-config --version | cut -d . -f 1,2)
 
-CFLAGS = -O0 -g -std=c++11 -Wall -fno-use-cxa-atexit -fPIC -flto
+CFLAGS = -O3 -std=c++11 -Wall -fno-use-cxa-atexit -fPIC
 ifeq (${OS}, Darwin)
   # OS X
   CLANG ?= clang++-${LLVM_VERSION}
+	DYLIB = libweldrt.dylib
 else ifeq (${OS}, Linux)
   # Linux
   CLANG ?= clang++-${LLVM_VERSION}
+	DYLIB = libweldrt.so
 else
   $(error Unsupported platform: ${OS})
 endif
 
+all: ${DYLIB} inline.bc
 
-all: libweldrt.bc
+inline.o: inline.cpp
+	${CLANG} ${CFLAGS} -c $< -o $@
+
+inline.bc: inline.cpp
+	${CLANG} ${CFLAGS} -c -emit-llvm $< -o $@
 
 vb.o: vb.cpp
 	${CLANG} ${CFLAGS} -c $< -o $@
@@ -24,11 +31,15 @@ merger.o: merger.cpp
 runtime.o: runtime.cpp
 	${CLANG} ${CFLAGS} -c $< -o $@
 
-libweldrt.bc: vb.o merger.o runtime.o
-	llvm-link-${LLVM_VERSION} $^ -o $@
+${DYLIB}: vb.o merger.o runtime.o inline.o
+	${CLANG} -shared -o $@ $^
+	mkdir -p ../../target/release
+	cp ${DYLIB} ../../target/release
+	mkdir -p ../../target/debug
+	cp ${DYLIB} ../../target/debug
 
 clean:
-	rm -f *.bc *.o
+	rm -f *.bc *.o ${DYLIB}
 
 .phony: all
 

--- a/weld_rt/cpp/inline.cpp
+++ b/weld_rt/cpp/inline.cpp
@@ -1,0 +1,16 @@
+#include "runtime.h"
+
+extern "C" void *weld_rt_get_merger_at_index(void *m, int64_t size, int32_t i) {
+  intptr_t ptr = reinterpret_cast<intptr_t>(m);
+  ptr = (ptr + (CACHE_LINE - 1)) & CACHE_MASK;
+  return reinterpret_cast<void *>(ptr + num_cache_blocks(size) * i * CACHE_LINE);
+}
+
+// a non-full task executes in correct serial order (and by the same thread)
+// after its associated full task (and potentially other non-full tasks also
+// assicated with the same full task), so it can simply write into its full
+// task's piece (the cur_piece) without creating a new one
+extern "C" vec_piece *weld_rt_cur_vb_piece(void *v, int32_t my_id) {
+  vec_builder *vb = (vec_builder *)v;
+  return (vec_piece *)weld_rt_get_merger_at_index(vb->thread_curs, sizeof(vec_piece), my_id);
+}

--- a/weld_rt/cpp/merger.cpp
+++ b/weld_rt/cpp/merger.cpp
@@ -1,22 +1,4 @@
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 #include "runtime.h"
-
-#define CACHE_BITS 6
-#define CACHE_LINE (1 << CACHE_BITS)
-#define MASK (~(CACHE_LINE - 1))
-
-static inline int64_t num_cache_blocks(int64_t size) {
-  // ceil of number of blocks
-  return (size + (CACHE_LINE - 1)) >> CACHE_BITS;
-}
-
-extern "C" void *weld_rt_get_merger_at_index(void *m, int64_t size, int32_t i) {
-  intptr_t ptr = reinterpret_cast<intptr_t>(m);
-  ptr = (ptr + (CACHE_LINE - 1)) & MASK;
-  return reinterpret_cast<void *>(ptr + num_cache_blocks(size) * i * CACHE_LINE);
-}
 
 // zero-initializes storage
 extern "C" void *weld_rt_new_merger(int64_t size, int32_t nworkers) {

--- a/weld_rt/cpp/runtime.h
+++ b/weld_rt/cpp/runtime.h
@@ -1,5 +1,11 @@
-#ifndef _PARLIB_H_
-#define _PARLIB_H_
+#ifndef _WELD_RUNTIME_H_
+#define _WELD_RUNTIME_H_
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <vector>
 
 // work item
 struct work_t {
@@ -68,10 +74,20 @@ struct vec_piece {
   int32_t nest_len;
 };
 
-typedef struct {
+struct vec_output {
   void *data;
   int64_t size;
-} vec_output;
+};
+
+struct vec_builder {
+  vector<vec_piece> pieces;
+  void *thread_curs;
+  int64_t elem_size;
+  int64_t starting_cap;
+  bool fixed_size;
+  void *fixed_vector;
+  pthread_mutex_t lock;
+};
 
 extern "C" {
   void weld_runtime_init();
@@ -111,4 +127,14 @@ extern "C" {
   void weld_run_set_errno(int64_t run_id, int64_t err);
 }
 
-#endif
+// Helper defines for cache size
+#define CACHE_BITS 6
+#define CACHE_LINE (1 << CACHE_BITS)
+#define CACHE_MASK (~(CACHE_LINE - 1))
+
+inline int64_t num_cache_blocks(int64_t size) {
+  // ceil of number of blocks
+  return (size + (CACHE_LINE - 1)) >> CACHE_BITS;
+}
+
+#endif // _WELD_RUNTIME_H_

--- a/weld_rt/cpp/runtime.h
+++ b/weld_rt/cpp/runtime.h
@@ -80,7 +80,7 @@ struct vec_output {
 };
 
 struct vec_builder {
-  vector<vec_piece> pieces;
+  std::vector<vec_piece> pieces;
   void *thread_curs;
   int64_t elem_size;
   int64_t starting_cap;

--- a/weld_rt/cpp/vb.cpp
+++ b/weld_rt/cpp/vb.cpp
@@ -18,16 +18,6 @@ concatenated to produce the correct output vector.
 
 using namespace std;
 
-struct vec_builder {
-  vector<vec_piece> pieces;
-  void *thread_curs;
-  int64_t elem_size;
-  int64_t starting_cap;
-  bool fixed_size;
-  void *fixed_vector;
-  pthread_mutex_t lock;
-};
-
 bool vp_compare(vec_piece one, vec_piece two) {
   for (int32_t i = 0; i < min(one.nest_len, two.nest_len); i++) {
     if (one.nest_idxs[i] != two.nest_idxs[i]) {
@@ -89,15 +79,6 @@ extern "C" void weld_rt_new_vb_piece(void *v, work_t *w) {
     cur_piece->capacity = vb->starting_cap; // larger than the real capacity for this task,
     // but it doesn't matter because the real capacity won't be reached in the fixed case
   }
-}
-
-// a non-full task executes in correct serial order (and by the same thread)
-// after its associated full task (and potentially other non-full tasks also
-// assicated with the same full task), so it can simply write into its full
-// task's piece (the cur_piece) without creating a new one
-extern "C" vec_piece *weld_rt_cur_vb_piece(void *v, int32_t my_id) {
-  vec_builder *vb = (vec_builder *)v;
-  return (vec_piece *)weld_rt_get_merger_at_index(vb->thread_curs, sizeof(vec_piece), my_id);
 }
 
 extern "C" vec_output weld_rt_result_vb(void *v) {


### PR DESCRIPTION
* Builds most of the C++ runtime library into a `libweldrt` instead of rebuilding it each time you compile a Weld module (which took about 500 ms with O2 optimizations). A few key functions are still saved as a .bc file to be inlined.
* Makes the LLVM optimization level configurable.
* Changes the way we generate code for structs to reduce the number of temporary structs stored in registers, which can slow down / confuse LLVM codegen. We use `getelementptr` on the struct to load the required field directly instead. (This can give a 20% compile time speedup).