### PR TITLE
Better Pass Handling in Python

### DIFF
--- a/python/pyweld/weld/bindings.py
+++ b/python/pyweld/weld/bindings.py
@@ -118,7 +118,7 @@ class WeldConf(c_void_p):
         weld_conf_get.argtypes = [c_weld_conf, c_char_p]
         weld_conf_get.restype = c_char_p
         val = weld_conf_get(self.conf, key)
-        return copy.copy(val.value)
+        return copy.copy(val)
 
     def set(self, key, value):
         key = c_char_p(key)
@@ -161,3 +161,22 @@ class WeldError(c_void_p):
         weld_error_free.argtypes = [c_weld_err]
         weld_error_free.restype = None
         weld_error_free(self.error)
+
+WeldLogLevelOff = 0
+WeldLogLevelError = 1
+WeldLogLevelWarn = 2
+WeldLogLevelInfo = 3
+WeldLogLevelDebug = 4
+WeldLogLevelTrace = 5
+
+def weld_set_log_level(log_level):
+     """
+     Sets the log_level for Weld:
+        0 = No Logs,
+        1 = Error,
+        2 = Warn,
+        3 = Info,
+        4 = Debug,
+        5 = Trace.
+     """
+     weld.weld_set_log_level(log_level)

--- a/python/pyweld/weld/weldobject.py
+++ b/python/pyweld/weld/weldobject.py
@@ -154,8 +154,10 @@ class WeldObject(object):
         text = header + " " + self.get_let_statements() + "\n" + self.weld_code
         return text
 
-    def evaluate(self, restype, verbose=True, decode=True):
+    def evaluate(self, restype, verbose=True, decode=True, passes=None):
         function = self.to_weld_func()
+
+        cweld.weld_set_log_level(cweld.WeldLogLevelTrace)
 
         # Returns a wrapped ctypes Structure
         def args_factory(encoded):
@@ -194,6 +196,10 @@ class WeldObject(object):
         arg = cweld.WeldValue(void_ptr)
         conf = cweld.WeldConf()
         err = cweld.WeldError()
+
+        if passes is not None:
+            conf.set("weld.optimization.passes", ",".join(passes))
+
         module = cweld.WeldModule(function, conf, err)
         if err.code() != 0:
             raise ValueError("Could not compile function {}: {}".format(

--- a/python/pyweld/weld/weldobject.py
+++ b/python/pyweld/weld/weldobject.py
@@ -157,8 +157,6 @@ class WeldObject(object):
     def evaluate(self, restype, verbose=True, decode=True, passes=None):
         function = self.to_weld_func()
 
-        cweld.weld_set_log_level(cweld.WeldLogLevelTrace)
-
         # Returns a wrapped ctypes Structure
         def args_factory(encoded):
             class Args(ctypes.Structure):


### PR DESCRIPTION
This adds logging capabilities in Python, and also makes it easier to change which passes are run. Some required passes have been factored out to always run (e.g., `inline-apply`) -- users shouldn't specify these in the list of passes they want run.