### PR TITLE
Standardize Booleans as 1-Byte values on the Weld ABI

### DIFF
--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -112,15 +112,15 @@ fn bool_eq() {
     let ref input_data: i32 = 0;
 
     let ret_value = compile_and_run(code, conf, input_data);
-    let data = ret_value.data() as *const WeldVec<bool>;
+    let data = ret_value.data() as *const WeldVec<WeldBool>;
     let result = unsafe { (*data).clone() };
 
     assert_eq!(result.len, 2);
 
     let bool1 = unsafe { (*result.data.offset(0)).clone() };
     let bool2 = unsafe { (*result.data.offset(1)).clone() };
-    assert_eq!(bool1, true);
-    assert_eq!(bool2, false);
+    assert_eq!(bool1 , 1);
+    assert_eq!(bool2 , 0);
 }
 
 #[test]

--- a/tests/vector_tests.rs
+++ b/tests/vector_tests.rs
@@ -14,12 +14,12 @@ fn map_comparison() {
     let ref input_data = WeldVec::from(&input_vec);
 
     let ret_value = compile_and_run(code, conf, input_data);
-    let data = ret_value.data() as *const WeldVec<bool>;
+    let data = ret_value.data() as *const WeldVec<WeldBool>;
     let result = unsafe { (*data).clone() };
     assert_eq!(result.len as usize, input_vec.len());
     for i in 0..(result.len as isize) {
         assert_eq!(
-            unsafe { *result.data.offset(i) },
+            unsafe { *result.data.offset(i) } != 0,
             input_vec[i as usize] == 100
         )
     }

--- a/weld/codegen/llvm2/builder/for_loop.rs
+++ b/weld/codegen/llvm2/builder/for_loop.rs
@@ -541,7 +541,7 @@ impl ForLoopGenInternal for LlvmGenerator {
                               pass_block: LLVMBasicBlockRef,
                               fail_block: LLVMBasicBlockRef) -> WeldResult<()> {
         use self::llvm_sys::LLVMIntPredicate::LLVMIntEQ;
-        let mut passed = self.bool(true);
+        let mut passed = self.i1(true);
         if self.conf.enable_bounds_checks {
             for value in iterations.iter().skip(1) {
                 let mut check = LLVMBuildICmp(ctx.builder, LLVMIntEQ, iterations[0], *value, c_str!(""));

--- a/weld/codegen/llvm2/dict.rs
+++ b/weld/codegen/llvm2/dict.rs
@@ -809,7 +809,7 @@ impl Dict {
             let mut arg_tys = [
                 self.dict_ty,
                 ser_ty,
-                self.bool_type(),
+                self.i1_type(),
                 self.void_pointer_type(),
                 self.void_pointer_type(),
                 self.run_handle_type()

--- a/weld/codegen/llvm2/eq.rs
+++ b/weld/codegen/llvm2/eq.rs
@@ -70,7 +70,7 @@ impl GenEq for LlvmGenerator {
         let llvm_ty = self.llvm_type(ty)?;
         // XXX Do we need the run handle?
         let mut arg_tys = [LLVMPointerType(llvm_ty, 0), LLVMPointerType(llvm_ty, 0)];
-        let ret_ty = self.bool_type();
+        let ret_ty = self.i1_type();
 
         let c_prefix = LLVMPrintTypeToString(llvm_ty);
         let prefix = CStr::from_ptr(c_prefix);
@@ -97,7 +97,7 @@ impl GenEq for LlvmGenerator {
                 gen_binop(builder, Equal, left, right, ty)?
             }
             Struct(ref elems) => {
-                let mut result = self.bool(true);
+                let mut result = self.i1(true);
                 for (i, elem) in elems.iter().enumerate() {
                     let func = self.gen_eq_fn(elem)?;
                     let field_left = LLVMBuildStructGEP(builder, left, i as u32, c_str!(""));
@@ -151,7 +151,7 @@ impl GenEq for LlvmGenerator {
 
                 // Finished - build a PHI node to select the result.
                 LLVMPositionBuilderAtEnd(builder, done_block);
-                let result = LLVMBuildPhi(builder, self.bool_type(), c_str!(""));
+                let result = LLVMBuildPhi(builder, self.i1_type(), c_str!(""));
 
                 let mut incoming_blocks = [entry_block, compare_data_block];
                 let mut incoming_values = [size_eq, data_eq];
@@ -203,9 +203,9 @@ impl GenEq for LlvmGenerator {
 
                 // Finish block - set result and compute number of consumed bits.
                 LLVMPositionBuilderAtEnd(builder, done_block);
-                let result = LLVMBuildPhi(builder, self.bool_type(), c_str!(""));
+                let result = LLVMBuildPhi(builder, self.i1_type(), c_str!(""));
                 let mut blocks = [entry_block, compare_data_block, loop_block];
-                let mut values = [size_eq, self.bool(true), eq_result];
+                let mut values = [size_eq, self.i1(true), eq_result];
                 LLVMAddIncoming(result, values.as_mut_ptr(), blocks.as_mut_ptr(), values.len() as u32);
                 result
             }

--- a/weld/codegen/llvm2/intrinsic.rs
+++ b/weld/codegen/llvm2/intrinsic.rs
@@ -234,7 +234,7 @@ impl Intrinsics {
                                       dst: LLVMValueRef,
                                       src: LLVMValueRef,
                                       size: LLVMValueRef) -> LLVMValueRef {
-        let mut args = [dst, src, size, self.i32(8), self.bool(false)];
+        let mut args = [dst, src, size, self.i32(8), self.i1(false)];
         LLVMBuildCall(builder,
                       self.get("llvm.memcpy.p0i8.p0i8.i64").unwrap(),
                       args.as_mut_ptr(), args.len() as u32, c_str!(""))
@@ -322,7 +322,7 @@ impl Intrinsics {
         LLVMExtAddAttrsOnParameter(self.context, function, &[NoCapture, NoAlias, NonNull, ReadOnly], 1);
         self.intrinsics.insert(name.into_string().unwrap(), function);
 
-        let mut params = vec![int8p, int8p, self.i64_type(), self.i32_type(), self.bool_type()];
+        let mut params = vec![int8p, int8p, self.i64_type(), self.i32_type(), self.i1_type()];
         let name = CString::new("llvm.memcpy.p0i8.p0i8.i64").unwrap();
         let fn_type = LLVMFunctionType(self.void_type(), params.as_mut_ptr(), params.len() as u32, 0);
         let function = LLVMAddFunction(self.module, name.as_ptr(), fn_type);

--- a/weld/codegen/llvm2/serde.rs
+++ b/weld/codegen/llvm2/serde.rs
@@ -377,7 +377,7 @@ impl SerHelper for LlvmGenerator {
                 // keys and values are memcpy'd individually into the buffer.
                 let dictionary = self.load(builder, value)?;
                 let null_pointer = self.null_ptr(self.i8_type());
-                let no_pointer_flag = self.bool(false);
+                let no_pointer_flag = self.i1(false);
                 let result = {
                     let mut methods = self.dictionaries.get_mut(ty).unwrap();
                     methods.gen_serialize(builder,
@@ -397,7 +397,7 @@ impl SerHelper for LlvmGenerator {
                 // function to serialize each key and value. We thus generate an externalized key
                 // and value serialization function and pass it to the dictionary's serializer.
                 let dictionary = self.load(builder, value)?;
-                let pointer_flag = self.bool(true);
+                let pointer_flag = self.i1(true);
                 // Deserialization functions have the signature (SER_TY, T*) -> void
                 // Generate the serialize function for the key.
                 let key_ser_fn = self.gen_serialize_fn(key)?;

--- a/weld/data/mod.rs
+++ b/weld/data/mod.rs
@@ -20,6 +20,13 @@ use std::marker::PhantomData;
 
 use std::fmt;
 
+/// A boolean in Weld.
+///
+/// Weld booleans are always defined as a single-byte unsigned value. Weld will always return a
+/// boolean with value 0 or 1, corresponding to `false` and `true` respectively. When passing
+/// booleans as input, Weld will consider _any_ non-zero value to be `true`, and 0 to be false.
+pub type WeldBool = u8;
+
 /// A dynamically sized constant vector.
 ///
 /// Vectors are always defined as a pointer and a length.


### PR DESCRIPTION
Booleans passed into and out of Weld are now defined to be exactly one (unsigned) byte in size.