### PR TITLE
RangeIter implementation

### DIFF
--- a/examples/cpp/vector_benchmark/vector_benchmark.cpp
+++ b/examples/cpp/vector_benchmark/vector_benchmark.cpp
@@ -17,8 +17,8 @@ struct args {
     int32_t a;
 };
 
-const char *program = "|x:vec[i32], a:i32| result(for(x, merger[i32,+],\
-                       |b,i,e| merge(b, e)))";
+const char *program = "|x:vec[i32], a:i32| result(for(zip(x, rangeiter(1L, 101L, 1L)), merger[i32,+],\
+                       |b,i,e| merge(b, i32(i64(e.$0) + e.$1))))";
 
 int main() {
     // Compile Weld module.
@@ -34,13 +34,10 @@ int main() {
     }
 
     weld_vector v;
-    const uint64_t length = 4093*10000 + 33;
-    int32_t *data = (int32_t *)malloc(sizeof(int32_t) * (length + 100));
-    for (int i = 0; i < length + 100; i++) {
+    const uint64_t length = 100;
+    int32_t *data = (int32_t *)malloc(sizeof(int32_t) * length);
+    for (int i = 0; i < length; i++) {
         data[i] = 1;
-        if (i >= length) {
-            data[i] = 0;
-        }
     }
 
     v.data = data;

--- a/weld/ast.rs
+++ b/weld/ast.rs
@@ -237,7 +237,8 @@ pub struct Expr<T: TypeBounds> {
 pub enum IterKind {
     ScalarIter, // A standard scalar iterator.
     SimdIter, // A vector iterator.
-    FringeIter, // A fringe iterator, handling the fringe of a vector iter.
+    FringeIter,
+    RangeIter,
 }
 
 impl fmt::Display for IterKind {
@@ -247,6 +248,7 @@ impl fmt::Display for IterKind {
             ScalarIter => "scalar",
             SimdIter => "vectorized",
             FringeIter => "fringe",
+            RangeIter => "range",
         };
         f.write_str(text)
     }

--- a/weld/pretty_print.rs
+++ b/weld/pretty_print.rs
@@ -135,6 +135,7 @@ fn print_iter_kind<T: PrintableType>(iter: &Iter<T>) -> &str {
         IterKind::ScalarIter => "",
         IterKind::SimdIter => "simd",
         IterKind::FringeIter => "fringe",
+        IterKind::RangeIter => "range",
     }
 }
 

--- a/weld/sir/mod.rs
+++ b/weld/sir/mod.rs
@@ -579,7 +579,8 @@ impl fmt::Display for ParallelForIter {
         let iterkind = match self.kind {
             IterKind::ScalarIter => "iter",
             IterKind::SimdIter => "simditer",
-            IterKind::FringeIter => "fringeiter"
+            IterKind::FringeIter => "fringeiter",
+            IterKind::RangeIter => "rangeiter",
         };
 
         if self.start.is_some() {

--- a/weld/tokenizer.rs
+++ b/weld/tokenizer.rs
@@ -47,6 +47,7 @@ pub enum Token {
     TScalarIter,
     TSimdIter,
     TFringeIter,
+    TRangeIter,
     TLen,
     TLookup,
     TKeyExists,
@@ -167,7 +168,7 @@ pub fn tokenize(input: &str) -> WeldResult<Vec<Token>> {
         static ref KEYWORD_RE: Regex = Regex::new(
             "^(if|for|zip|len|lookup|keyexists|slice|sort|exp|sin|cos|tan|asin|acos|atan|sinh|cosh|tanh|\
              log|erf|sqrt|simd|select|broadcast|\
-             iterate|cudf|simditer|fringeiter|iter|merge|result|let|true|false|macro|\
+             iterate|cudf|simditer|fringeiter|rangeiter|iter|merge|result|let|true|false|macro|\
              i8|i16|i32|i64|u8|u16|u32|u64|f32|f64|bool|vec|appender|merger|vecmerger|\
              dictmerger|groupmerger|tovec|min|max|pow)$").unwrap();
 
@@ -230,6 +231,7 @@ pub fn tokenize(input: &str) -> WeldResult<Vec<Token>> {
                             "iter" => TScalarIter,
                             "simditer" => TSimdIter,
                             "fringeiter" => TFringeIter,
+                            "rangeiter" => TRangeIter,
                             "len" => TLen,
                             "lookup" => TLookup,
                             "keyexists" => TKeyExists,
@@ -391,6 +393,7 @@ impl fmt::Display for Token {
                     TScalarIter => "iter",
                     TSimdIter => "simditer",
                     TFringeIter => "fringeiter",
+                    TRangeIter => "rangeiter",
                     TLen => "len",
                     TLookup => "lookup",
                     TKeyExists => "keyexists",

--- a/weld/type_inference.rs
+++ b/weld/type_inference.rs
@@ -448,11 +448,17 @@ fn infer_locally(expr: &mut PartialExpr, env: &mut TypeMap) -> WeldResult<bool> 
             // Push iters and builder type into func
             let mut elem_types = vec![];
             for iter in iters.iter_mut() {
-                let elem_type = match iter.data.ty {
+                let mut elem_type = match iter.data.ty {
                     Vector(ref elem) => *elem.clone(),
                     Unknown => Unknown,
                     _ => return weld_err!("non-vector type in For"),
                 };
+
+                // RangeIters always have this element type.
+                if iter.kind == IterKind::RangeIter {
+                    elem_type = Scalar(I64);
+                }
+
                 elem_types.push(elem_type);
                 if iter.start.is_some() {
                     for i in [&mut iter.start, &mut iter.end, &mut iter.stride].iter_mut() {


### PR DESCRIPTION
Implements a basic iterator over a range of values without materializing a vector.

The syntax for this follows the other iterators:

`for(rangeiter(0L, 100L, 1L), ...)` iterates over the interval `[0, 100)` and accesses every element. The arguments are the start index, the end index, and the stride; iteration continues until the index is greater than or equal to the specified end index.

The range iterator follows all the standard rule of the for loop: namely, the number of iterations must be equal across all zipped iterators.

## Limitations

* Currently doesn't support transforms that inspect iterators (namely, loop fusion and vectorization).