### PR TITLE
NULL-pointer check for dictionary + allow NULL in ToVec

### DIFF
--- a/weld/codegen/llvm2/serde.rs
+++ b/weld/codegen/llvm2/serde.rs
@@ -669,6 +669,10 @@ impl DeHelper for LlvmGenerator {
                     // having to do this.
                     use self::llvm_sys::LLVMIntPredicate::LLVMIntSGT;
                     use codegen::llvm2::hash::GenHash;
+                    use std::ffi::CString;
+
+
+                    self.gen_print(builder, run, CString::new("Deserializing dictionary").unwrap())?;
 
                     let size_type = self.i64_type();
                     let (size, start_position) = self.gen_get_value(builder, size_type, buffer, position)?;


### PR DESCRIPTION
Adds assertions for dictionary methods to ensure that a null pointer is not passed.

The `tovec` function supports null dictionaries: a null dictionary indicates no key/value pairs, and returns a 0-sized vector. All other methods require a valid dictionary and will now fail with an assertion error if not compiled with `-DNDEBUG`