### PR TITLE
Dump Optimized LLVM and Assembly

### DIFF
--- a/weld/easy_ll/tests.rs
+++ b/weld/easy_ll/tests.rs
@@ -15,9 +15,9 @@ fn basic_use() {
            %2 = call i64 @bar(i64 %1)
            ret i64 %2
        }
-    ", 2, None);
+    ", 2, false, None);
     assert!(module.is_ok());
-    assert_eq!(module.unwrap().0.run(42), 44);
+    assert_eq!(module.unwrap().module.run(42), 44);
 }
 
 #[test]
@@ -26,7 +26,7 @@ fn compile_error() {
        define ZZZZZZZZ @run(i64 %arg) {
            ret i64 0
        }
-    ", 2, None);
+    ", 2, false, None);
     assert!(!module.is_ok());
     assert!(module.unwrap_err().description().contains("Compile"));
 }
@@ -37,7 +37,7 @@ fn no_run_function() {
        define i64 @ZZZZZZZ(i64 %arg) {
            ret i64 0
        }
-    ", 2, None);
+    ", 2, false, None);
     assert!(!module.is_ok());
     assert!(module.unwrap_err().description().contains("run function"));
 }
@@ -48,7 +48,7 @@ fn wrong_function_type() {
        define i64 @run() {
            ret i64 0
        }
-    ", 2, None);
+    ", 2, false, None);
     assert!(!module.is_ok());
     assert!(module.unwrap_err().description().contains("wrong type"));
 }


### PR DESCRIPTION
this dumps the LLVM post optimization passes and the optimized target-dependent assembly when the `dumpCode` configuration option is enabled.