### PR TITLE
Unroll Transform

### DIFF
--- a/weld/annotations.rs
+++ b/weld/annotations.rs
@@ -12,6 +12,7 @@ pub enum AnnotationKind {
     GrainSize,
     AlwaysUseRuntime,
     Size,
+    LoopSize,
     BranchSelectivity,
     NumKeys,
 }
@@ -24,6 +25,7 @@ impl fmt::Display for AnnotationKind {
                    AnnotationKind::TileSize => "tile_size",
                    AnnotationKind::GrainSize => "grain_size",
                    AnnotationKind::Size => "size",
+                   AnnotationKind::LoopSize => "loopsize",
                    AnnotationKind::BranchSelectivity => "branch_selectivity",
                    AnnotationKind::NumKeys => "num_keys",
                    AnnotationKind::Predicate => "predicate",
@@ -58,6 +60,7 @@ enum AnnotationValue {
     VTileSize(i32),
     VGrainSize(i32),
     VSize(i64),
+    VLoopSize(i64),
     VNumKeys(i64),
     VBranchSelectivity(i32), // Fractions of 10,000
     VPredicate,
@@ -73,6 +76,7 @@ impl fmt::Display for AnnotationValue {
                    AnnotationValue::VTileSize(ref v) => format!("{}", v),
                    AnnotationValue::VGrainSize(ref v) => format!("{}", v),
                    AnnotationValue::VSize(ref v) => format!("{}", v),
+                   AnnotationValue::VLoopSize(ref v) => format!("{}", v),
                    AnnotationValue::VBranchSelectivity(ref v) => format!("{}", v),
                    AnnotationValue::VNumKeys(ref v) => format!("{}", v),
                    // These are flags, so their existence indicates that the value is `true`.
@@ -145,6 +149,19 @@ impl Annotations {
 
     pub fn set_size(&mut self, value: i64) {
         self.values.insert(AnnotationKind::Size, AnnotationValue::VSize(value));
+    }
+
+    pub fn loopsize(&self) -> Option<i64> {
+        if let Some(s) = self.values.get(&AnnotationKind::LoopSize) {
+            if let AnnotationValue::VLoopSize(ref s) = *s {
+                return Some(s.clone());
+            }
+        }
+        None
+    }
+
+    pub fn set_loopsize(&mut self, value: i64) {
+        self.values.insert(AnnotationKind::LoopSize, AnnotationValue::VLoopSize(value));
     }
 
     pub fn num_keys(&self) -> Option<i64> {

--- a/weld/ast.rs
+++ b/weld/ast.rs
@@ -511,6 +511,9 @@ pub struct Parameter<T: TypeBounds> {
 /// A typed expression struct.
 pub type TypedExpr = Expr<Type>;
 
+/// A typed iter struct.
+pub type TypedIter = Iter<Type>;
+
 /// A typed parameter.
 pub type TypedParameter = Parameter<Type>;
 

--- a/weld/conf.rs
+++ b/weld/conf.rs
@@ -31,7 +31,7 @@ pub const DEFAULT_TRACE_RUN: bool = false;
 
 lazy_static! {
     pub static ref DEFAULT_OPTIMIZATION_PASSES: Vec<Pass> = {
-        let m = ["loop-fusion", "infer-size", "short-circuit-booleans", "predicate", "vectorize", "fix-iterate"];
+        let m = ["loop-fusion", "unroll-static-loop", "infer-size", "short-circuit-booleans", "predicate", "vectorize", "fix-iterate"];
         m.iter().map(|e| (*OPTIMIZATION_PASSES.get(e).unwrap()).clone()).collect()
     };
     pub static ref DEFAULT_DUMP_CODE_DIR: PathBuf = Path::new(".").to_path_buf();

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -100,7 +100,7 @@ pub fn apply_opt_passes(expr: &mut TypedExpr, opt_passes: &Vec<Pass>, stats: &mu
         pass.transform(expr)?;
         let end = PreciseTime::now();
         stats.pass_times.push((pass.pass_name(), start.to(end)));
-        trace!("After {} pass:\n{}", pass.pass_name(), print_typed_expr(&expr));
+        debug!("After {} pass:\n{}", pass.pass_name(), print_typed_expr(&expr));
     }
     Ok(())
 }
@@ -109,7 +109,7 @@ pub fn apply_opt_passes(expr: &mut TypedExpr, opt_passes: &Vec<Pass>, stats: &mu
 pub fn compile_program(program: &Program, conf: &ParsedConf, stats: &mut CompilationStats)
         -> WeldResult<CompiledModule> {
     let mut expr = macro_processor::process_program(program)?;
-    trace!("After macro substitution:\n{}\n", print_typed_expr(&expr));
+    debug!("After macro substitution:\n{}\n", print_typed_expr(&expr));
 
     let start = PreciseTime::now();
     uniquify::uniquify(&mut expr)?;
@@ -121,7 +121,7 @@ pub fn compile_program(program: &Program, conf: &ParsedConf, stats: &mut Compila
     type_inference::infer_types(&mut expr)?;
     let mut expr = expr.to_typed()?;
     let end = PreciseTime::now();
-    trace!("After type inference:\n{}\n", print_typed_expr(&expr));
+    debug!("After type inference:\n{}\n", print_typed_expr(&expr));
     stats.weld_times.push(("Type Inference".to_string(), start.to(end)));
 
     apply_opt_passes(&mut expr, &conf.optimization_passes, stats)?;
@@ -146,7 +146,7 @@ pub fn compile_program(program: &Program, conf: &ParsedConf, stats: &mut Compila
     // be useful.
     let start = PreciseTime::now();
     if conf.enable_sir_opt {
-        debug!("Applying SIR optimizations");
+        info!("Applying SIR optimizations");
         optimizations::fold_constants::fold_constants(&mut sir_prog)?;
     }
     let end = PreciseTime::now();

--- a/weld/parser.rs
+++ b/weld/parser.rs
@@ -620,7 +620,16 @@ impl<'t> Parser<'t> {
                                 if let TI64Literal(l) = *self.next() {
                                     annotations.set_size(l);
                                 } else {
-                                    return weld_err!("Invalid vector size (must be a i32)");
+                                    return weld_err!("Invalid vector size (must be a i64)");
+                                }
+                            }
+                            "loopsize" => {
+                                self.consume(TIdent("loopsize".to_string()))?;
+                                try!(self.consume(TColon));
+                                if let TI64Literal(l) = *self.next() {
+                                    annotations.set_loopsize(l);
+                                } else {
+                                    return weld_err!("Invalid vector size (must be a i64)");
                                 }
                             }
                             "selectivity" => {
@@ -638,7 +647,7 @@ impl<'t> Parser<'t> {
                                 if let TI64Literal(l) = *self.next() {
                                     annotations.set_num_keys(l);
                                 } else {
-                                    return weld_err!("Invalid number of keys (must be a i32)");
+                                    return weld_err!("Invalid number of keys (must be a i64)");
                                 }
                             }
                             _ => return weld_err!("Invalid annotation type"),

--- a/weld/passes.rs
+++ b/weld/passes.rs
@@ -7,6 +7,7 @@ use super::transforms::size_inference;
 use super::transforms::short_circuit;
 use super::transforms::annotator;
 use super::transforms::vectorizer;
+use super::transforms::unroller;
 
 use super::expr_hash::*;
 
@@ -68,6 +69,9 @@ lazy_static! {
                                 loop_fusion::fuse_loops_vertical,
                                 inliner::inline_get_field],
                  "loop-fusion"));
+        m.insert("unroll-static-loop",
+                 Pass::new(vec![unroller::unroll_static_loop],
+                 "unroll-static-loop"));
         m.insert("infer-size",
                  Pass::new(vec![size_inference::infer_size],
                  "infer-size"));

--- a/weld/transforms/mod.rs
+++ b/weld/transforms/mod.rs
@@ -7,3 +7,4 @@ pub mod size_inference;
 pub mod annotator;
 pub mod vectorizer;
 pub mod short_circuit;
+pub mod unroller;

--- a/weld/transforms/unroller.rs
+++ b/weld/transforms/unroller.rs
@@ -1,137 +1,143 @@
 //! Analyzes the `loopsize` annotation to unroll loops into a series of `Lookup` nodes at compile
 //! time.
-//! 
+//!
+
+use std::error::Error;
 
 use ast::*;
+
+use ast::BuilderKind::*;
 use ast::ExprKind::*;
+use ast::Type::*;
+
+use error::*;
+use exprs::*;
 
 use annotations::*;
 
 use super::uniquify::uniquify;
 
-struct MergeSingle<'a> {
-    params: &'a Vec<TypedParameter>,
-    value: &'a TypedExpr
-}
+/// Maximum number of iterations this transformation will unroll.
+pub const UNROLL_LIMIT: i64 = 8;
 
-impl<'a> MergeSingle<'a> {
-    fn extract(expr: &'a TypedExpr) -> Option<MergeSingle<'a>> {
-        if let Lambda{ref params, ref body} = expr.kind {
-            if let Merge{ref builder, ref value} = body.kind {
-                match builder.kind {
-                    Ident(ref name) if *name == params[0].name =>
-                        return Some(MergeSingle{params, value}),
-                    _ => {}
-                }
-            }
-        }
-        return None
-    }
-}
-
-struct NewAppender<'a> {
-    elem_type: &'a Type
-}
-
-impl<'a> NewAppender<'a> {
-    fn extract(expr: &'a TypedExpr) -> Option<NewAppender<'a>> {
-        if let NewBuilder(_) = expr.kind {
-            if let Builder(Appender(ref elem_type), _) = expr.ty {
-                return Some(NewAppender{elem_type})
-            }
-        }
-        return None
-    }
-}
-
-struct ResForAppender<'a> {
-    iters: &'a Vec<Iter<Type>>,
-    func: &'a TypedExpr
-}
-
-impl<'a> ResForAppender<'a> {
-    fn extract(expr: &'a TypedExpr) -> Option<ResForAppender<'a>> {
-        if let Res{ref builder} = expr.kind {
-            if let For{ref iters, ref builder, ref func} = builder.kind {
-                if NewAppender::extract(builder).is_some() {
-                    return Some(ResForAppender{iters, func})
-                }
-            }
-        }
-        return None;
-    }
-}
-
-struct MapIter<'a> {
-    iters: &'a Vec<Iter<Type>>,
+/// A simple map pattern, which is a Result(For(.. with a single merge expression as the
+/// For loop's function body.
+struct UnrollPattern<'a> {
+    iters: &'a Vec<TypedIter>,
+    builder_kind: &'a BuilderKind,
     merge_params: &'a Vec<TypedParameter>,
     merge_value: &'a TypedExpr
 }
 
-impl<'a> MapIter<'a> {
-    fn extract(iter: &'a TypedIter) -> Option<MapIter> {
-        if iter.is_simple() {
-            if let Some(rfa) = ResForAppender::extract(&iter.data) {
-                if rfa.iters.iter().all(|ref i| i.is_simple()) {
-                    if let Some(merge) = MergeSingle::extract(&rfa.func) {
-                        return Some(MapIter {
-                            iters: &rfa.iters,
-                            merge_params: merge.params,
-                            merge_value: merge.value
-                        });
+impl<'a> UnrollPattern<'a> {
+    /// Extracts a `UnrollPattern` from the expression, or returns `None`.
+    // TODO check annotation.
+    // TODO check annotation cutoff.
+    fn extract(expr: &'a TypedExpr) -> Option<UnrollPattern> {
+        if let Res { ref builder } = expr.kind {
+            if let For { ref iters, ref builder, ref func } = builder.kind {
+                if let Builder(ref bk, _) = builder.ty {
+                    if let Lambda {ref params, ref body} = func.kind {
+                        if let Merge { builder: ref builder2, ref value} = body.kind {
+                            match builder2.kind {
+                                Ident(ref name) if *name == params[0].name => {
+                                    return Some(UnrollPattern {
+                                        iters: iters,
+                                        builder_kind: bk,
+                                        merge_params: params,
+                                        merge_value: value,
+                                    });
+                                }
+                                _ => {
+                                    return None;
+                                }
+                            }
+                        }
                     }
                 }
             }
         }
-        return None;
+        None
     }
 }
 
-// TODO When should the transformation be applied?
-// 1. Has the loopsize annotation.
-// 2. loopsize annotation is below some threshold (lets say 4-8 for now)
-// 3. Loop follows the ResForAppender/SimpleMerge pattern.
-// 4. The SimpleMerge pattern does not contain any other builder expressions (e.g., nested loops).
+pub fn unroll_static_loop(expr: &mut TypedExpr) {
+    if let Err(_) = uniquify(expr) {
+        return;
+    }
+    expr.transform(&mut |ref mut expr| {
+        if let Some(pat) = UnrollPattern::extract(expr) {
+            let vals = unroll_values(pat.merge_params, pat.merge_value, pat.iters, 4);
+            if vals.is_err() {
+                trace!("Unroller error: {}", vals.unwrap_err().description());
+                return None;
+            }
+            let vals = vals.unwrap();
+
+            let combined_expr = combine_unrolled_values(pat.builder_kind.clone(), vals);
+            if combined_expr.is_err() {
+                trace!("Unroller error: {}", combined_expr.unwrap_err().description());
+                return None;
+            }
+            let combined_expr = combined_expr.unwrap();
+            Some(combined_expr)
+        } else {
+            None
+        }
+    });
+}
+
+fn is_same_ident(expr: &TypedExpr, other: &TypedExpr) -> bool {
+    if let Ident(ref name) = other.kind {
+        if let Ident(ref name2) = expr.kind {
+            return name == name2 && expr.ty == other.ty;
+        }
+    }
+    false
+}
 
 /// Takes a `MergeSingle` and returns a list of expressions which replace the element
 /// in the merge with a Lookup.
-fn unroll_values<'a>(merge_single: &'a MergeSingle, iters: &'a Vec<TypedIter>, loopsize: usize) -> WeldResult<Vec<TypedExpr>> {
-    if merge_single.params.len() != 3 {
+fn unroll_values(parameters: &Vec<TypedParameter>, value: &TypedExpr, iters: &Vec<TypedIter>, loopsize: usize) -> WeldResult<Vec<TypedExpr>> {
+    if parameters.len() != 3 {
         return weld_err!("Expected three parameters to Merge function");
     }
 
-    let ref elem_symbol = merge_single.params[2].name;
-    // To match on the element.
-    let ref elem_ident = ident_expr(elem_symbol.clone(), merge_single.params[2].ty.clone())?;
-    let mut expressions = vec![];
+    let ref index_symbol = parameters[1].name;
+    let ref elem_symbol = parameters[2].name;
+    let ref elem_ident = ident_expr(elem_symbol.clone(), parameters[2].ty.clone())?;
 
+    let mut expressions = vec![];
     for i in 0..loopsize {
-        let mut value = merge_single.value.clone();
-        value.transform(&mut |ref mut e| {
+        let mut unrolled_value = value.clone();
+        unrolled_value.transform(&mut |ref mut e| {
             match e.kind {
-                // TODO the index value can also be handled here rather easily.
-                Ident(ref name) if name == elem_symbol && iters.len() == 1 {
+                // TODO identifiers using the index value could also be handled here.
+                Ident(ref name) if name == index_symbol => {
+                    Some(literal_expr(LiteralKind::I64Literal(i as i64)).unwrap())
+                }
+                Ident(ref name) if name == elem_symbol && iters.len() == 1 => {
                     // There is a single iterator, which means the type of the element is the type
                     // of the iterator's data. Replace it with a lookup into the vector.
-                    return Ok(lookup_expr(iters[0].data.as_ref().clone(), literal_expr(LiteralKind::I64Literal(i as i64))?)?);
+                    Some(lookup_expr(iters[0].data.as_ref().clone(), literal_expr(LiteralKind::I64Literal(i as i64)).unwrap()).unwrap())
                 }
-                GetField { ref expr, ref index } if expr == elem_ident && iters.len() > 1 => {
+                GetField { ref expr, ref index } if is_same_ident(expr, elem_ident) && iters.len() > 1 => {
                     // There are multiple iterators zipped into a struct, and this expression is
                     // pulling one of the elements out of that struct. Replace it with a lookup into the vector.
-                    let data_expr = iters[index].data.as_ref().clone();
-                    return Ok(lookup_expr(data_expr, literal_expr(LiteralKind::I64Literal(i as i64))?)?);
+                    let data_expr = iters[*index as usize].data.as_ref().clone();
+                    Some(lookup_expr(data_expr, literal_expr(LiteralKind::I64Literal(i as i64)).unwrap()).unwrap())
                 }
+                _ => None
             }
-            None
         });
-        expressions.push(value);
+        expressions.push(unrolled_value);
     }
     return Ok(expressions);
 }
 
 /// Combines the expressions in `values` into a single value based on the kind of builder the
 /// values would have been merged into.
-/// 
+///
 /// As an example, if `values` is [ Literal(1), Literal(2), Literal(3)] and the builder was a
 /// merger[i32,+], this function will produce the expression Literal(1) + Literal(2) + Literal(3).
 fn combine_unrolled_values(bk: BuilderKind, values: Vec<TypedExpr>) -> WeldResult<TypedExpr> {
@@ -140,7 +146,7 @@ fn combine_unrolled_values(bk: BuilderKind, values: Vec<TypedExpr>) -> WeldResul
     }
     match bk {
         Merger(ref ty, ref binop) => {
-            if values.iter().any(|ref expr| expr.ty != ty) {
+            if values.iter().any(|ref expr| expr.ty != *ty.as_ref()) {
                 return weld_err!("Mismatched types in Merger and unrolled values.");
             }
             // Use the specified binary op to produce the final expression.
@@ -149,19 +155,19 @@ fn combine_unrolled_values(bk: BuilderKind, values: Vec<TypedExpr>) -> WeldResul
                 if prev.is_none() {
                     prev = Some(value);
                 } else {
-                    prev = Ok(binop_expr(*binop, prev.unwrap(), value)?)
+                    prev = Some(binop_expr(*binop, prev.unwrap(), value)?);
                 }
             }
-            return prev.unwrap();
+            return Ok(prev.unwrap());
         }
         Appender(ref ty) => {
-            if values.iter().any(|ref expr| expr.ty != ty) {
+            if values.iter().any(|ref expr| expr.ty != *ty.as_ref()) {
                 return weld_err!("Mismatched types in Appender and unrolled values.");
             }
-            return makevector_expr(values)?;
+            return makevector_expr(values);
         }
         ref bk => {
-            weld_err!("Unroller transform does not support loops with builder of kind {:?}", bk);
+            return weld_err!("Unroller transform does not support loops with builder of kind {:?}", bk);
         }
     }
 }

--- a/weld/transforms/unroller.rs
+++ b/weld/transforms/unroller.rs
@@ -1,0 +1,163 @@
+//! Analyzes the `loopsize` annotation to unroll loops into a series of `Lookup` nodes at compile
+//! time.
+//! 
+
+use ast::*;
+use ast::ExprKind::*;
+
+use annotations::*;
+
+use super::uniquify::uniquify;
+
+struct MergeSingle<'a> {
+    params: &'a Vec<TypedParameter>,
+    value: &'a TypedExpr
+}
+
+impl<'a> MergeSingle<'a> {
+    fn extract(expr: &'a TypedExpr) -> Option<MergeSingle<'a>> {
+        if let Lambda{ref params, ref body} = expr.kind {
+            if let Merge{ref builder, ref value} = body.kind {
+                match builder.kind {
+                    Ident(ref name) if *name == params[0].name =>
+                        return Some(MergeSingle{params, value}),
+                    _ => {}
+                }
+            }
+        }
+        return None
+    }
+}
+
+struct NewAppender<'a> {
+    elem_type: &'a Type
+}
+
+impl<'a> NewAppender<'a> {
+    fn extract(expr: &'a TypedExpr) -> Option<NewAppender<'a>> {
+        if let NewBuilder(_) = expr.kind {
+            if let Builder(Appender(ref elem_type), _) = expr.ty {
+                return Some(NewAppender{elem_type})
+            }
+        }
+        return None
+    }
+}
+
+struct ResForAppender<'a> {
+    iters: &'a Vec<Iter<Type>>,
+    func: &'a TypedExpr
+}
+
+impl<'a> ResForAppender<'a> {
+    fn extract(expr: &'a TypedExpr) -> Option<ResForAppender<'a>> {
+        if let Res{ref builder} = expr.kind {
+            if let For{ref iters, ref builder, ref func} = builder.kind {
+                if NewAppender::extract(builder).is_some() {
+                    return Some(ResForAppender{iters, func})
+                }
+            }
+        }
+        return None;
+    }
+}
+
+struct MapIter<'a> {
+    iters: &'a Vec<Iter<Type>>,
+    merge_params: &'a Vec<TypedParameter>,
+    merge_value: &'a TypedExpr
+}
+
+impl<'a> MapIter<'a> {
+    fn extract(iter: &'a TypedIter) -> Option<MapIter> {
+        if iter.is_simple() {
+            if let Some(rfa) = ResForAppender::extract(&iter.data) {
+                if rfa.iters.iter().all(|ref i| i.is_simple()) {
+                    if let Some(merge) = MergeSingle::extract(&rfa.func) {
+                        return Some(MapIter {
+                            iters: &rfa.iters,
+                            merge_params: merge.params,
+                            merge_value: merge.value
+                        });
+                    }
+                }
+            }
+        }
+        return None;
+    }
+}
+
+// TODO When should the transformation be applied?
+
+/// Takes a `MergeSingle` and returns a list of expressions which replace the element
+/// in the merge with a Lookup.
+fn unroll_values(merge_single: &'a MergeSingle, iters: &'a Vec<TypedIter>, loopsize: usize) -> WeldResult<Vec<TypedExpr>> {
+    if merge_single.params.len() != 3 {
+        return weld_err!("Expected three parameters to Merge function");
+    }
+
+    let ref elem_symbol = merge_single.params[2].name;
+    // To match on the element.
+    let ref elem_ident = ident_expr(elem_symbol.clone(), merge_single.params[2].ty.clone())?;
+    let mut expressions = vec![];
+
+    for i in 0..loopsize {
+        let mut value = merge_single.value.clone();
+        value.transform(&mut |ref mut e| {
+            match e.kind {
+                Ident(ref name) if name == elem_symbol && iters.len() == 1 {
+                    // There is a single iterator, which means the type of the element is the type
+                    // of the iterator's data. Replace it with a lookup into the vector.
+                    return Ok(lookup_expr(iters[0].data.as_ref().clone(), literal_expr(LiteralKind::I64Literal(i as i64))?)?);
+                }
+                GetField { ref expr, ref index } if expr == elem_ident && iters.len() > 1 => {
+                    // There are multiple iterators zipped into a struct, and this expression is
+                    // pulling one of the elements out of that struct. Replace it with a lookup into the vector.
+                    let data_expr = iters[index].data.as_ref().clone();
+                    return Ok(lookup_expr(data_expr, literal_expr(LiteralKind::I64Literal(i as i64))?)?);
+                }
+            }
+            None
+        });
+        expressions.push(value);
+    }
+    return Ok(expressions);
+}
+
+/// Combines the expressions in `values` into a single value based on the kind of builder the
+/// values would have been merged into.
+/// 
+/// As an example, if `values` is [ Literal(1), Literal(2), Literal(3)] and the builder was a
+/// merger[i32,+], this function will produce the expression Literal(1) + Literal(2) + Literal(3).
+fn combine_unrolled_values(bk: BuilderKind, values: Vec<TypedExpr>) -> WeldResult<TypedExpr> {
+    if values.len() == 0 {
+        return weld_err!("Need at least one value to combine in unroller");
+    }
+    match bk {
+        Merger(ref ty, ref binop) => {
+            if values.iter().any(|ref expr| expr.ty != ty) {
+                return weld_err!("Mismatched types in Merger and unrolled values.");
+            }
+            // Use the specified binary op to produce the final expression.
+            let mut prev = None;
+            for value in values.into_iter() {
+                if prev.is_none() {
+                    prev = Some(value);
+                } else {
+                    prev = Ok(binop_expr(*binop, prev.unwrap(), value)?)
+                }
+            }
+            return prev.unwrap();
+        }
+        Appender(ref ty) => {
+            if values.iter().any(|ref expr| expr.ty != ty) {
+                return weld_err!("Mismatched types in Appender and unrolled values.");
+            }
+            return makevector_expr(values)?;
+        }
+        ref bk => {
+            weld_err!("Unroller transform does not support loops with builder of kind {:?}", bk);
+        }
+    }
+}
+

--- a/weld/transforms/unroller.rs
+++ b/weld/transforms/unroller.rs
@@ -30,8 +30,6 @@ struct UnrollPattern<'a> {
 
 impl<'a> UnrollPattern<'a> {
     /// Extracts a `UnrollPattern` from the expression, or returns `None`.
-    // TODO check annotation.
-    // TODO check annotation cutoff.
     fn extract(expr: &'a TypedExpr) -> Option<UnrollPattern> {
         if let Res { ref builder } = expr.kind {
             if let Some(loopsize) = builder.annotations.loopsize() {
@@ -132,8 +130,8 @@ fn unroll_values(parameters: &Vec<TypedParameter>, value: &TypedExpr, vectors: &
         let mut unrolled_value = value.clone();
         unrolled_value.transform(&mut |ref mut e| {
             match e.kind {
-                // TODO identifiers using the index value could also be handled here.
                 Ident(ref name) if name == index_symbol => {
+                    // Index identifiers can be handled by just substituting a static index.
                     Some(literal_expr(LiteralKind::I64Literal(i as i64)).unwrap())
                 }
                 Ident(ref name) if name == elem_symbol && vectors.len() == 1 => {


### PR DESCRIPTION
Uses the `loopsize` annotation to unroll loops over `Appender` or `Merger`.