### PR TITLE
Fix boolean equality

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -208,6 +208,27 @@ fn negated_arithmetic() {
     unsafe { free_value_and_module(ret_value) };
 }
 
+fn bool_eq() {
+    let code = "|| [(2 < 3) != (2 > 2), true == false]";
+
+    let conf = default_conf();
+
+    let ref input_data: i32 = 0;
+
+    let ret_value = compile_and_run(code, conf, input_data);
+    let data = unsafe { weld_value_data(ret_value) as *const WeldVec<bool> };
+    let result = unsafe { (*data).clone() };
+
+    assert_eq!(result.len, 2);
+
+    let bool1 = unsafe { (*result.data.offset(0)).clone() };
+    let bool2 = unsafe { (*result.data.offset(1)).clone() };
+    assert_eq!(bool1, true);
+    assert_eq!(bool2, false);
+
+    unsafe { free_value_and_module(ret_value) };
+}
+
 // TODO(shoumik): - Failing on Linux. Will fix in a in PR
 // For the C UDF integration test.
 // #[no_mangle]
@@ -2085,6 +2106,7 @@ fn main() {
              ("negation", negation),
              ("negation_double", negation_double),
              ("negated_arithmetic", negated_arithmetic),
+             ("bool_eq", bool_eq),
              //("c_udf", c_udf),
              ("f64_cast", f64_cast),
              ("i32_cast", i32_cast),
@@ -2155,7 +2177,7 @@ fn main() {
              ("simple_float_mod", simple_float_mod),
              ("simple_int_mod", simple_int_mod),
              ("predicate_if_iff_annotated", predicate_if_iff_annotated)];
-    
+
     println!("");
     println!("running tests");
     let mut passed = 0;

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -2534,10 +2534,10 @@ fn llvm_binop(op_kind: BinOpKind, ty: &Type) -> WeldResult<&'static str> {
                 Modulo if s.is_unsigned_integer() => Ok("urem"),
                 Modulo if s.is_float() => Ok("frem"),
 
-                Equal if s.is_integer() => Ok("icmp eq"),
+                Equal if s.is_integer() || s.is_bool() => Ok("icmp eq"),
                 Equal if s.is_float() => Ok("fcmp oeq"),
 
-                NotEqual if s.is_integer() => Ok("icmp ne"),
+                NotEqual if s.is_integer() || s.is_bool() => Ok("icmp ne"),
                 NotEqual if s.is_float() => Ok("fcmp one"),
 
                 LessThan if s.is_signed_integer() => Ok("icmp slt"),
@@ -2712,7 +2712,7 @@ fn predicate_only(code: &str) -> WeldResult<TypedExpr> {
     let mut e = parse_expr(code).unwrap();
     assert!(type_inference::infer_types(&mut e).is_ok());
     let mut typed_e = e.to_typed().unwrap();
-    
+
     let optstr = ["predicate"];
     let optpass = optstr.iter().map(|x| (*OPTIMIZATION_PASSES.get(x).unwrap()).clone()).collect();
 


### PR DESCRIPTION
`Equals` && `NotEquals` expressions are currently broken for boolean inputs. For example the following program:
```
|b: bool| b == false
```
...fails with the following error:
```
Unsupported binary op: == on bool
```
This issue was introduced by https://github.com/weld-project/weld/commit/7bf6469e8f018ffdea418c63d9e1051877b641b8. This PR fixes this issue by adding the required checks to `llvm.rs`.