### PR TITLE
Relaxes requirements for vectorization

### DIFF
--- a/weld/transforms/vectorizer.rs
+++ b/weld/transforms/vectorizer.rs
@@ -30,10 +30,8 @@ pub fn vectorize(expr: &mut Expr<Type>) {
     expr.transform_and_continue_res(&mut |ref mut expr| {
         //  The Res is a stricter-than-necessary check, but prevents us from having to check nested
         //  loops for now.
-        if let Res { builder: ref for_loop } = expr.kind {
-            let ref broadcast_idens = vectorizable(for_loop)?;
-            if let For { ref iters, builder: ref init_builder, ref func } = for_loop.kind {
-                if let NewBuilder(_) = init_builder.kind {
+        if let Some(ref broadcast_idens) = vectorizable(expr) {
+            if let For { ref iters, builder: ref init_builder, ref func } = expr.kind {
                     if let Lambda { ref params, ref body } = func.kind {
                         // This is the vectorized body.
                         let mut vectorized_body = body.clone();
@@ -77,16 +75,13 @@ pub fn vectorize(expr: &mut Expr<Type>) {
 
                         let vectorized_loop = exprs::for_expr(vec_iters, *init_builder.clone(), vec_func, true)?;
                         let scalar_loop = exprs::for_expr(fringe_iters, vectorized_loop, *func.clone(), false)?;
-                        let result = exprs::result_expr(scalar_loop)?;
-
-                        let mut prev_expr = result;
+                        let mut prev_expr = scalar_loop;
                         for (iter, name) in iters.iter().zip(data_names).rev() {
                             prev_expr = exprs::let_expr(name.clone(), *iter.data.clone(), prev_expr)?;
                         }
 
                         vectorized = true;
                         return Ok((Some(prev_expr), false));
-                    }
                 }
             }
         }
@@ -166,21 +161,12 @@ pub fn predicate(e: &mut Expr<Type>) {
 ///
 /// We can vectorize an iterator if all of its iterators consume the entire collection.
 fn vectorizable_iters(iters: &Vec<Iter<Type>>) -> bool {
-    for ref iter in iters {
-        if iter.start.is_some() || iter.end.is_some() || iter.stride.is_some() {
-            return false;
+    iters.iter().all(|ref iter| {
+        iter.start.is_none() && iter.end.is_none() && iter.stride.is_none() && match iter.data.ty {
+            Vector(ref elem) if elem.is_scalar() => true,
+            _ => false,
         }
-        if let Vector(ref elem_ty) = iter.data.ty {
-            if let Scalar(_) = *elem_ty.as_ref() {
-            } else {
-                return false;
-            }
-        }
-        if iter.kind != IterKind::ScalarIter {
-            return false;
-        }
-    }
-    true
+    })
 }
 
 /// Vectorizes an expression in-place, also changing its type if needed.
@@ -231,15 +217,25 @@ fn vectorize_expr(e: &mut Expr<Type>, broadcast_idens: &HashSet<Symbol>) -> Weld
     Ok(cont)
 }
 
+fn vectorizable_newbuilder(expr: &TypedExpr) -> bool {
+    if let NewBuilder(_) = expr.kind {
+        return true;
+    }
+    if let MakeStruct { ref elems } = expr.kind {
+        return elems.iter().all(|ref e| vectorizable_newbuilder(e));
+    }
+    false
+}
+
 /// Checks basic vectorizability for a loop - this is a strong check which ensure that the only
 /// expressions which appear in a function body are vectorizable expressions (see
 /// `docs/internals/vectorization.md` for details)
-fn vectorizable(for_loop: &Expr<Type>) -> WeldResult<HashSet<Symbol>> {
+fn vectorizable(for_loop: &Expr<Type>) -> Option<HashSet<Symbol>> {
     if let For { ref iters, builder: ref init_builder, ref func } = for_loop.kind {
         // Check if the iterators are consumed.
         if vectorizable_iters(&iters) {
             // Check if the builder is newly initialized.
-            if let NewBuilder(_) = init_builder.kind {
+            if vectorizable_newbuilder(init_builder) {
                 // Check the loop function.
                 if let Lambda { ref params, ref body } = func.kind {
                     let mut passed = true;
@@ -287,7 +283,8 @@ fn vectorizable(for_loop: &Expr<Type>) -> WeldResult<HashSet<Symbol>> {
                     });
 
                     if !passed {
-                        return weld_err!("Unsupported pattern");
+                        trace!("Vectorization failed due to unsupported expression in loop body");
+                        return None;
                     }
 
                     // If the data in the vector is not a Scalar, we can't vectorize it.
@@ -306,7 +303,8 @@ fn vectorizable(for_loop: &Expr<Type>) -> WeldResult<HashSet<Symbol>> {
                     }
 
                     if !check_arg_ty {
-                        return weld_err!("Unsupported type");
+                        trace!("Vectorization failed due to unsupported type");
+                        return None;
                     }
 
                     let mut idens = HashSet::new();
@@ -326,14 +324,16 @@ fn vectorizable(for_loop: &Expr<Type>) -> WeldResult<HashSet<Symbol>> {
                                        });
 
                     if !passed {
-                        return weld_err!("Unsupporte pattern: non-scalar identifier that must be broadcast");
+                        trace!("Unsupported pattern: non-scalar identifier that must be broadcast");
+                        return None;
                     }
-                    return Ok(idens);
+                    return Some(idens);
                 }
             }
         }
     }
-    return weld_err!("Unsupported pattern");
+    trace!("Vectorization failed due to unsupported pattern");
+    None
 }
 
 fn should_be_predicated(e: &mut Expr<Type>) -> bool {


### PR DESCRIPTION
This allows loops with structs of appenders to be vectorized as well.

This PR also writes error messages which occur during transformations to `trace!`.