### PR TITLE
Add __ne__ to WeldType

### DIFF
--- a/python/pyweld/weld/types.py
+++ b/python/pyweld/weld/types.py
@@ -40,6 +40,17 @@ class WeldType(object):
         """
         return hash(other) == hash(self)
 
+    def __ne__(self, other):
+        """Summary
+
+        Args:
+            other (TYPE): Description
+
+        Returns:
+            TYPE: Description
+        """
+        return hash(other) != hash(self)
+
     @property
     def ctype_class(self):
         """


### PR DESCRIPTION
Required by Python 2 for `!=` checks; Python 3 used the negation of `__eq__` by default.