### PR TITLE
First pass adding support for multidimensional arrays [WIP]

### DIFF
--- a/python/numpy/tests/test_common.py
+++ b/python/numpy/tests/test_common.py
@@ -1,0 +1,117 @@
+import numpy as np
+import py.test
+import random
+from weldnumpy import *
+from test_utils import *
+
+'''
+TODO:
+    1. tests that preserve view properties.
+'''
+
+'''
+Tests that are common for both 1-d and multi-dimensional cases
+'''
+def test_unary_elemwise():
+    '''
+    Tests all the unary ops in UNARY_OPS.
+
+    FIXME: For now, unary ops seem to only be supported on floats.
+    '''
+    for SHAPE in SHAPES:
+        for op in UNARY_OPS:
+            for dtype in TYPES:
+                print(dtype)
+                # int still not supported for the unary ops in Weld.
+                if "int" in dtype:
+                    continue
+                np_test, w = random_arrays(SHAPE, dtype)
+                w2 = op(w)
+                np_result = op(np_test)
+                w2_eval = w2.evaluate()
+
+                assert np.allclose(w2, np_result)
+                assert np.array_equal(w2_eval, np_result)
+
+def test_binary_elemwise():
+    '''
+    '''
+    for SHAPE in SHAPES:
+        for op in BINARY_OPS:
+            for dtype in TYPES:
+                np_test, w = random_arrays(SHAPE, dtype)
+                np_test2, w2 = random_arrays(SHAPE, dtype)
+                w3 = op(w, w2)
+                weld_result = w3.evaluate()
+                np_result = op(np_test, np_test2)
+                # Need array equal to keep matching types for weldarray, otherwise
+                # allclose tries to subtract floats from ints.
+                assert np.array_equal(weld_result, np_result)
+
+def test_mix_np_weld_ops():
+    '''
+    Weld Ops + Numpy Ops - before executing any of the numpy ops, the
+    registered weld ops must be evaluateuated.
+    '''
+    for SHAPE in SHAPES:
+        np_test, w = random_arrays(SHAPE, 'float32')
+        np_test = np.exp(np_test)
+        np_result = np.sin(np_test)
+
+        w2 = np.exp(w)
+        w2 = np.sin(w2)
+        weld_result = w2.evaluate()
+        assert np.allclose(weld_result, np_result)
+
+def test_scalars():
+    '''
+    Special case of broadcasting rules - the scalar is applied to all the
+    Weldrray members.
+    '''
+    for SHAPE in SHAPES:
+        t = "int32"
+        print("t = ", t)
+        n, w = random_arrays(SHAPE, t)
+        n2 = n + 2
+        w2 = w + 2
+
+        w2 = w2.evaluate()
+        assert np.allclose(w2, n2)
+
+        # test by combining it with binary op.
+        n, w = random_arrays(SHAPE, t)
+        w += 10
+        n += 10
+
+        n2, w2 = random_arrays(SHAPE, t)
+
+        w = np.add(w, w2)
+        n = np.add(n, n2)
+
+        assert np.allclose(w, n)
+
+        t = "float32"
+        print("t = ", t)
+        np_test, w = random_arrays(SHAPE, t)
+        np_result = np_test + 2.00
+        w2 = w + 2.00
+        weld_result = w2.evaluate()
+        assert np.allclose(weld_result, np_result)
+
+def test_shapes():
+    '''
+    After creating a new array and doing some operations on it - the shape, ndim, and {other
+    atrributes?} should remain the same as before.
+    '''
+    for SHAPE in SHAPES:
+        n, w = random_arrays(SHAPE, 'float32')
+        print('view: ', w._weldarray_view)
+        n = np.exp(n)
+        w = np.exp(w)
+        print('view: ', w._weldarray_view)
+        w = w.evaluate()
+
+        assert n.shape == w.shape
+        assert n.ndim == w.ndim
+        assert n.size == w.size
+        assert np.array_equal(w, n)

--- a/python/numpy/tests/test_multid.py
+++ b/python/numpy/tests/test_multid.py
@@ -1,0 +1,282 @@
+import numpy as np
+import py.test
+import random
+from weldnumpy import *
+from test_utils import *
+
+'''
+General Notes:
+    - Two multi-dim contig arrays with different strides/shapes isn't possible.
+'''
+
+'''
+Views based tests.
+
+TODO tests:
+    - Scalars with multi-dim arrays.
+    - somehow test that for non-contig arrays, weld's loop goes over as much contiguous elements as
+      it can.
+    - scalar op view.
+    - a + other (view).
+    - Then update the view after. This should not affect a+other's result.
+'''
+# ND_SHAPES = [(5,3,4), (5,4), (6,4,7,3)]
+ND_SHAPES = [(5,3,4), (3,4)]
+
+def get_idx(shape):
+    '''
+    TODO: Need to generate idxs based on the shape parameter...
+
+    Just gives a bunch of random multi-d indices.
+    Things to test:
+        - different number of idxs
+        - different types of indexing styles (None, :, ... etc.)
+        - different sizes, strides etc.
+    '''
+    idx = []
+
+    for s in shape:
+        print('s: ', s)
+        start = random.randint(0, s-1)
+        stop = random.randint(start+1, s)
+        # step = random.randint(0, 3)
+        step = 1
+        idx.append(slice(start, stop, step))
+
+
+    return tuple(idx)
+
+def test_views_non_contig_basic():
+    shape = (5,5,5)
+    n, w = random_arrays(shape, 'float32')
+    idx = get_idx(shape)
+
+    n2 = n[idx]
+    w2 = w[idx]
+
+    # useful test to add.
+    assert w2.shape == n2.shape
+    assert w2.flags == n2.flags
+    assert w2.strides == n2.strides
+
+    # test unary op.
+    n3 = np.log(n2)
+    w3 = np.log(w2)
+    w3 = w3.evaluate()
+
+    # test binary op.
+
+    assert np.allclose(n3, w3)
+    assert np.allclose(n, w)
+
+def test_views_non_contig_inplace_unary():
+    for shape in ND_SHAPES:
+        n, w = random_arrays(shape, 'float32')
+        idx = get_idx(shape)
+
+        n2 = n[idx]
+        w2 = w[idx]
+
+        # unary op test.
+        n2 = np.sqrt(n2, out=n2)
+        w2 = np.sqrt(w2, out=w2)
+
+        assert np.allclose(n2, w2)
+        assert np.allclose(n, w)
+
+def test_views_non_contig_newarray_binary():
+    '''
+    binary involves a few cases that we need to test:
+        - non-contig + contig
+        - contig + non-contig
+        - non-contig + non-contig
+    '''
+    for shape in ND_SHAPES:
+        n, w = random_arrays(shape, 'float32')
+        n2, w2 = random_arrays(shape, 'float32')
+        idx = get_idx(shape)
+        nv1 = n[idx]
+        wv1 = w[idx]
+        nv2 = n2[idx]
+        wv2 = w2[idx]
+
+        for op in BINARY_OPS:
+            print('op = ', op)
+            nv3 = op(nv1, nv2)
+            wv3 = op(wv1, wv2)
+            wv3 = wv3.evaluate()
+
+            assert nv3.shape == wv3.shape, 'shape not same'
+
+            assert np.allclose(nv2, wv2)
+            assert np.allclose(nv1, wv1)
+            assert np.allclose(nv3, wv3)
+
+def test_views_non_contig_inplace_binary1():
+    '''
+    TODO: separate out case with updated other into new test.
+
+    binary involves a few cases that we need to test:
+    In place ops, consider the case:
+        - non-contig + non-contig
+
+    Note: these don't test for performance, for instance, if the non-contig array is being
+    evaluated with the max contiguity etc.
+    '''
+    for shape in ND_SHAPES:
+        n, w = random_arrays(shape, 'float32')
+        n2, w2 = random_arrays(shape, 'float32')
+        idx = get_idx(shape)
+        print('idx : ', idx)
+
+        nv1 = n[idx]
+        wv1 = w[idx]
+        nv2 = n2[idx]
+        wv2 = w2[idx]
+
+        # update other from before.
+        # important: we need to make sure the case with the second array having some operations
+        # stored in it is dealt with.
+        wv2 = np.sqrt(wv2, out=wv2)
+        nv2 = np.sqrt(nv2, out=nv2)
+
+        for op in BINARY_OPS:
+            print('op = ', op)
+            nv1 = op(nv1, nv2, out=nv1)
+            wv1 = op(wv1, wv2, out=wv1)
+
+            # when we evaluate a weldarray_view, the view properties (parent array etc) must be preserved in the
+            # returned array.
+            wv1 = wv1.evaluate()
+
+            # print(wv1.flags)
+            # print(wv1._weldarray_weldview)
+            # print('nv1: ', nv1)
+            # print('wv1: ', wv1)
+
+            assert np.allclose(nv2, wv2)
+            assert np.allclose(nv1, wv1)
+            assert np.allclose(n, w)
+            assert np.allclose(n2, w2)
+
+            print('***********ENDED op {} ************'.format(op))
+        print('***********ENDED shape {} ************'.format(shape))
+
+def test_views_non_contig_inplace_binary2():
+    '''
+    binary involves a few cases that we need to test:
+    In place ops:
+        - contig + non-contig
+        - non-contig + contig
+            - surprisingly these two cases aren't so trivial because we can't just loop over the
+              contiguous array as there would be no clear way to map the indices to the non-contig
+              case.
+            - it might even be better sometimes for performance to convert the non-contig case to
+              contig?
+
+    These cases are similar to the newarray cases though and both these tests should pass together
+    based on current implementation.
+    TODO: write the test.
+    '''
+    for shape in ND_SHAPES:
+        n, w = random_arrays(shape, 'float32')
+        n2, w2 = random_arrays(shape, 'float32')
+        idx = get_idx(shape)
+        # TODO: write test.
+        pass
+
+def test_views_non_contig_inplace_other_updates():
+    '''
+    '''
+    for shape in ND_SHAPES:
+        n, w = random_arrays(shape, 'float32')
+        n2, w2 = random_arrays(shape, 'float32')
+        idx = get_idx(shape)
+
+        nv1 = n[idx]
+        wv1 = w[idx]
+        nv2 = n2[idx]
+        wv2 = w2[idx]
+
+        # update other from before.
+        # important: we need to make sure the case with the second array having some operations
+        # stored in it is dealt with.
+        wv2 = np.sqrt(wv2, out=wv2)
+        nv2 = np.sqrt(nv2, out=nv2)
+        # wv2 = wv2.evaluate()
+
+        op = np.subtract
+        nv1 = op(nv1, nv2, out=nv1)
+        wv1 = op(wv1, wv2, out=wv1)
+
+        nv2 = np.log(nv2, out=nv2)
+        wv2 = np.log(wv2, out=wv2)
+        wv2 = wv2.evaluate()
+
+        n2 = np.sqrt(n2, out=n2)
+        w2 = np.sqrt(w2, out=w2)
+
+        # when we evaluate a weldarray_view, the view properties (parent array etc) must be preserved in the
+        # returned array.
+        wv1 = wv1.evaluate()
+
+        assert np.allclose(nv2, wv2)
+        assert np.allclose(nv1, wv1)
+        assert np.allclose(n, w)
+        assert np.allclose(n2, w2)
+
+        print('***********ENDED shape {} ************'.format(shape))
+
+
+def test_views_non_contig_inplace_binary_mess():
+    '''
+    Just mixes a bunch of operations on top of the previous setup.
+    '''
+    for shape in ND_SHAPES:
+        n, w = random_arrays(shape, 'float32')
+        n2, w2 = random_arrays(shape, 'float32')
+        idx = get_idx(shape)
+        nv1 = n[idx]
+        wv1 = w[idx]
+        nv2 = n2[idx]
+        wv2 = w2[idx]
+        # TODO: write test.
+
+'''
+General Tests.
+'''
+def test_reshape():
+    n, w = random_arrays(36, 'float32')
+    n = n.reshape((6,6))
+    w = w.reshape((6,6))
+
+    assert isinstance(w, weldarray)
+    assert w.shape == n.shape
+    assert w.strides == n.strides
+
+'''
+TODO: Set up multi-dimensional array creation routines.
+
+    - create new arrays in different ways: transpose, reshape, concatenation, horizontal/vertical etc.
+'''
+def test_subtle_new_array():
+    pass
+    '''
+    FIXME:
+    a.T, or a.imag seem to create new weldarrays without passing through __init__. Might have to
+    create __array_finalize__ after all.
+    '''
+    # for a in attr:
+        # if a == 'imag' or a == 'T':
+            # continue
+        # print(a)
+        # print(eval('n.' + a))
+        # print(eval('w.' + a))
+
+'''
+More advanced tests.
+'''
+
+'''
+Broadcasting based tests.
+'''

--- a/python/numpy/tests/test_utils.py
+++ b/python/numpy/tests/test_utils.py
@@ -1,0 +1,44 @@
+import numpy as np
+from weldnumpy import *
+
+UNARY_OPS = [np.exp, np.log, np.sqrt]
+# TODO: Add wa.erf - doesn't use the ufunc functionality of numpy so not doing it for
+# now.
+BINARY_OPS = [np.add, np.subtract, np.multiply, np.divide]
+REDUCE_UFUNCS = [np.add.reduce, np.multiply.reduce]
+
+TYPES = ['float32', 'float64', 'int32', 'int64']
+SHAPES = [10, (2,2), (3,7), (9,1,4), (2,5,7,2)]
+NUM_ELS = 10
+
+# TODO: Create test with all other ufuncs.
+def random_arrays(shape, dtype):
+    '''
+    Generates random Weld array, and numpy array of the given num elements.
+    '''
+    # np.random does not support specifying dtype, so this is a weird
+    # way to support both float/int random numbers
+    test = np.zeros((shape), dtype=dtype)
+    test[:] = np.random.randn(*test.shape)
+    test = np.abs(test)
+    # at least add 1 so no 0's (o.w. divide errors)
+    random_add = np.random.randint(1, high=10, size=test.shape)
+    test = test + random_add
+    test = test.astype(dtype)
+
+    np_test = np.copy(test)
+    w = weldarray(test, verbose=False)
+
+    return np_test, w
+
+def given_arrays(l, dtype):
+    '''
+    @l: list.
+    returns a np array and a weldarray.
+    '''
+    test = np.array(l, dtype=dtype)
+    np_test = np.copy(test)
+    w = weldarray(test)
+
+    return np_test, w
+

--- a/python/numpy/weldnumpy/weldnumpy.py
+++ b/python/numpy/weldnumpy/weldnumpy.py
@@ -5,21 +5,31 @@ class weldarray_view():
     '''
     This can be either a parent or a child.
     '''
-    def __init__(self, base_array, parent, start, end, idx):
+    def __init__(self, base_array, parent, idx):
         '''
-        TODO: Need to add more stuff / generalize to nd case.
         TODO: Can also just use w.base instead of storing base_array here.
         @base_array: base array from which all views are derived.
-        @parent: direct parent from which this view is generated.
-        @start:  starting index of view in base_array.
-        @end:    ending index of view in base_array.
-        @idx:    the slicing notation used to generate the view.
+        @parent: direct parent from which this view is generated. It is convenient to store this
+        for evaluation.
+        @segments: list of segments (of the parent array) that belong to this view.
+        @idx: the slicing notation used to generate the view (from the parent) - for convenience in
+        _eval.
         '''
         self.base_array = base_array
         self.parent = parent
-        self.start = start
-        self.end = end
         self.idx = idx
+        # FIXME: need to have an absolute start for this welview in the parent.  does not need to
+        # be here! Can just be a separate field in the weldarray, because not only views would have
+        # it.
+
+class segment():
+    '''
+    represents one segment of a view
+    '''
+    def __init__(self, start, stop, step):
+        self.start = start
+        self.stop = stop
+        self.step = step
 
 def is_view_child(view, par):
     '''
@@ -74,7 +84,7 @@ def get_supported_types():
 
 def get_supported_suffixes():
     '''
-    Right now weld supports int32, int64, float32, float64.      
+    Right now weld supports int32, int64, float32, float64.
     '''
     suffixes = {}
     suffixes['i32'] = ''


### PR DESCRIPTION
* Contiguous multi-dimensional arrays work for all supported ops
* Handling of all common cases for non-contiguous arrays and views for
arbitrary dimensions - mostly required changes in binary_op to support
different cases like (non_contig + non_contig, non_contig + contig etc.)
* Changes to views due to using segments - breaks 1d stuff but it should
not be too hard to fix that.
* New tests + minor changes to structure of tests (common tests b/w 1-d and
multi-dimensional cases etc.)