### PR TITLE
Fixes vectorization bug

### DIFF
--- a/weld/vectorizer.rs
+++ b/weld/vectorizer.rs
@@ -326,6 +326,12 @@ pub fn predicate(e: &mut Expr<Type>) {
 /// Vectorize an expression.
 pub fn vectorize(expr: &mut Expr<Type>) {
     let mut vectorized = false;
+    // Used to create the identifiers which refer to the data items. These identifiers are
+    // used to pull out the iter into a let statement. This lets us repeat the iter via an
+    // identifier in the vectorized loop later. Declaring this before any transformations so
+    // there is no clash of variable names.
+    let mut sym_gen = SymbolGenerator::from_expression(expr);
+
     expr.transform_and_continue_res(&mut |ref mut expr| {
         //  The Res is a stricter-than-necessary check, but prevents us from having to check nested
         //  loops for now.
@@ -345,11 +351,6 @@ pub fn vectorize(expr: &mut Expr<Type>) {
                         vectorized_params[2].ty = vectorized_params[2].ty.simd_type()?;
 
                         let vec_func = exprs::lambda_expr(vectorized_params, *vectorized_body)?;
-
-                        // Pull out the iter into a let statement. This lets us repeat the
-                        // iter via an identifier in the vectorized loop. Here, we just
-                        // create the identifiers which refer to the data items.
-                        let mut sym_gen = SymbolGenerator::from_expression(expr);
 
                         let data_names = iters
                             .iter()


### PR DESCRIPTION
*Originallly, after vectorization, we were getting code like:

  (let a=(e0);(let a#1=((let a=((let a=(e1);result(
    for(
      fringeiter(a),
      for(
        simditer(a),
        appender[f32],
        |b,i,x|
          merge(b,(sqrt(x)))
      ),
      |b,i,x|
        merge(b,(sqrt(x)))
    )
  )));(let a#1=(e2);result(...
  ...
  ))))))

So variable names were being reused. Re-using the variable names seems
to work in some cases - the scoping rules aren't entirely clear to me...
but by declaring the symbol_generator before the transformation calls,
we are able to get unique symbol names for the let statements (a,
a#1, a#2 etc.) - which fixes the tets "blackscholes_bug", and
"vectorization_bug", from the numpy tests.