### PR TITLE
Add SIR Tracing as a Configuration Option

### DIFF
--- a/examples/cpp/add_repl/Makefile
+++ b/examples/cpp/add_repl/Makefile
@@ -1,5 +1,5 @@
 CC=clang++
-LDFLAGS=-L../../../target/release/
+LDFLAGS=-L../../../target/debug/
 LIBS=-lweld
 
 .PHONY: all clean

--- a/examples/cpp/add_repl/add_repl.cpp
+++ b/examples/cpp/add_repl/add_repl.cpp
@@ -12,7 +12,18 @@ int main() {
     weld_error_t e = weld_error_new();
     weld_conf_t conf = weld_conf_new();
 
-    weld_conf_set(conf, "weld.compile.multithread_support", "false");
+    // Some example configuration parameters.
+    
+    // Disable multithreading support
+    weld_conf_set(conf, "weld.compile.multithreadSupport", "false");
+
+    // Print out the SIR while we execute. This is useful for debugging a crashing
+    // program.
+    weld_conf_set(conf, "weld.compile.traceExecution", "true");
+
+    // Set a small 1KB memory memory limit for the runtime. We don't need more than
+    // that for this simple program!
+    weld_conf_set(conf, "weld.memory.limit", "1024");
 
     weld_module_t m = weld_module_compile("|x:i64| x+5L", conf, e);
     weld_conf_free(conf);

--- a/weld/conf.rs
+++ b/weld/conf.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 pub const MEMORY_LIMIT_KEY: &'static str = "weld.memory.limit";
 pub const THREADS_KEY: &'static str = "weld.threads";
 pub const SUPPORT_MULTITHREAD_KEY: &'static str = "weld.compile.multithreadSupport";
+pub const TRACE_RUN_KEY: &'static str = "weld.compile.traceExecution";
 pub const OPTIMIZATION_PASSES_KEY: &'static str = "weld.optimization.passes";
 pub const SIR_OPT_KEY: &'static str = "weld.optimization.sirOptimization";
 pub const LLVM_OPTIMIZATION_LEVEL_KEY: &'static str = "weld.llvm.optimization.level";
@@ -26,6 +27,7 @@ pub const DEFAULT_SUPPORT_MULTITHREAD: bool = true;
 pub const DEFAULT_SIR_OPT: bool = true;
 pub const DEFAULT_LLVM_OPTIMIZATION_LEVEL: u32 = 2;
 pub const DEFAULT_DUMP_CODE: bool = false;
+pub const DEFAULT_TRACE_RUN: bool = false;
 
 lazy_static! {
     pub static ref DEFAULT_OPTIMIZATION_PASSES: Vec<Pass> = {
@@ -46,6 +48,7 @@ pub struct ParsedConf {
     pub memory_limit: i64,
     pub threads: i32,
     pub support_multithread: bool,
+    pub trace_run: bool,
     pub enable_sir_opt: bool,
     pub optimization_passes: Vec<Pass>,
     pub llvm_optimization_level: u32,
@@ -86,10 +89,15 @@ pub fn parse(conf: &WeldConf) -> WeldResult<ParsedConf> {
     let sir_opt_enabled = value.map(|s| parse_bool_flag(&s, "Invalid flag for sirOptimization"))
                       .unwrap_or(Ok(DEFAULT_SIR_OPT))?;
 
+    let value = get_value(conf, TRACE_RUN_KEY);
+    let trace_run = value.map(|s| parse_bool_flag(&s, "Invalid flag for trace.run"))
+                      .unwrap_or(Ok(DEFAULT_TRACE_RUN))?;
+
     Ok(ParsedConf {
         memory_limit: memory_limit,
         threads: threads,
         support_multithread: support_multithread,
+        trace_run: trace_run,
         enable_sir_opt: sir_opt_enabled,
         optimization_passes: passes,
         llvm_optimization_level: level,

--- a/weld/resources/prelude.ll
+++ b/weld/resources/prelude.ll
@@ -47,6 +47,8 @@ declare i32 @memcmp(i8*, i8*, i64)
 declare float @erff(float)
 declare double @erf(double)
 
+declare i32 @puts(i8* nocapture) nounwind
+
 ; Weld runtime functions
 
 declare i64     @weld_run_begin(void (%work_t*)*, i8*, i64, i32)


### PR DESCRIPTION
This adds SIR tracing as a configurable option during compilation. This is based on @mateiz's earlier patch which did the same thing (but with the option to turn it off).

Also added some examples on how to set configuration options in the `add_repl` example.