### PR TITLE
Change Exception to AttributeError in Grizzly wrappers

### DIFF
--- a/python/grizzly/grizzly/grizzly.py
+++ b/python/grizzly/grizzly/grizzly.py
@@ -127,7 +127,7 @@ class DataFrameWeld:
                     weld_type,
                     dim
                 )
-        raise Exception("Attr %s does not exist" % key)
+        raise AttributeError("Attr %s does not exist" % key)
 
     def _get_column_names(self):
         """Summary
@@ -311,7 +311,7 @@ class SeriesWeld(LazyOpResult):
                 self.df,
                 self.column_name
             )
-        raise Exception("Attr %s does not exist" % key)
+        raise AttributeError("Attr %s does not exist" % key)
 
     def unique(self):
         """Summary


### PR DESCRIPTION
In DataFrameWeld and SeriesWeld, there are custom __getattr__ handlers
implemented that raise Exception if asked for an unsupported key. Since
these do not implement the __dir__ handler, this causes default dir()
functionality to break, since the behavior of dir() is to first ask for
the __dir__ attribute if it exists, and then fall back to some default
behavior if it catches an AttributeError. Since it only catches
AttributeError and not Exception, dir() no longer works, notably
preventing autocomplete for interactive environments like ipython
notebooks. We provide the straightforward fix in this commit by simply
raising AttributeError instead of Exception in the implementation of
__getattr__ for these classes.

Note that things that are retrieved through __getattr__, such as
'values' for SeriesWeld, will still not work with autocomplete, since
the default dir() implementation is unaware of things that are retrieved
by falling back to __getattr__.

This commit fixes #255 