### PR TITLE
Version numbers for log and env_logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ easy_ll = { path = "easy_ll", version = "^0.1.0" }
 weld_common = { path = "weld_common", version = "^0.1.0" }
 libc = "0.2.0"
 csv = "0.15.0"
-log = "*"
-env_logger = "*"
+log = "0.3.9"
+env_logger = "0.4.3"
 chrono = "*"
 
 [lib]


### PR DESCRIPTION
New versions have changes to class names that aren't backwards-compatible.