### PR TITLE
Debug options to write Weld, SIR, and LLVM code to a file

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -183,8 +183,8 @@ weld_error_free(weld_error_t);
 ## Configurations
 
 A configuration specifies tunable parameters when generating and running code. The table below
-specifies some _runtime_ options that can be tuned by using configurations. Right now,
-configurations are not used during compile time.
+specifies some example that can be tuned by using configurations (where both keys and values
+are encoded as C strings.
 
   Configuration | Value
   ------------- | -------------

--- a/docs/language.md
+++ b/docs/language.md
@@ -62,7 +62,8 @@ The core language consists of the following expressions:
   `f32` | `1.0f`, `1.0F`
   `f64` | `1.0`
 
-* Arithmetic expressions, e.g. `a + b`, `a - b`, `-a`, `a & b`, etc.
+* Arithmetic expressions, e.g., `a + b`, `a - b`, `-a`, `a & b`, `min(a,b)`, `max(a,b)`, etc.
+* Some math expressions, e.g., `exp`, `sqrt`, `log`.
 * Let expressions, which introduce a new variable. The syntax for these is `let name = expr; body`. This evaluates `expr`, assigns it to the variable `name`, and then evaluates `body` with that binding and returns its result.
 * `if(condition, on_true, on_false)`, which evaluates `on_true` or `on_false` based on the value of `condition`.
 * `iterate(initial_value, update_func)`, which performs a sequential loop. `initial_value`  can be any type `T`, and `update_func` must be of type `T => {T, bool}`. We call `update_func` repeatedly on the value until the boolean it returns is `false`, and then return the `T` field in its output as the final value of the expression.

--- a/weld/lib.rs
+++ b/weld/lib.rs
@@ -325,12 +325,7 @@ pub unsafe extern "C" fn weld_module_compile(code: *const c_char,
     }
 
     info!("Started compiling program");
-    let module = llvm::compile_program(
-        &parsed.unwrap(),
-        &conf.optimization_passes,
-        conf.llvm_optimization_level,
-        conf.support_multithread,
-        &mut stats);
+    let module = llvm::compile_program(&parsed.unwrap(), &conf, &mut stats);
     info!("Done compiling program");
 
     if let Err(ref e) = module {

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -10,6 +10,10 @@ use time::PreciseTime;
 
 use common::WeldRuntimeErrno;
 
+use std::io::Write;
+use std::path::PathBuf;
+use std::fs::OpenOptions;
+
 use super::ast::*;
 use super::ast::Type::*;
 use super::ast::LiteralKind::*;
@@ -31,6 +35,8 @@ use super::type_inference;
 use super::util::IdGenerator;
 use super::util::WELD_INLINE_LIB;
 use super::annotations::*;
+
+use super::conf::ParsedConf;
 
 use super::CompilationStats;
 
@@ -73,7 +79,7 @@ pub fn apply_opt_passes(expr: &mut TypedExpr, opt_passes: &Vec<Pass>, stats: &mu
 }
 
 /// Generate a compiled LLVM module from a program whose body is a function.
-pub fn compile_program(program: &Program, opt_passes: &Vec<Pass>, llvm_opt_level: u32, multithreaded: bool, stats: &mut CompilationStats)
+pub fn compile_program(program: &Program, conf: &ParsedConf, stats: &mut CompilationStats)
         -> WeldResult<easy_ll::CompiledModule> {
     let mut expr = macro_processor::process_program(program)?;
     trace!("After macro substitution:\n{}\n", print_typed_expr(&expr));
@@ -91,7 +97,7 @@ pub fn compile_program(program: &Program, opt_passes: &Vec<Pass>, llvm_opt_level
     let end = PreciseTime::now();
     stats.weld_times.push(("Type Inference".to_string(), start.to(end)));
 
-    apply_opt_passes(&mut expr, opt_passes, stats)?;
+    apply_opt_passes(&mut expr, &conf.optimization_passes, stats)?;
 
     let start = PreciseTime::now();
     transforms::uniquify(&mut expr)?;
@@ -103,14 +109,14 @@ pub fn compile_program(program: &Program, opt_passes: &Vec<Pass>, llvm_opt_level
     debug!("Optimized Weld program:\n{}\n", print_expr(&expr));
 
     let start = PreciseTime::now();
-    let sir_prog = sir::ast_to_sir(&expr, multithreaded)?;
+    let sir_prog = sir::ast_to_sir(&expr, conf.support_multithread)?;
     debug!("SIR program:\n{}\n", &sir_prog);
     let end = PreciseTime::now();
     stats.weld_times.push(("AST to SIR".to_string(), start.to(end)));
 
     let start = PreciseTime::now();
     let mut gen = LlvmGenerator::new();
-    gen.multithreaded = multithreaded;
+    gen.multithreaded = conf.support_multithread;
 
     gen.add_function_on_pointers("run", &sir_prog)?;
     let llvm_code = gen.result();
@@ -121,7 +127,7 @@ pub fn compile_program(program: &Program, opt_passes: &Vec<Pass>, llvm_opt_level
     debug!("Started compiling LLVM");
     let (module, llvm_times) = try!(easy_ll::compile_module(
         &llvm_code,
-        llvm_opt_level,
+        conf.llvm_optimization_level,
         Some(WELD_INLINE_LIB)));
     debug!("Done compiling LLVM");
 
@@ -139,7 +145,40 @@ pub fn compile_program(program: &Program, opt_passes: &Vec<Pass>, llvm_opt_level
     let end = PreciseTime::now();
     stats.weld_times.push(("Runtime Init".to_string(), start.to(end)));
 
+    // Dump files if needed.
+    if conf.dump_code.enabled {
+        let ref timestamp = format!("{}", time::now().to_timespec().sec);
+        info!("Writing code to directory '{}' with timestamp {}", &conf.dump_code.dir.display(), timestamp);
+
+        write_code(&print_typed_expr(&expr), "weld", timestamp, &conf.dump_code.dir);
+        write_code(&format!("{}", &sir_prog), "sir", timestamp, &conf.dump_code.dir);
+        write_code(&llvm_code, "ll", timestamp, &conf.dump_code.dir);
+    }
+
     Ok(module)
+}
+
+/// Writes code to a file specified by `PathBuf`. Writes a log message if it failed.
+fn write_code(code: &str, ext: &str, timestamp: &str, dir_path: &PathBuf) {
+    let mut options = OpenOptions::new();
+    options.write(true)
+        .create_new(true)
+        .create(true);
+    let ref mut path = dir_path.clone();
+    path.push(format!("code-{}", timestamp));
+    path.set_extension(ext);
+
+    let ref path_str = format!("{}", path.display());
+    match options.open(path) {
+        Ok(ref mut file) => {
+            if let Err(_) = file.write_all(code.as_bytes()) {
+                error!("Write failed: could not write code to file {}", path_str);
+            }
+        }
+        Err(_) => {
+            error!("Open failed: could not write code to file {}", path_str);
+        }
+    }
 }
 
 /// Stores whether the code generator has created certain helper functions for a given type.


### PR DESCRIPTION
This adds the `weld.compile.dumpCode` and `weld.compile.dumpCodeDir` options to the weld configuration. The former causes Weld, SIR, and LLVM code to be dumped to separate files, and the latter specifies the directory to write the files to.

In the REPL, these options can be set using `setconf`, or can be set using the command line options `-D <logdir>` and the flag `-d` (to enable code dumping).