### PR TITLE
New predication transform

### DIFF
--- a/weld/ast.rs
+++ b/weld/ast.rs
@@ -388,6 +388,14 @@ impl<T: TypeBounds> ExprKind<T> {
             Res { .. } => "Res",
         }
     }
+
+    pub fn is_builder_expr(&self) -> bool {
+        use ast::ExprKind::*;
+        match *self {
+            Merge { .. } | Res { .. } | For { .. } | NewBuilder(_) => true,
+            _ => false,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -3683,6 +3683,14 @@ fn simple_predicate() {
     let expected = "|v1:vec[i32],v2:vec[bool]|result(for(zip(v1:vec[i32],v2:vec[bool]),merger[i32,+],|b:merger[i32,+],i:i64,e:{i32,bool}|merge(b:merger[i32,+],select(e:{i32,bool}.$1,e:{i32,bool}.$0,0))))";
     assert_eq!(print_typed_expr_without_indent(&typed_e.unwrap()).as_str(),
                expected);
+
+    /* Ensure that the simple_predicate transform doesn't change the program if on_true or on_false contains a builder expression. */
+    let code = "|v1:vec[i32],v2:vec[bool]| result(for(v2, appender, |b,i,e| merge(b, @(predicate:true) if(e, result(for(v1, merger[i32,+], |b2,i2,e2| merge(b2,e2))), 0))))";
+    let typed_e = predicate_only(code);
+    assert!(typed_e.is_ok());
+    let expected = "|v1:vec[i32],v2:vec[bool]|result(for(v2:vec[bool],appender[i32],|b:appender[i32],i:i64,e:bool|merge(b:appender[i32],@(predicate:true)if(e:bool,result(for(v1:vec[i32],merger[i32,+],|b2:merger[i32,+],i2:i64,e2:i32|merge(b2:merger[i32,+],e2:i32))),0))))";
+    assert_eq!(print_typed_expr_without_indent(&typed_e.unwrap()).as_str(),
+               expected);
 }
 
 #[test]

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -3675,6 +3675,17 @@ fn predicate_only(code: &str) -> WeldResult<TypedExpr> {
 }
 
 #[test]
+fn simple_predicate() {
+    /* Ensure that the simple_predicate transform works. */
+    let code = "|v1:vec[i32],v2:vec[bool]| result(for(zip(v1, v2), merger[i32,+], |b,i,e| merge(b, @(predicate:true) if(e.$1, e.$0, 0))))";
+    let typed_e = predicate_only(code);
+    assert!(typed_e.is_ok());
+    let expected = "|v1:vec[i32],v2:vec[bool]|result(for(zip(v1:vec[i32],v2:vec[bool]),merger[i32,+],|b:merger[i32,+],i:i64,e:{i32,bool}|merge(b:merger[i32,+],select(e:{i32,bool}.$1,e:{i32,bool}.$0,0))))";
+    assert_eq!(print_typed_expr_without_indent(&typed_e.unwrap()).as_str(),
+               expected);
+}
+
+#[test]
 fn predicate_iff_annotated() {
     /* Ensure predication is only applied if annotation is present. */
 

--- a/weld/passes.rs
+++ b/weld/passes.rs
@@ -75,7 +75,7 @@ lazy_static! {
                  Pass::new(vec![short_circuit::short_circuit_booleans],
                  "short-circuit-booleans"));
         m.insert("predicate",
-                 Pass::new(vec![vectorizer::predicate],
+                 Pass::new(vec![vectorizer::predicate_merge_expr, vectorizer::predicate_simple_expr],
                  "predicate"));
         m.insert("vectorize",
                  Pass::new(vec![vectorizer::vectorize],

--- a/weld/transforms/vectorizer.rs
+++ b/weld/transforms/vectorizer.rs
@@ -164,31 +164,20 @@ pub fn predicate_simple_expr(e: &mut Expr<Type>) {
             return Ok((None, true));
         }
 
-        // Check if any sub-expression has a builder; if so bail out in order to not break linearity.
-        let mut safe = true;
-        e.traverse(&mut |ref sub_expr| {
-            match sub_expr.kind {
-                Merge { .. } => {
-                    safe = false;
-                },
-                Res { .. } => {
-                    safe = false;
-                },
-                For { .. } => {
-                    safe = false;
-                },
-                NewBuilder(_) => {
-                    safe = false;
-                },
-                _ => {}
-            }
-        });
-        if !safe {
-            return Ok((None, true));
-        }
-
         // This pattern checks for if(cond, scalar1, scalar2).
         if let If { ref cond, ref on_true, ref on_false } = e.kind {
+            // Check if any sub-expression has a builder; if so bail out in order to not break linearity.
+            let mut safe = true;
+            on_true.traverse(&mut |ref sub_expr| if sub_expr.kind.is_builder_expr() {
+                safe = false;
+            });
+            on_false.traverse(&mut |ref sub_expr| if sub_expr.kind.is_builder_expr() {
+                safe = false;
+            });
+            if !safe {
+                return Ok((None, true));
+            }
+
             if let Scalar(_) = on_true.ty {
                 if let Scalar(_) = on_false.ty {
                     let expr = exprs::select_expr(*cond.clone(), *on_true.clone(), *on_false.clone())?;

--- a/weld/transforms/vectorizer.rs
+++ b/weld/transforms/vectorizer.rs
@@ -91,7 +91,7 @@ pub fn vectorize(expr: &mut Expr<Type>) {
 }
 
 /// Predicate an `If` expression by checking for if(cond, merge(b, e), b) and transforms it to merge(b, select(cond, e,identity)).
-pub fn predicate(e: &mut Expr<Type>) {
+pub fn predicate_merge_expr(e: &mut Expr<Type>) {
     e.transform_and_continue_res(&mut |ref mut e| {
         if !(should_be_predicated(e)) {
             return Ok((None, true));
@@ -150,6 +150,26 @@ pub fn predicate(e: &mut Expr<Type>) {
                             }
                         }
                     }
+                }
+            }
+        }
+        Ok((None, true))
+    });
+}
+
+/// Predicate an `If` expression by checking for if(cond, scalar1, scalar2) and transforms it to select(cond, scalar1, scalar2).
+pub fn predicate_simple_expr(e: &mut Expr<Type>) {
+    e.transform_and_continue_res(&mut |ref mut e| {
+        if !(should_be_predicated(e)) {
+            return Ok((None, true));
+        }
+
+        // This pattern checks for if(cond, scalar1, scalar2).
+        if let If { ref cond, ref on_true, ref on_false } = e.kind {
+            if let Scalar(_) = on_true.ty {
+                if let Scalar(_) = on_false.ty {
+                    let expr = exprs::select_expr(*cond.clone(), *on_true.clone(), *on_false.clone())?;
+                    return Ok((Some(expr), true));
                 }
             }
         }
@@ -426,7 +446,7 @@ fn simple_merger() {
 #[test]
 fn predicated_merger() {
     let mut e = typed_expr("|v:vec[i32]| result(for(v, merger[i32,+], |b,i,e| @(predicate:true)if(e>0, merge(b,e), b)))");
-    predicate(&mut e);
+    predicate_merge_expr(&mut e);
     vectorize(&mut e);
     assert!(has_vectorized_merge(&e));
 }
@@ -450,7 +470,7 @@ fn simple_appender() {
 fn predicated_appender() {
     // This code should NOT be vectorized because we can't predicate merges into vecbuilder.
     let mut e = typed_expr("|v:vec[i32]| result(for(v, appender[i32], |b,i,e| @(predicate:true)if(e>0, merge(b,e), b)))");
-    predicate(&mut e);
+    predicate_merge_expr(&mut e);
     vectorize(&mut e);
     assert!(!has_vectorized_merge(&e));
 }


### PR DESCRIPTION
Added a new predicate to transform expressions from `if(cond, scalar1, scalar2)` to `select(cond, scalar1, scalar2)`.

Downstream vectorization doesn't work though.