### PR TITLE
Build refactor

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,22 +7,6 @@ fn main() {
     let status = Command::new("make")
         .arg("clean")
         .arg("-C")
-        .arg(format!("{}/python/grizzly/grizzly", project_dir))
-        .status()
-        .unwrap();
-    assert!(status.success());
-
-    let status = Command::new("make")
-        .arg("convertor")
-        .arg("-C")
-        .arg(format!("{}/python/grizzly/grizzly", project_dir))
-        .status()
-        .unwrap();
-    assert!(status.success());
-
-    let status = Command::new("make")
-        .arg("clean")
-        .arg("-C")
         .arg(format!("{}/weld_rt/cpp/", project_dir))
         .status()
         .unwrap();

--- a/python/README.md
+++ b/python/README.md
@@ -4,7 +4,7 @@ This directory contains the Weld Python API and the Grizzly implementation.
 
 ### Prerequisites
 
-Build and run tests for Weld (the instructions for this are in the main `README.md`).
+Build and run tests for Weld (the instructions for this are in the main `README.md`. <br />
 Make sure the `WELD_HOME` environment variable is set as detailed in the main
 `README.md`.
 
@@ -22,11 +22,11 @@ Otherwise, run:
 $ cd pyweld;  python setup.py install; cd ..
 ```
 
-The script setup.py will call `cargo build --release`.
-The generated libweld binary will be copied to the appropriate directory.
-In developer mode, `libweld` will be copied to the weld directory which contains the source code. 
-In install mode, `libweld` will be copied to to build/lib.macosx-10.7-x86_64-2.7/weld.
-Note that the tag name following `lib` depends on both the platform and python version.
+Note that setup.py will call `cargo build --release`. <br />
+The generated libweld binary will be copied to the appropriate directory. <br />
+In developer mode, `libweld` will be copied to the weld directory. <br /> 
+In install mode, `libweld` will be copied to to build/lib.macosx-10.7-x86_64-2.7/weld. <br />
+Note that the tag name following `lib` depends on both the platform and python version. <br />
 
 Alternatively, you can install our pre-build PyPI packages,
 
@@ -48,9 +48,9 @@ Otherwise, run:
 ```
 
 Grizzly is packaged as a source dstribution and so will include `numpy_weld_convertor.cpp`, `common.h`, and `Makefile`.
-When installed it will call `make` to compile the numpy_weld_convertor dynamic library.
+During installation setup.py will call `make` to compile the numpy_weld_convertor dynamic library.
 
-Note: you must have Weld's Python API installed before installing Grizzly.
+Note: You must have Weld's Python API installed before installing Grizzly.
 
 ### Updating Weld and Grizzly
 
@@ -71,7 +71,8 @@ $ cd grizzly; python setup.py install; cd ..
 The python bindings and grizzly have been tested on OSX, and Ubuntu 16.04 and 14.04.
 You may run into the following runtime error:
 
-```/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site.py", line 231, in getuserbase
+```bash
+ /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site.py", line 231, in getuserbase
    USER_BASE = get_config_var('userbase')
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/sysconfig.py", line 520, in get_config_var
    return get_config_vars().get(name)
@@ -79,8 +80,9 @@ You may run into the following runtime error:
    import re
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/re.py", line 108, in <module>
    import _locale
-SystemError: dynamic module not initialized properly```
+SystemError: dynamic module not initialized properly
+```
 
 This can be resolved by upgrading pip to the latest version.
 If you are using a virtual environment, make sure to also have pip installed within the virtual environment.
-The root cause of these issues is that the python interpreter used for installation is different from the interpreter used at runtime.
+The root cause is that the python interpreter used for installation is different from the interpreter used at runtime.

--- a/python/README.md
+++ b/python/README.md
@@ -44,7 +44,7 @@ $ cd grizzly; python setup.py develop; cd ..
 
 Otherwise, run:
 ```bash
-# cd grizzly; python setup.py install; cd ..
+$ cd grizzly; python setup.py install; cd ..
 ```
 
 Grizzly is packaged as a source dstribution and so will include `numpy_weld_convertor.cpp`, `common.h`, and `Makefile`.

--- a/python/README.md
+++ b/python/README.md
@@ -10,23 +10,47 @@ Make sure the `WELD_HOME` environment variable is set as detailed in the main
 
 ### Setup
 
-If you want to install Weld's Python API and Grizzly in 'development' mode, run:
+#### Installing Weld's Python API
+
+If you want to install Weld's Python API in `development` mode, run:
 ```bash
 $ cd pyweld;  python setup.py develop; cd ..
-$ cd grizzly; python setup.py develop; cd ..
 ```
 
 Otherwise, run:
 ```bash
 $ cd pyweld;  python setup.py install; cd ..
-$ cd grizzly; python setup.py install; cd ..
 ```
 
+The script setup.py will call `cargo build --release`.
+The generated libweld binary will be copied to the appropriate directory.
+In developer mode, `libweld` will be copied to the weld directory which contains the source code. 
+In install mode, `libweld` will be copied to to build/lib.macosx-10.7-x86_64-2.7/weld.
+Note that the tag name following `lib` depends on both the platform and python version.
+
 Alternatively, you can install our pre-build PyPI packages,
+
 ```bash
 $ pip install pyweld
 $ pip install pygrizzly
 ```
+
+#### Installing Grizzly
+
+If you want to install Grizzly in 'development' mode, run:
+```bash
+$ cd grizzly; python setup.py develop; cd ..
+```
+
+Otherwise, run:
+```bash
+# cd grizzly; python setup.py install; cd ..
+```
+
+Grizzly is packaged as a source dstribution and so will include `numpy_weld_convertor.cpp`, `common.h`, and `Makefile`.
+When installed it will call `make` to compile the numpy_weld_convertor dynamic library.
+
+Note: you must have Weld's Python API installed before installing Grizzly.
 
 ### Updating Weld and Grizzly
 
@@ -41,3 +65,22 @@ $ git pull
 $ cd pyweld;  python setup.py install; cd ..
 $ cd grizzly; python setup.py install; cd ..
 ```
+
+### Troubleshooting
+
+The python bindings and grizzly have been tested on OSX, and Ubuntu 16.04 and 14.04.
+You may run into the following runtime error:
+
+```/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site.py", line 231, in getuserbase
+   USER_BASE = get_config_var('userbase')
+ File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/sysconfig.py", line 520, in get_config_var
+   return get_config_vars().get(name)
+ File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/sysconfig.py", line 453, in get_config_vars
+   import re
+ File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/re.py", line 108, in <module>
+   import _locale
+SystemError: dynamic module not initialized properly```
+
+This can be resolved by upgrading pip to the latest version.
+If you are using a virtual environment, make sure to also have pip installed within the virtual environment.
+The root cause of these issues is that the python interpreter used for installation is different from the interpreter used at runtime.

--- a/python/grizzly/setup.py
+++ b/python/grizzly/setup.py
@@ -7,6 +7,7 @@ import sys
 from setuptools import setup, Distribution
 import setuptools.command.build_ext as _build_ext
 from setuptools.command.install import install
+from setuptools.command.develop import develop
 
 system = platform.system()
 if system == 'Linux':
@@ -30,6 +31,18 @@ class Install(install):
         if subprocess.call(protoc_command_make, shell=True) != 0:
             sys.exit(-1)
 
+class Develop(develop):
+    def run(self):
+        develop.run(self)
+        python_executable = sys.executable
+        protoc_command_clean = ["make -C grizzly/ clean"]
+        if subprocess.call(protoc_command_clean, shell=True) != 0:
+            sys.exit(-1)
+
+        protoc_command_make = ["make -C grizzly/ EXEC=" + python_executable]
+        if subprocess.call(protoc_command_make, shell=True) != 0:
+            sys.exit(-1)
+
 class BinaryDistribution(Distribution):
     def has_ext_modules(self):
         return True
@@ -38,7 +51,7 @@ setup(name='pygrizzly',
       version='0.0.1',
       packages=['grizzly'],
       package_data = {'grizzly': ['numpy_weld_convertor.cpp', 'common.h', 'Makefile']},
-      cmdclass={"install": Install},
+      cmdclass={"install": Install, "develop": Develop},
       distclass=BinaryDistribution,
       url='https://github.com/weld-project/weld',
       author='Weld Developers',

--- a/python/grizzly/setup.py
+++ b/python/grizzly/setup.py
@@ -22,15 +22,19 @@ class Install(install):
     def run(self):
         install.run(self)
         python_executable = sys.executable
-        protoc_command = ["make -C " + self.install_lib + "grizzly/ EXEC=" + python_executable]
-        if subprocess.call(protoc_command, shell=True) != 0:
+        protoc_command_clean = ["make -C " + self.install_lib + "grizzly clean"]
+        if subprocess.call(protoc_command_clean, shell=True) != 0:
+            sys.exit(-1)
+
+        protoc_command_make = ["make -C " + self.install_lib + "grizzly/ EXEC=" + python_executable]
+        if subprocess.call(protoc_command_make, shell=True) != 0:
             sys.exit(-1)
 
 class BinaryDistribution(Distribution):
     def has_ext_modules(self):
         return True
 
-setup(name='grizzly',
+setup(name='pygrizzly',
       version='0.0.1',
       packages=['grizzly'],
       package_data = {'grizzly': ['numpy_weld_convertor.cpp', 'common.h', 'Makefile']},

--- a/python/pyweld/setup.py
+++ b/python/pyweld/setup.py
@@ -6,6 +6,7 @@ import sys
 
 from setuptools import setup, Distribution
 import setuptools.command.build_ext as _build_ext
+from setuptools.extension import Extension
 
 system = platform.system()
 if system == 'Linux':
@@ -17,8 +18,10 @@ elif system == 'Darwin':
 else:
     raise OSError("Unsupported platform {}", system)
 
-libweld = os.environ["WELD_HOME"] + "/target/release/" + libweld
+libweld_dir = os.environ["WELD_HOME"] + "/target/release/"
+libweld = libweld_dir + libweld
 
+module1 = Extension('weld', sources=[], libraries=['weld'], library_dirs=[libweld_dir])
 
 class build_ext(_build_ext.build_ext):
     def run(self):
@@ -45,4 +48,5 @@ setup(name='pyweld',
       url='https://github.com/weld-project/weld',
       author='Weld Developers',
       author_email='weld-group@lists.stanford.edu',
-      install_requires=['pandas', 'numpy'])
+      install_requires=['pandas', 'numpy'],
+      ext_modules=[module1])

--- a/python/pyweld/setup.py
+++ b/python/pyweld/setup.py
@@ -6,6 +6,7 @@ import sys
 
 from setuptools import setup, Distribution
 import setuptools.command.build_ext as _build_ext
+from setuptools.command.develop import develop
 from setuptools.extension import Extension
 
 system = platform.system()
@@ -20,19 +21,36 @@ else:
 
 libweld_dir = os.environ["WELD_HOME"] + "/target/release/"
 libweld = libweld_dir + libweld
-
 module1 = Extension('weld', sources=[], libraries=['weld'], library_dirs=[libweld_dir])
 
+is_develop_command = False
 class build_ext(_build_ext.build_ext):
     def run(self):
         if not os.path.exists(libweld):
             subprocess.call("cargo build --release", shell=True)
-        self.move_file(libweld, "weld")
+        if not is_develop_command:
+            self.move_file(libweld, "weld")
 
     def move_file(self, filename, directory):
         source = filename
         dir, name = os.path.split(source)        
         destination = os.path.join(self.build_lib + "/" + directory + "/", name)
+        print("Copying {} to {}".format(source, destination))
+        shutil.copy(source, destination)
+
+class Develop(develop):
+    def run(self):
+        global is_develop_command
+        if not os.path.exists(libweld):
+            subprocess.call("cargo build --release", shell=True)
+        self.move_file(libweld, "weld")
+        is_develop_command = True
+        develop.run(self)
+
+    def move_file(self, filename, directory):
+        source = filename
+        dir, name = os.path.split(source)
+        destination = os.path.join(directory + "/", name)
         print("Copying {} to {}".format(source, destination))
         shutil.copy(source, destination)
 
@@ -43,7 +61,7 @@ class BinaryDistribution(Distribution):
 setup(name='pyweld',
       version='0.0.1',
       packages=['weld'],
-      cmdclass={"build_ext": build_ext},
+      cmdclass={"build_ext": build_ext, "develop": Develop},
       distclass=BinaryDistribution,
       url='https://github.com/weld-project/weld',
       author='Weld Developers',


### PR DESCRIPTION
1. Removes the make commands from build.rs that were used to build the convertor dylib.
2. Change the package name grizzly to pygrizzly
3. Added a binary extension for libweld in pyweld/setup.py which somehow allowed auditwheel to stop complaining about libweld.so being part of the python wheel. I could run auditwheel successfully and it changed the platform tag which allowed me to upload to pypi. 