### PR TITLE
Type Inference Fixes for Let

### DIFF
--- a/weld/parser.rs
+++ b/weld/parser.rs
@@ -206,16 +206,22 @@ impl<'t> Parser<'t> {
         let name = try!(self.symbol());
         let ty = try!(self.optional_type());
         try!(self.consume(TEqual));
-        let value = try!(self.operator_expr());
+        let mut value = try!(self.operator_expr());
+
+        // If a type was found, assign it (even if the value already has a known type).
+        // Type inference will catch any type mismatches later on.
+        if ty != Unknown {
+            value.ty = ty;
+        }
+
         try!(self.consume(TSemicolon));
         let body = try!(self.expr());
-        let mut expr = expr_box(Let {
+        let expr = expr_box(Let {
                                     name: name,
                                     value: value,
                                     body: body,
                                 },
                                 Annotations::new());
-        expr.ty = ty;
         Ok(expr)
     }
 

--- a/weld/type_inference.rs
+++ b/weld/type_inference.rs
@@ -56,22 +56,42 @@ fn infer_up(expr: &mut PartialExpr, env: &mut TypeMap) -> WeldResult<bool> {
 
     // For Lets and Lambdas, add the identifiers they (re-)define to env
     let mut old_bindings: Vec<(Symbol, Option<PartialType>)> = Vec::new();
-    match expr.kind {
+    let finished = match expr.kind {
         Let {
-            ref name,
-            ref value,
-            ..
+            ref mut name,
+            ref mut value,
+            ref mut body
         } => {
-            old_bindings.push((name.clone(), env.insert(name.clone(), value.ty.clone())));
-        }
+            // Infer the type of the value before updating the binding.
+            changed |= try!(infer_up(value, env));
 
+            // Update the binding, saving the old one.
+            let old_binding = env.insert(name.clone(), value.ty.clone());
+
+            // Then, infer the type of the body (with the new binding).
+            changed |= try!(infer_up(body, env));
+
+            // Undo the changes to the bindings.
+            match old_binding {
+                Some(old) => env.insert(name.clone(), old),
+                None => env.remove(name),
+            };
+            // Finished! Infer own type outside the match to avoid double mutable borrow.
+            true
+        }
         Lambda { ref params, .. } => {
             for p in params {
                 old_bindings.push((p.name.clone(), env.insert(p.name.clone(), p.ty.clone())));
             }
+            false
         }
+        _ => false,
+    };
 
-        _ => (),
+    // Done! Only for Lets for now.
+    if finished {
+        changed |= infer_locally(expr, env)?;
+        return Ok(changed);
     }
 
     // Infer types of children first (with new environment)
@@ -89,7 +109,6 @@ fn infer_up(expr: &mut PartialExpr, env: &mut TypeMap) -> WeldResult<bool> {
 
     // Infer our type
     changed |= try!(infer_locally(expr, env));
-
     Ok(changed)
 }
 


### PR DESCRIPTION
This fixes a few type inference issues with Let. First, it fixes #270 by assigning the type hint in the parser to the correct expression, only if the type hint is given (otherwise, the hint can override the type ascribed by expressions such as `appender[i64]`, which both creates an expression and specifies its type).

Second, this fixes a small scoping bug where for `Let` statements, the environment was being updated *before* the value was evaluated. This was incorrect since the value is evaluated before the name is defined.

@pratiksha this should fix issues you've been having.