### PR TITLE
Parse & print utilities

### DIFF
--- a/weld/colors.rs
+++ b/weld/colors.rs
@@ -1,0 +1,29 @@
+//! Basic format strings for colored output.
+
+const RESET: &str = "\x1b[0m";
+
+pub enum Color {
+    Red,
+    BoldRed,
+    Green,
+    Yellow
+}
+
+trait Prefix {
+    fn prefix(&self) -> &str;
+}
+
+impl Prefix for Color {
+    fn prefix(&self) -> &str {
+        match *self {
+            Color::Red     => "\x1b[0;31m",
+            Color::BoldRed => "\x1b[1;31m",
+            Color::Green   => "\x1b[0;32m",
+            Color::Yellow  => "\x1b[0;33m",
+        }
+    }
+}
+
+pub fn format_color(color: Color, text: &str) -> String {
+    format!("{}{}{}", color.prefix(), text, RESET)
+}

--- a/weld/lib.rs
+++ b/weld/lib.rs
@@ -36,6 +36,7 @@ macro_rules! weld_err {
 pub mod annotations;
 pub mod ast;
 pub mod code_builder;
+pub mod colors;
 pub mod common;
 pub mod error;
 pub mod llvm;

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -3679,7 +3679,7 @@ fn simple_predicate() {
     let code = "|v1:vec[i32],v2:vec[bool]| result(for(zip(v1, v2), merger[i32,+], |b,i,e| merge(b, @(predicate:true) if(e.$1, e.$0, 0))))";
     let typed_e = predicate_only(code);
     assert!(typed_e.is_ok());
-    let expected = "|v1:vec[i32],v2:vec[bool]|result(for(zip(v1:vec[i32],v2:vec[bool]),merger[i32,+],|b:merger[i32,+],i:i64,e:{i32,bool}|merge(b:merger[i32,+],select(e:{i32,bool}.$1,e:{i32,bool}.$0,0))))";
+    let expected = "|v1:vec[i32],v2:vec[bool]|result(for(zip(v1:vec[i32],v2:vec[bool]),merger[i32,+],|b:merger[i32,+],i:i64,e:{i32,bool}|merge(b:merger[i32,+],select(e.$1,e.$0,0))))";
     assert_eq!(print_typed_expr_without_indent(&typed_e.unwrap()).as_str(),
                expected);
 
@@ -3729,7 +3729,7 @@ fn predicate_dictmerger() {
     let code = "|v:vec[i32]| result(for(v, dictmerger[{i32, i32},i32,+], |b,i,e| @(predicate:true)if(e>0, merge(b,{{e,e},e*2}), b)))";
     let typed_e = predicate_only(code);
     assert!(typed_e.is_ok());
-    let expected = "|v:vec[i32]|result(for(v:vec[i32],dictmerger[{i32,i32},i32,+],|b:dictmerger[{i32,i32},i32,+],i:i64,e:i32|(let k:{{i32,i32},i32}=({{e:i32,e:i32},(e:i32*2)});select((e:i32>0),k:{{i32,i32},i32},{k:{{i32,i32},i32}.$0,0}))))";
+    let expected = "|v:vec[i32]|result(for(v:vec[i32],dictmerger[{i32,i32},i32,+],|b:dictmerger[{i32,i32},i32,+],i:i64,e:i32|(let k:{{i32,i32},i32}=({{e:i32,e:i32},(e:i32*2)});select((e:i32>0),k:{{i32,i32},i32},{k.$0,0}))))";
     assert_eq!(expected,
                print_typed_expr_without_indent(&typed_e.unwrap()).as_str());
 }

--- a/weld/parser.rs
+++ b/weld/parser.rs
@@ -15,7 +15,7 @@ use super::ast::ExprKind::*;
 use super::ast::LiteralKind::*;
 use super::ast::ScalarKind;
 use super::ast::IterKind::*;
-use super::colors;
+use super::colors::*;
 use super::error::*;
 use super::partial_types::*;
 use super::partial_types::PartialBuilderKind::*;
@@ -114,7 +114,7 @@ impl<'t> Parser<'t> {
         for i in (self.position - context_length)..min((self.position + context_length), self.tokens.len()) {
             let token_str = format!("{}", &self.tokens[i]);
             if i == self.position { 
-                string.push_str(colors::format_color(colors::Color::BoldRed, token_str.as_str()).as_str());
+                string.push_str(format_color(Color::BoldRed, token_str.as_str()).as_str());
             } else {
                 string.push_str(format!("{}", token_str.as_str()).as_str());
             }

--- a/weld/parser.rs
+++ b/weld/parser.rs
@@ -4,6 +4,7 @@
 //! backtracking, so we simply track a position as we go and keep incrementing it.
 
 use std::vec::Vec;
+use std::cmp::min;
 
 use super::ast::Symbol;
 use super::ast::Iter;
@@ -109,8 +110,12 @@ impl<'t> Parser<'t> {
             self.position
         };
 
-        for i in (self.position - context_length)..self.position {
-            string.push_str(format!("{}", &self.tokens[i]).as_str());
+        for i in (self.position - context_length)..min((self.position + context_length), self.tokens.len()) {
+            if i == self.position { 
+                string.push_str(format!("\x1b[1;31m{}\x1b[0m", &self.tokens[i]).as_str());
+            } else {
+                string.push_str(format!("{}", &self.tokens[i]).as_str());
+            }
             if i != self.position - 1 && self.tokens[i+1].requires_space() {
                 if self.tokens[i].requires_space() {
                     string.push_str(" ");

--- a/weld/parser.rs
+++ b/weld/parser.rs
@@ -15,6 +15,7 @@ use super::ast::ExprKind::*;
 use super::ast::LiteralKind::*;
 use super::ast::ScalarKind;
 use super::ast::IterKind::*;
+use super::colors;
 use super::error::*;
 use super::partial_types::*;
 use super::partial_types::PartialBuilderKind::*;
@@ -111,10 +112,11 @@ impl<'t> Parser<'t> {
         };
 
         for i in (self.position - context_length)..min((self.position + context_length), self.tokens.len()) {
+            let token_str = format!("{}", &self.tokens[i]);
             if i == self.position { 
-                string.push_str(format!("\x1b[1;31m{}\x1b[0m", &self.tokens[i]).as_str());
+                string.push_str(colors::format_color(colors::Color::BoldRed, token_str.as_str()).as_str());
             } else {
-                string.push_str(format!("{}", &self.tokens[i]).as_str());
+                string.push_str(format!("{}", token_str.as_str()).as_str());
             }
             if i != self.position - 1 && self.tokens[i+1].requires_space() {
                 if self.tokens[i].requires_space() {

--- a/weld/parser.rs
+++ b/weld/parser.rs
@@ -111,13 +111,14 @@ impl<'t> Parser<'t> {
             self.position
         };
 
-        for i in (self.position - context_length)..min((self.position + context_length), self.tokens.len()) {
+        for i in (self.position - context_length)..min((self.position + context_length), self.tokens.len()-1) {
             let token_str = format!("{}", &self.tokens[i]);
             if i == self.position { 
                 string.push_str(format_color(Color::BoldRed, token_str.as_str()).as_str());
             } else {
                 string.push_str(format!("{}", token_str.as_str()).as_str());
             }
+
             if i != self.position - 1 && self.tokens[i+1].requires_space() {
                 if self.tokens[i].requires_space() {
                     string.push_str(" ");

--- a/weld/pretty_print.rs
+++ b/weld/pretty_print.rs
@@ -329,7 +329,7 @@ fn print_expr_impl<T: PrintableType>(expr: &Expr<T>,
 
         GetField { ref expr, index } => {
             format!("{}.${}",
-                    print_expr_impl(expr, typed, indent, should_indent),
+                    print_expr_impl(expr, false, indent, should_indent),
                     index)
         }
 


### PR DESCRIPTION
Highlight problem tokens in parse error output, and remove types when printing GetField to make pretty printed `Expr`s parseable.