### PR TITLE
Fix the error message when NumPy is not installed.

### DIFF
--- a/python/grizzly/Makefile
+++ b/python/grizzly/Makefile
@@ -2,8 +2,13 @@ OS=$(shell uname -s)
 LLVM_VERSION=$(shell llvm-config --version | cut -d . -f 1,2)
 
 PYTHON_HEADER_INCLUDE = $(shell python-config --includes)
-NUMPY_HEADER_INCLUDE = -I$(shell python -c "import numpy; print numpy.get_include()")
+NUMPY_HEADER_INCLUDE = -I$(shell python -c "import numpy; print numpy.get_include()" 2>/dev/null)
 PYTHON_LDFLAGS = $(shell python-config --ldflags)
+
+ifeq (${NUMPY_HEADER_INCLUDE}, -I)
+  $(error NumPy is needed to be installed)
+endif
+
 ifeq (${OS}, Darwin)
   # OS X
   CLANG ?= clang

--- a/python/grizzly/Makefile
+++ b/python/grizzly/Makefile
@@ -6,7 +6,7 @@ NUMPY_HEADER_INCLUDE = -I$(shell python -c "import numpy; print numpy.get_includ
 PYTHON_LDFLAGS = $(shell python-config --ldflags)
 
 ifeq (${NUMPY_HEADER_INCLUDE}, -I)
-  $(error NumPy is needed to be installed)
+  $(error Error: NumPy installation not found)
 endif
 
 ifeq (${OS}, Darwin)


### PR DESCRIPTION
When we try to build weld without NumPy installed, the error message may somewhat confuse us.
Let's make the error message more meaningful.