### PR TITLE
Add entries to .gitignore to ignore backup files of Emacs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 target
 Cargo.lock
 .DS_Store
+\#*#
+.#*
+*~
 *.swp
 *.bc
 *.pyc


### PR DESCRIPTION
Emacs has 3 types of backup files like vim's .swp file.
I think it's better to ignore those files.