### PR TITLE
Improve numpy_to_weld_type

### DIFF
--- a/python/grizzly/grizzly/encoders.py
+++ b/python/grizzly/grizzly/encoders.py
@@ -1,9 +1,3 @@
-"""Summary
-
-Attributes:
-    numpy_to_weld_type_mapping (TYPE): Description
-"""
-
 from weld.weldobject import *
 import numpy as np
 import os
@@ -11,15 +5,29 @@ import sys
 
 import pkg_resources
 
-numpy_to_weld_type_mapping = {
-    'str': WeldVec(WeldChar()),
-    'int16': WeldInt16(),
-    'int32': WeldInt(),
-    'int64': WeldLong(),
-    'float32': WeldFloat(),
-    'float64': WeldDouble(),
-    'bool': WeldBit()
+_numpy_to_weld_type_mapping = {
+    'S': WeldVec(WeldChar()),
+    'b': WeldChar(),
+    'h': WeldInt16(),
+    'i': WeldInt(),
+    'l': WeldLong(),
+    'f': WeldFloat(),
+    'd': WeldDouble(),
+    '?': WeldBit()
 }
+
+def numpy_to_weld_type(numpy_dtype):
+    """ Convert from np.dtype or str to WeldType
+
+    :param numpy_dtype: np.dtype or str
+    :return: WeldType
+    """
+    assert isinstance(numpy_dtype, (np.dtype, str))
+
+    if isinstance(numpy_dtype, str):
+        numpy_dtype = np.dtype(numpy_dtype)
+
+    return _numpy_to_weld_type_mapping[numpy_dtype.char]
 
 
 def to_shared_lib(name):

--- a/python/grizzly/grizzly/grizzly.py
+++ b/python/grizzly/grizzly/grizzly.py
@@ -66,7 +66,7 @@ class DataFrameWeld:
                 raw_column = self.raw_columns[key]
                 weld_type = WeldVec(WeldChar())
             else:
-                weld_type = grizzly_impl.numpy_to_weld_type_mapping[dtype]
+                weld_type = grizzly_impl.numpy_to_weld_type(dtype)
             if self.predicates is None:
                 return SeriesWeld(raw_column, weld_type, self, key)
             return SeriesWeld(
@@ -101,7 +101,7 @@ class DataFrameWeld:
         """
         if isinstance(value, np.ndarray):
             dtype = str(value.dtype)
-            weld_type = grizzly_impl.numpy_to_weld_type_mapping[dtype]
+            weld_type = grizzly_impl.numpy_to_weld_type(dtype)
             self.unmaterialized_cols[key] = SeriesWeld(
                 value,
                 weld_type,
@@ -134,8 +134,8 @@ class DataFrameWeld:
             if self.predicates is None:
                 return self.df.values
             if isinstance(self.df.values, np.ndarray):
-                weld_type = grizzly_impl.numpy_to_weld_type_mapping[
-                    str(self.df.values.dtype)]
+                weld_type = grizzly_impl.numpy_to_weld_type(
+                    self.df.values.dtype)
                 dim = self.df.values.ndim
                 return LazyOpResult(
                     grizzly_impl.filter(
@@ -790,8 +790,8 @@ class GroupByWeld:
             self.grouping_column_type = column.weld_type
             self.grouping_column = column.expr
         elif isinstance(column, np.ndarray):
-            self.grouping_column_type = numpyImpl.numpy_to_weld_type_mapping[
-                str(column.dtype)]
+            self.grouping_column_type = numpyImpl.numpy_to_weld_type(
+                column.dtype)
             self.grouping_column = column
 
         self.column_names = df._get_column_names()
@@ -807,8 +807,8 @@ class GroupByWeld:
                 column_type = column.weld_type
                 column = column.expr
             elif isinstance(column, np.ndarray):
-                column_type = numpyImpl.numpy_to_weld_type_mapping[
-                    str(column.dtype)]
+                column_type = numpyImpl.numpy_to_weld_type(
+                    column.dtype)
             self.columns.append(column)
             self.column_types.append(column_type)
 

--- a/python/grizzly/grizzly/lazy_op.py
+++ b/python/grizzly/grizzly/lazy_op.py
@@ -18,7 +18,7 @@ def to_weld_type(weld_type, dim):
     return weld_type
 
 
-class LazyOpResult:
+class LazyOpResult(object):
     """Wrapper class around as yet un-evaluated Weld computation results
 
     Attributes:

--- a/python/grizzly/grizzly/numpy_weld.py
+++ b/python/grizzly/grizzly/numpy_weld.py
@@ -80,15 +80,15 @@ def dot(matrix, vector):
         matrix_weld_type = matrix.weld_type
         matrix = matrix.expr
     elif isinstance(matrix, np.ndarray):
-        matrix_weld_type = numpy_weld_impl.numpy_to_weld_type_mapping[
-            str(matrix.dtype)]
+        matrix_weld_type = numpy_weld_impl.numpy_to_weld_type(
+            matrix.dtype)
 
     if isinstance(vector, LazyOpResult):
         vector_weld_type = vector.weld_type
         vector = vector.expr
     elif isinstance(vector, np.ndarray):
-        vector_weld_type = numpy_weld_impl.numpy_to_weld_type_mapping[
-            str(vector.dtype)]
+        vector_weld_type = numpy_weld_impl.numpy_to_weld_type(
+            vector.dtype)
 
     return NumpyArrayWeld(
         numpy_weld_impl.dot(
@@ -111,6 +111,6 @@ def exp(vector):
         weld_type = vector.weld_type
         vector = vector.expr
     elif isinstance(vector, np.ndarray):
-        weld_type = numpy_weld_impl.numpy_to_weld_type_mapping[
-            str(vector.dtype)]
+        weld_type = numpy_weld_impl.numpy_to_weld_type(
+            vector.dtype)
     return NumpyArrayWeld(numpy_weld_impl.exp(vector, weld_type), WeldDouble())


### PR DESCRIPTION
1. A more generic way of converting types: tackle the multiple dtypes for string in numpy, extensible method, and option to pass a string
2. Slight change to conform to old-style python class on LazyOpResult (also making it easy to subclass)