### PR TITLE
C++ Header Generation Tooling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,12 @@ name = "repl"
 path = "weld/bin/repl.rs"
 bench = false
 
+
+[[bin]]
+name = "hdrgen"
+path = "weld/bin/hdrgen.rs"
+bench = false
+
 [[test]]
 name = "integration_tests"
 path = "tests/integration_tests.rs"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can join the discussion on Weld on our [Google Group](https://groups.google.
       - [Building Weld](#building-weld)
   * [Documentation](#documentation)
   * [Grizzly (Pandas on Weld)](#grizzly)
-  * [Running an Interactive REPL](#interactive-repl)
+  * [Tools](#tools)
 
 ## Building
 
@@ -114,43 +114,12 @@ To run Grizzly, you will also need the `WELD_HOME` environment variable to be se
    cargo test <substring to match in test name>
    ```
 
-## Interactive REPL
+## Tools
 
-The `target/release/repl` program is a simple "shell" where one can type Weld programs and see the results of parsing, macro substitution and type inference.
-
-Example `repl` session:
-```
-$ ./target/debug/repl
-> let a = 5 + 2; a + a
-Raw structure: [...]
-
-After macro substitution:
-let a=((5+2));(a+a)
-
-After inlining applies:
-let a=((5+2));(a+a)
-
-After type inference:
-let a:i32=((5+2));(a:i32+a:i32)
-
-Expression type: i32
-
-> map([1, 2], |x| x+1)
-Raw structure: [...]
-
-After macro substitution:
-result(for([1,2],appender[?],|b,x|merge(b,(|x|(x+1))(x))))
-
-After inlining applies:
-result(for([1,2],appender[?],|b,x|merge(b,(x+1))))
-
-After type inference:
-result(for([1,2],appender[i32],|b:appender[i32],x:i32|merge(b:appender[i32],(x:i32+1))))
-
-Expression type: vec[i32]
-```
-
-Passing a `Lambda` expression will also perform LLVM code generation - other expression types will only perform parsing, type inference, and IR transformations.
+This repository contains a number of useful command line tools which are built
+automatically with the main Weld repository, including an interactive REPL for
+inspecting and debugging programs.  More information on those tools can be
+found under [docs/tools.md](https://github.com/weld-project/weld/tree/master/docs/tools.md).
 
 ## Current performance metrics
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,68 @@
+
+The Weld repository contains a few command line tools to facilitate development.
+
+
+* [REPL](#repl)
+* [Header Generation](#header-generation)
+
+## REPL
+
+The `target/release/repl` program is a simple "shell" where one can type Weld programs and see the results of parsing, macro substitution and type inference.
+
+Example `repl` session:
+```
+$ ./target/debug/repl
+> let a = 5 + 2; a + a
+Raw structure: [...]
+
+After macro substitution:
+let a=((5+2));(a+a)
+
+After inlining applies:
+let a=((5+2));(a+a)
+
+After type inference:
+let a:i32=((5+2));(a:i32+a:i32)
+
+Expression type: i32
+
+> map([1, 2], |x| x+1)
+Raw structure: [...]
+
+After macro substitution:
+result(for([1,2],appender[?],|b,x|merge(b,(|x|(x+1))(x))))
+
+After inlining applies:
+result(for([1,2],appender[?],|b,x|merge(b,(x+1))))
+
+After type inference:
+result(for([1,2],appender[i32],|b:appender[i32],x:i32|merge(b:appender[i32],(x:i32+1))))
+
+Expression type: vec[i32]
+```
+
+Passing a `Lambda` expression will also perform LLVM code generation - other expression types will only perform parsing, type inference, and IR transformations.
+
+## Header Generation
+
+The `target/release/hdrgen` program takes a Weld program and generates a C++ header file, containing the argument and return types for the Weld program. Example:
+
+```bash
+$ cat program.weld
+|s: {i32,i32,f32}| [s, s, s]
+$ target/release/hdrgen -i program.weld
+#ifndef _WELD_CPP_HEADER_
+#define _WELD_CPP_HEADER_
+
+// THIS IS A GENERATED C++ FILE.
+
+#include <stdint.h> // For explicitly sized integer types.
+#include <stdlib.h> // For malloc
+
+// Defines Weld's primitive numeric types.
+typedef bool        i1;
+
+<some more generated code>
+
+#endif /* _WELD_CPP_HEADER_ */
+```

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -43,6 +43,9 @@ Expression type: vec[i32]
 
 Passing a `Lambda` expression will also perform LLVM code generation - other expression types will only perform parsing, type inference, and IR transformations.
 
+The REPL tool can also take a number of options (e.g., to compile a Weld program into LLVM or set the logging level).
+Run `target/release/repl --help` to see the available options.
+
 ## Header Generation
 
 The `target/release/hdrgen` program takes a Weld program and generates a C++ header file, containing the argument and return types for the Weld program. Example:

--- a/weld/bin/hdrgen.rs
+++ b/weld/bin/hdrgen.rs
@@ -1,0 +1,186 @@
+//! Generates headers for a Weld program.
+
+#[macro_use]
+extern crate weld;
+extern crate libc;
+extern crate clap;
+
+use weld::*;
+use weld::common::*;
+
+use clap::{Arg, App};
+
+use std::ffi::{CStr, CString};
+use libc::c_char;
+use std::collections::HashMap;
+
+use std::path::Path;
+use std::fs::File;
+use std::error::Error;
+use std::io::prelude::*;
+
+use weld::code_builder::CodeBuilder;
+use weld::util::IdGenerator;
+
+use weld::ast::*;
+use weld::error::*;
+
+static PRELUDE_CODE: &'static str = include_str!("resources/cpp_prelude.h");
+
+#[derive(Debug,Clone,PartialEq,Eq)]
+struct LambdaTypes {
+    param_types: Vec<Type>,
+    return_type: Type,
+}
+
+fn parse_weld_lambda(code: &str) -> WeldResult<LambdaTypes> {
+    unsafe {
+        let code = CString::new(code).unwrap();
+        let err = weld_error_new();
+        let conf = weld_conf_new();
+        let module = weld_module_compile(code.into_raw() as *const c_char, conf, err);
+        if weld_error_code(err) != WeldRuntimeErrno::Success {
+            return weld_err!("Compile error: {}",
+                     CStr::from_ptr(weld_error_message(err)).to_str().unwrap());
+        }
+        weld_error_free(err);
+        weld_conf_free(conf);
+
+        let module_ref = &*module;
+
+        let result = LambdaTypes {
+            return_type: module_ref.return_type().clone(),
+            param_types: module_ref.param_types().clone(),
+        };
+        
+        // Don't actually need the code, just the types.
+        weld_module_free(module);
+        Ok(result)
+    }
+}
+
+struct CppHeaderGenerator {
+    /// List of already generated types.
+    generated_types: HashMap<Type, String>,
+    struct_names: IdGenerator,
+    code: CodeBuilder, 
+}
+
+impl CppHeaderGenerator {
+    /// Return a new header generator for C++.
+    fn new() -> CppHeaderGenerator {
+        CppHeaderGenerator{
+            generated_types: HashMap::new(),
+            struct_names: IdGenerator::new("struct"),
+            code: CodeBuilder::new(),
+        }
+    }
+
+    /// Generates a new Struct definition.
+    fn generate_struct_definition(&mut self, types: &Vec<Type>) -> WeldResult<String> {
+        let struct_name = self.struct_names.next();
+        let mut names = vec![];
+        for ty in types.iter() {
+            names.push(self.generate_type(ty)?);
+        }
+        self.code.add(format!("struct {} {{", struct_name));
+        for (field, name) in names.iter().enumerate() {
+            self.code.add(format!("{} _{};", name, field)); 
+        }
+        self.code.add("};");
+        Ok(struct_name)
+    }
+
+    /// Generates a single type in returns its name.
+    fn generate_type(&mut self, ty: &Type) -> WeldResult<String> {
+        use ast::Type::*;
+        if let Some(name) = self.generated_types.get(ty) {
+            return Ok(name.to_string());
+        }
+
+        let result = match *ty {
+            Scalar(ref kind) => Ok(format!("{}", kind)),
+            Vector(ref elem) => Ok(format!("vec<{}>", self.generate_type(elem)?)),
+            Struct(ref elems) => self.generate_struct_definition(elems),
+            // Other types (Builders, Functions, etc.) cannot be passed into Weld.
+            _ => weld_err!("Invalid C++ type {:?}", ty),
+        };
+
+        if result.is_ok() {
+            self.generated_types.insert(ty.clone(), result.as_ref().unwrap().clone());
+        }
+        self.code.add("\n");
+
+        result
+    }
+
+    fn build(&mut self, types: LambdaTypes) -> String {
+        // Add the prelude code, which defines the templatized vector type vec<T> 
+        // and the primitive types (i1, i32, f32, etc.).
+        self.code.add("#ifndef _WELD_CPP_HEADER_");
+        self.code.add("#define _WELD_CPP_HEADER_");
+        self.code.add("\n");
+        self.code.add(PRELUDE_CODE);
+        self.code.add("\n");
+
+        let return_type = self.generate_type(&types.return_type)
+            .expect("Type generation failed!");
+        let param_type = self.generate_type(&ast::Type::Struct(types.param_types))
+            .expect("Type generation failed!");
+
+        self.code.add("\n");
+        self.code.add("// Aliases for argument and return types.");
+        self.code.add(format!("typedef {} input_type;", param_type));
+        self.code.add(format!("typedef {} return_type;", return_type));
+        self.code.add("\n");
+        self.code.add("#endif /* _WELD_CPP_HEADER_ */");
+        self.code.result().to_string()
+    }
+}
+
+fn read_full(arg: &str) -> WeldResult<String> {
+    let path = Path::new(arg);
+    let path_display = path.display();
+
+    let mut file = match File::open(&path) {
+        Err(why) => {
+            return weld_err!("Error: couldn't open {}: {}",
+                             path_display,
+                             why.description());
+        }
+        Ok(res) => res,
+    };
+
+    let mut contents = String::new();
+    if let Err(why) = file.read_to_string(&mut contents) {
+        return weld_err!("Error: couldn't read {}: {}",
+                         path_display,
+                         why.description());
+    }
+    Ok(contents.trim().to_string())
+}
+
+fn main() {
+    let matches = App::new("Weld Header Generator")
+        .version("0.1.0")
+        .author("Weld authors <weld-group@cs.stanford.edu")
+        .about("Generates headers for types which appear in Weld programs")
+        .arg(Arg::with_name("input")
+             .short("i")
+             .long("input")
+             .value_name("FILE")
+             .help("Weld program to generate a header for")
+             .takes_value(true))
+        .get_matches();
+
+    let code = read_full(matches.value_of("input").expect("Argument required"))
+        .expect("Invalid code file");
+
+    let type_info = parse_weld_lambda(&code)
+        .expect("Weld code compilation failed");
+
+    let mut generator = CppHeaderGenerator::new();
+    let result = generator.build(type_info);
+
+    println!("{}", result);
+}

--- a/weld/bin/resources/cpp_prelude.h
+++ b/weld/bin/resources/cpp_prelude.h
@@ -1,0 +1,32 @@
+// THIS IS A GENERATED C++ FILE.
+
+#include <stdint.h> // For explicitly sized integer types.
+#include <stdlib.h> // For malloc
+
+// Defines Weld's primitive numeric types.
+typedef bool        i1;
+typedef uint8_t     u8;
+typedef int8_t      i8;
+typedef uint16_t   u16;
+typedef int16_t    i16;
+typedef uint32_t   u32;
+typedef int32_t    i32;
+typedef uint64_t   u64;
+typedef int64_t    i64;
+typedef float      f32;
+typedef double     f64;
+
+// Defines the basic Vector struture using C++ templates.
+template<typename T>
+struct vec {
+  T *ptr;
+  i64 size;
+};
+
+template<typename T>
+vec<T> new_vec(i64 size) {
+  vec<T> t;
+  t.ptr = (T *)malloc(size * sizeof(T));
+  t.size = size;
+  return t;
+}

--- a/weld/lib.rs
+++ b/weld/lib.rs
@@ -25,6 +25,7 @@ use common::WeldRuntimeErrno;
 use common::WeldLogLevel;
 
 /// Utility macro to create an Err result with a WeldError from a format string.
+#[macro_export]
 macro_rules! weld_err {
     ( $($arg:tt)* ) => ({
         ::std::result::Result::Err($crate::error::WeldError::new(format!($($arg)*)))
@@ -64,7 +65,7 @@ extern "C" {
 }
 
 /// A clean alias for a compiled LLVM module.
-pub type WeldModule = easy_ll::CompiledModule;
+pub type WeldModule = llvm::CompiledModule;
 
 /// An error passed as an opaque pointer using the runtime API.
 pub struct WeldError {
@@ -246,7 +247,7 @@ pub unsafe extern "C" fn weld_value_data(obj: *const WeldValue) -> *const c_void
 }
 
 #[no_mangle]
-/// Returns a pointer to the data wrapped by the given Weld value.
+/// Returns a pointer to the module owning the given Weld value.
 pub unsafe extern "C" fn weld_value_module(obj: *mut WeldValue) -> *mut WeldModule {
     assert!(!obj.is_null());
     let obj = &*obj;
@@ -359,7 +360,8 @@ pub unsafe extern "C" fn weld_module_run(module: *mut WeldModule,
     assert!(!arg.is_null());
     assert!(!err_ptr.is_null());
 
-    let module_callable = &mut *module;
+    let module_ref = &mut *module;
+    let module_callable = module_ref.llvm_mut();
     let arg = &*arg;
     let mut err = &mut *err_ptr;
 
@@ -410,7 +412,7 @@ pub unsafe extern "C" fn weld_module_run(module: *mut WeldModule,
 ///
 /// Freeing a module does not free the memory it may have allocated. Values returned by the module
 /// must be freed explicitly using `weld_value_free`.
-pub unsafe extern "C" fn weld_module_free(ptr: *mut easy_ll::CompiledModule) {
+pub unsafe extern "C" fn weld_module_free(ptr: *mut WeldModule) {
     if ptr.is_null() {
         return;
     }


### PR DESCRIPTION
This PR adds a tool to generate C++ headers for argument/returns types in a Weld program. As an example, if we have the file called `program.weld` with the program:

```
|s: {i32, f32}| [s, s]
```

Running `target/release/hdrgen -i program.weld` will output the following C++ header file:

```c++
#ifndef _WELD_CPP_HEADER_
#define _WELD_CPP_HEADER_

// THIS IS A GENERATED C++ FILE.

#include <stdint.h> // For explicitly sized integer types.
#include <stdlib.h> // For malloc

// Defines Weld's primitive numeric types.
typedef bool        i1;
typedef uint8_t     u8;
typedef int8_t      i8;
typedef uint16_t   u16;
typedef int16_t    i16;
typedef uint32_t   u32;
typedef int32_t    i32;
typedef uint64_t   u64;
typedef int64_t    i64;
typedef float      f32;
typedef double     f64;

// Defines the basic Vector struture using C++ templates.
template<typename T>
struct vec {
  T *ptr;
  i64 size;
};

template<typename T>
vec<T> new_vec(i64 size) {
  vec<T> t;
  t.ptr = (T *)malloc(size * sizeof(T));
  t.size = size;
  return t;
}

struct struct0 {
  i32 _0;
  f32 _1;
};

struct struct1 {
  struct0 _0;
};

// Aliases for argument and return types.
typedef struct1 input_type;
typedef vec<struct0> return_type;

#endif /* _WELD_CPP_HEADER_ */
```

This makes it easier to write programs in C/C++ to debug Weld programs.