### PR TITLE
Iterate over empty vectors

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -799,6 +799,20 @@ fn nested_if_statement_with_builders_loop() {
     unsafe { free_value_and_module(ret_value) };
 }
 
+fn empty_appender_loop() {
+    let code = "||result(for([]:vec[i32], merger[i32, +], |b, i, n| merge(b, n)))";
+    let conf = default_conf();
+
+    let ref input_data: i32 = 0;
+
+    let ret_value = compile_and_run(code, conf, input_data);
+    let data = unsafe { weld_value_data(ret_value) as *const i32 };
+    let result = unsafe { *data };
+    assert_eq!(result, 0);
+
+    unsafe { free_value_and_module(ret_value) };
+}
+
 fn simple_for_appender_loop() {
     #[allow(dead_code)]
     struct Args {
@@ -2219,6 +2233,7 @@ fn main() {
              ("exp_error", exp_error),
              ("simple_erf", simple_erf),
              ("simple_sqrt", simple_sqrt),
+             ("empty_appender_loop", empty_appender_loop),
              ("map_exp", map_exp),
              ("nested_if_statement_loop", nested_if_statement_loop),
              ("nested_if_statement_with_builders_loop", nested_if_statement_with_builders_loop),

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -384,7 +384,7 @@ impl LlvmGenerator {
             ctx.code.add(format!("{} = sub i64 {}, 1", t0, num_iters_str));
             ctx.code.add(format!("{} = mul i64 {}, {}", t1, stride_str, t0));
             ctx.code.add(format!("{} = add i64 {}, {}", t2, t1, start_str));
-            ctx.code.add(format!("{} = icmp ult i64 {}, {}", cond, t2, data_size_ll_tmp));
+            ctx.code.add(format!("{} = icmp slt i64 {}, {}", cond, t2, data_size_ll_tmp));
             ctx
                 .code
                 .add(format!("br i1 {}, label {}, label %fn.boundcheckfailed", cond, next_bounds_check_label));


### PR DESCRIPTION
It is currently impossible to iterate over empty vectors. If you try this weld will throw an `BadIteratorLength` error.

This is caused by the logic used to check iterator lengths. This calculates the end position of the iterator by applying the following steps in pseudo code:
```
val strides = numIterations - 1 // This yields -1 for an empty iterator
val delta = strides * stride // This yields -1 for an empty iterator and the normal stride size of 1
val end = start + delta // This yields -1 for an empty iterator, the normal stride size of 1 and a start of 0
if (end > numElements) {
  // Kaboom
}
```
The problem is that the comparison uses an unsigned comparison operator. `-1` will be interpreted as `2^64` which is (most likely) bigger than any input collection. This PR fixes this by using a signed comparison.