### PR TITLE
Add function tracing to parse errors

### DIFF
--- a/weld/parser.rs
+++ b/weld/parser.rs
@@ -140,6 +140,16 @@ impl<'t> Parser<'t> {
         }
     }
 
+    /// Consume the next token and check that it equals `expected`. If not, return an Err.
+    /// Calling functions can pass in their name to display to the user.
+    fn consume_with_fn(&mut self, expected: Token, fn_str: &str) -> WeldResult<()> {
+        if *self.next() != expected {
+            weld_err!("Expected '{}' in {}", expected, fn_str)
+        } else {
+            Ok(())
+        }
+    }
+
     /// Are we done parsing all the input?
     fn is_done(&self) -> bool {
         self.position == self.tokens.len() || *self.peek() == TEndOfInput

--- a/weld/parser.rs
+++ b/weld/parser.rs
@@ -141,10 +141,14 @@ impl<'t> Parser<'t> {
     }
 
     /// Consume the next token and check that it equals `expected`. If not, return an Err.
-    /// Calling functions can pass in their name to display to the user.
-    fn consume_with_fn(&mut self, expected: Token, fn_str: &str) -> WeldResult<()> {
+    /// Calling functions can pass in an error to display to the user.
+    fn consume_with_err(&mut self, expected: Token, fn_str: &str, err_str: &str) -> WeldResult<()> {
         if *self.next() != expected {
-            weld_err!("Expected '{}' in {}", expected, fn_str)
+            if err_str.len() > 0 {
+                weld_err!("Expected '{}' in {}: {}", expected, fn_str, err_str)
+            } else {
+                weld_err!("Expected '{}' in {}", expected, fn_str)
+            }
         } else {
             Ok(())
         }


### PR DESCRIPTION
A small change to aid parse debugging (e.g. TComma error is ambiguous without caller name)