### PR TITLE
Make pyweld Python 3 friendly

### DIFF
--- a/python/pyweld/setup.py
+++ b/python/pyweld/setup.py
@@ -2,10 +2,9 @@ import os
 import platform
 import shutil
 import subprocess
-import sys
 
-from setuptools import setup, Distribution
 import setuptools.command.build_ext as _build_ext
+from setuptools import setup, Distribution
 from setuptools.command.develop import develop
 from setuptools.extension import Extension
 

--- a/python/pyweld/weld/bindings.py
+++ b/python/pyweld/weld/bindings.py
@@ -2,11 +2,9 @@
 # Implements a wrapper around the Weld API.
 #
 
-from ctypes import *
-
-import os
-import platform
 import copy
+import platform
+from ctypes import *
 
 import pkg_resources
 
@@ -46,7 +44,7 @@ class WeldModule(c_void_p):
             c_char_p, c_weld_conf, c_weld_err]
         weld_module_compile.restype = c_weld_module
 
-        code = c_char_p(code)
+        code = c_char_p(code.encode('utf-8'))
         self.module = weld_module_compile(code, conf.conf, err.error)
 
     def run(self, conf, arg, err):
@@ -113,7 +111,7 @@ class WeldConf(c_void_p):
         self.conf = weld_conf_new()
 
     def get(self, key):
-        key = c_char_p(key)
+        key = c_char_p(key.encode('utf-8'))
         weld_conf_get = weld.weld_conf_get
         weld_conf_get.argtypes = [c_weld_conf, c_char_p]
         weld_conf_get.restype = c_char_p
@@ -121,8 +119,8 @@ class WeldConf(c_void_p):
         return copy.copy(val)
 
     def set(self, key, value):
-        key = c_char_p(key)
-        value = c_char_p(value)
+        key = c_char_p(key.encode('utf-8'))
+        value = c_char_p(value.encode('utf-8'))
         weld_conf_set = weld.weld_conf_set
         weld_conf_set.argtypes = [c_weld_conf, c_char_p, c_char_p]
         weld_conf_set.restype = None

--- a/python/pyweld/weld/encoders.py
+++ b/python/pyweld/weld/encoders.py
@@ -3,13 +3,13 @@ Implements some common standard encoders and decoders mapping
 Python types to Weld types.
 """
 
-from types import *
-
-from weldobject import WeldObjectEncoder, WeldObjectDecoder
-import bindings as cweld
+import ctypes
 
 import numpy as np
-import ctypes
+
+from . import bindings as cweld
+from .types import *
+from .weldobject import WeldObjectEncoder, WeldObjectDecoder
 
 
 def dtype_to_weld_type(dtype):


### PR DESCRIPTION
- use `__future__ print_function` & update prints
- optimize imports
- use `encode` with `c_char_p`
- move to separate static method the weld input name generation
- use `sorted`

Tested with Python 2.7 & 3.5:

    python setup.py bdist_wheel
    python3 setup.py bdist_wheel


    import numpy as np

    from weld.encoders import NumpyArrayDecoder, NumpyArrayEncoder
    from weld.types import WeldLong
    from weld.weldobject import WeldObject

    weld_obj = WeldObject(NumpyArrayEncoder(), NumpyArrayDecoder())
    obj_id = weld_obj.update(np.array([1, 2, 3]))
    weld_obj.weld_code = "len(%s)" % obj_id

    print(weld_obj.evaluate(WeldLong()))