### PR TITLE
Short Circuiting Booleans

### DIFF
--- a/weld/conf.rs
+++ b/weld/conf.rs
@@ -31,7 +31,7 @@ pub const DEFAULT_TRACE_RUN: bool = false;
 
 lazy_static! {
     pub static ref DEFAULT_OPTIMIZATION_PASSES: Vec<Pass> = {
-        let m = ["inline-apply", "inline-let", "inline-zip", "loop-fusion", "infer-size", "predicate", "vectorize", "fix-iterate"];
+        let m = ["inline-apply", "inline-let", "inline-zip", "loop-fusion", "infer-size", "short-circuit-booleans", "predicate", "vectorize", "fix-iterate"];
         m.iter().map(|e| (*OPTIMIZATION_PASSES.get(e).unwrap()).clone()).collect()
     };
     pub static ref DEFAULT_DUMP_CODE_DIR: PathBuf = Path::new(".").to_path_buf();

--- a/weld/passes.rs
+++ b/weld/passes.rs
@@ -4,6 +4,7 @@ use super::error::*;
 use super::transforms::loop_fusion;
 use super::transforms::inliner;
 use super::transforms::size_inference;
+use super::transforms::short_circuit;
 use super::transforms::annotator;
 use super::transforms::vectorizer;
 
@@ -70,6 +71,9 @@ lazy_static! {
         m.insert("infer-size",
                  Pass::new(vec![size_inference::infer_size],
                  "infer-size"));
+        m.insert("short-circuit-booleans",
+                 Pass::new(vec![short_circuit::short_circuit_booleans],
+                 "short-circuit-booleans"));
         m.insert("predicate",
                  Pass::new(vec![vectorizer::predicate],
                  "predicate"));

--- a/weld/transforms/mod.rs
+++ b/weld/transforms/mod.rs
@@ -6,3 +6,4 @@ pub mod inliner;
 pub mod size_inference;
 pub mod annotator;
 pub mod vectorizer;
+pub mod short_circuit;

--- a/weld/transforms/short_circuit.rs
+++ b/weld/transforms/short_circuit.rs
@@ -98,6 +98,19 @@ fn complex_and_or() {
 }
 
 #[test]
+fn complex_and_or_2() {
+    let mut e = typed_expr("|x:i32| (x > 5 && x < 10) || (x == 15)");
+    short_circuit_booleans(&mut e);
+    let ref expect = typed_expr("|x:i32|
+                    if(
+                        if (x > 5, x < 10, false),
+                        true,
+                        (x == 15)
+                    )");
+    assert!(e.compare_ignoring_symbols(expect).unwrap());
+}
+
+#[test]
 fn predicated_if() {
     let mut e = typed_expr("|x:i32| @(predicate:true) if (x > 5 && x < 10, x > 3 || x < 4, false)");
     short_circuit_booleans(&mut e);

--- a/weld/transforms/short_circuit.rs
+++ b/weld/transforms/short_circuit.rs
@@ -112,8 +112,3 @@ fn predicated_if() {
                     )");
     assert!(e.compare_ignoring_symbols(expect).unwrap());
 }
-
-
-
-
-

--- a/weld/transforms/short_circuit.rs
+++ b/weld/transforms/short_circuit.rs
@@ -1,0 +1,119 @@
+
+use ast::*;
+use ast::ExprKind::*;
+use exprs::*;
+
+pub fn short_circuit_booleans(expr: &mut TypedExpr) {
+    // For If statements annotated as predicated, do not apply the transform on the condition,
+    // since it removes the predication opportunity.
+    let applied = match expr.kind {
+        If { ref mut on_true, ref mut on_false, .. } if expr.annotations.predicate() => {
+            short_circuit_booleans(on_true);
+            short_circuit_booleans(on_false);
+            true
+        },
+        _ => false,
+    };
+
+    if applied {
+        return;
+    }
+
+    let new = match expr.kind {
+        BinOp { ref kind, ref left, ref right } if *kind == BinOpKind::LogicalAnd => {
+            Some(if_expr(left.as_ref().clone(), right.as_ref().clone(), literal_expr(LiteralKind::BoolLiteral(false)).unwrap()).unwrap())
+        },
+        BinOp { ref kind, ref left, ref right } if *kind == BinOpKind::LogicalOr => {
+            Some(if_expr(left.as_ref().clone(), literal_expr(LiteralKind::BoolLiteral(true)).unwrap(), right.as_ref().clone()).unwrap())
+        },
+        _ => None,
+    };
+
+    if let Some(new) = new {
+        *expr = new;
+    }
+
+    for child in expr.children_mut() {
+        short_circuit_booleans(child);
+    }
+}
+
+#[cfg(test)]
+use parser::*;
+#[cfg(test)]
+use type_inference::*;
+
+/// Parse and perform type inference on an expression.
+#[cfg(test)]
+fn typed_expr(code: &str) -> TypedExpr {
+    let mut e = parse_expr(code).unwrap();
+    assert!(infer_types(&mut e).is_ok());
+    e.to_typed().unwrap()
+}
+
+#[test]
+fn simple_and() {
+    let mut e = typed_expr("|x:i32| (x > 5 && x < 10)");
+    short_circuit_booleans(&mut e);
+    let ref expect = typed_expr("|x:i32| if (x > 5, x < 10, false)");
+    assert!(e.compare_ignoring_symbols(expect).unwrap());
+}
+
+
+#[test]
+fn simple_or() {
+    let mut e = typed_expr("|x:i32| (x > 5 || x < 10)");
+    short_circuit_booleans(&mut e);
+    let ref expect = typed_expr("|x:i32| if (x > 5, true, x < 10)");
+    assert!(e.compare_ignoring_symbols(expect).unwrap());
+}
+
+#[test]
+fn compound_and() {
+    let mut e = typed_expr("|x:i32| x > 5 && x < 10 && x == 7");
+    short_circuit_booleans(&mut e);
+    let ref expect = typed_expr("|x:i32| if ( if (x > 5, x < 10, false),  x == 7, false)");
+    assert!(e.compare_ignoring_symbols(expect).unwrap());
+}
+
+#[test]
+fn compound_or() {
+    let mut e = typed_expr("|x:i32| (x > 5 || x < 10 || x == 7)");
+    short_circuit_booleans(&mut e);
+    let ref expect = typed_expr("|x:i32| if ( if (x > 5, true, x < 10), true, x == 7 )");
+    assert!(e.compare_ignoring_symbols(expect).unwrap());
+}
+
+#[test]
+fn complex_and_or() {
+    let mut e = typed_expr("|x:i32| (x > 5 || x < 10) && (x == 7 || x == 2)");
+    short_circuit_booleans(&mut e);
+    let ref expect = typed_expr("|x:i32|
+                    if(
+                        if (x > 5, true, x < 10),
+                        if (x == 7, true, x == 2),
+                        false  
+                    )");
+    assert!(e.compare_ignoring_symbols(expect).unwrap());
+}
+
+#[test]
+fn predicated_if() {
+    let mut e = typed_expr("|x:i32| @(predicate:true) if (x > 5 && x < 10, x > 3 || x < 4, false)");
+    short_circuit_booleans(&mut e);
+
+    // Since the If is predicated, the condition should not be short-circuited.
+    let ref expect = typed_expr("|x:i32|
+                    @(predicate:true)
+                    if (
+                        x > 5 && x < 10, 
+                        if (x > 3, true, x < 4),
+                        false
+                    )");
+    assert!(e.compare_ignoring_symbols(expect).unwrap());
+}
+
+
+
+
+


### PR DESCRIPTION
This PR adds short circuit support for booleans. Note that this is a semantic change to the language.

As an example, before the patch, in the expression:

```
(false && expr)
```

`expr1` would be evaluated, but with this patch, it is not evaluated. Likewise, in `(true || expr)`, `expr` is no longer evaluated (but would have been earlier).

One exception is for `if` expressions with `@(predicate:true)` annotations. The _condition_ for the expression is then not short circuited, but any boolean expressions in the `on_true` and `on_false` subexpression are.