### PR TITLE
Fix caching for the hello_weld python example

### DIFF
--- a/examples/python/hello_weld/lib.py
+++ b/examples/python/hello_weld/lib.py
@@ -60,7 +60,7 @@ class HelloWeldVector(object):
 
     def __str__(self):
         if self.cached is not None:
-            return str(v)
+            return str(self.cached)
         v = self.weldobj.evaluate(WeldVec(WeldInt()), verbose=False)
         self.cached = v
         return str(v)


### PR DESCRIPTION
This example was incorrectly referencing the `v` variable in the caching code.

This is an example of the existing behavior:

```python
>>> from lib import *
>>> import numpy as np
>>> size = (2 << 28)
>>> a = np.zeros((size), dtype='int32')
>>> b = HelloWeldVector(a)
>>> print b
[0 0 0 ... 0 0 0]
>>> print b
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "lib.py", line 63, in __str__
    return str(v)
UnboundLocalError: local variable 'v' referenced before assignment
```

After this fix, subsequent calls to `print b` immediately return the cached zero vector, as expected.