### PR TITLE
Prevent CSE in SIR for CUDFs

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1489,8 +1489,8 @@ fn simple_for_vecmerger_binops() {
         assert_eq!(unsafe { *result.sum.data.offset(i) },
                    input_vec[i as usize] + input_vec[i as usize] * 7);
         assert_eq!(unsafe { *result.prod.data.offset(i) }, input_vec[i as usize] * (i as i64));
-        assert_eq!(unsafe { *result.min.data.offset(i) }, cmp::min(input_vec[i as usize], (i as i64)));
-        assert_eq!(unsafe { *result.max.data.offset(i) }, cmp::max(input_vec[i as usize], (i as i64)));
+        assert_eq!(unsafe { *result.min.data.offset(i) }, cmp::min(input_vec[i as usize], i as i64));
+        assert_eq!(unsafe { *result.max.data.offset(i) }, cmp::max(input_vec[i as usize], i as i64));
     }
     unsafe { free_value_and_module(ret_value) };
 }

--- a/weld/llvm.rs
+++ b/weld/llvm.rs
@@ -13,7 +13,6 @@ use common::WeldRuntimeErrno;
 use std::io::Write;
 use std::path::PathBuf;
 use std::fs::OpenOptions;
-use std::ascii::AsciiExt;
 
 use super::ast::*;
 use super::ast::Type::*;
@@ -3481,7 +3480,7 @@ impl LlvmGenerator {
                                         for s in b.statements.iter() {
                                             self.gen_statement(s, keyfunc, keyfunc_ctx)?
                                         }
-                                        if (i != end_block_index) {
+                                        if i != end_block_index {
                                             if let Terminator::Branch { ref cond, on_true, on_false} = b.terminator {
                                                 keyfunc_ctx.code.add(format!("; {}", b.terminator));
                                                 if self.trace_run {

--- a/weld/parser.rs
+++ b/weld/parser.rs
@@ -112,7 +112,7 @@ impl<'t> Parser<'t> {
             self.position
         };
 
-        for i in (self.position - context_length)..min((self.position + context_length), self.tokens.len()-1) {
+        for i in (self.position - context_length)..min(self.position + context_length, self.tokens.len()-1) {
             let token_str = format!("{}", &self.tokens[i]);
             if i == self.position { 
                 string.push_str(format_color(Color::BoldRed, token_str.as_str()).as_str());

--- a/weld/tokenizer.rs
+++ b/weld/tokenizer.rs
@@ -9,7 +9,6 @@
 use std::fmt;
 use std::str::FromStr;
 use std::vec::Vec;
-use std::ascii::AsciiExt;
 
 use regex::Regex;
 

--- a/weld/transforms/inliner.rs
+++ b/weld/transforms/inliner.rs
@@ -157,9 +157,9 @@ pub fn inline_cast(expr: &mut TypedExpr) {
             if let Literal(ref literal_kind) = child_expr.kind {
                 return match (scalar_kind, literal_kind) {
                     (&F64, &I32Literal(a)) => Some(literal_expr(F64Literal((a as f64).to_bits())).unwrap()),
-                    (&I64, &I32Literal(a)) => Some(literal_expr(I64Literal((a as i64))).unwrap()),
+                    (&I64, &I32Literal(a)) => Some(literal_expr(I64Literal(a as i64)).unwrap()),
                     (&F64, &I64Literal(a)) => Some(literal_expr(F64Literal((a as f64).to_bits())).unwrap()),
-                    (&I64, &I64Literal(a)) => Some(literal_expr(I64Literal((a as i64))).unwrap()),
+                    (&I64, &I64Literal(a)) => Some(literal_expr(I64Literal(a as i64)).unwrap()),
                     _ => None,
                 }
             }


### PR DESCRIPTION
CUDFs can have "safe" side effects such as printing values -- to allow these side effects, this PR removes the SIR's CSE functionality for CUDFs. Before, code that called the same CUDF with the same arguments could be de-duplicated if it was in the same basic block. Now, both CUDFs will be called.

Note that side effects such as modifying global state are still semantically in correct in Weld (of course, Weld cannot statically check for this), since UDFs may be called in parallel, out of order, etc. from a for loop.

Resolves #349 