### PR TITLE
Rewrite of Annotation System

### DIFF
--- a/weld/ast/ast.rs
+++ b/weld/ast/ast.rs
@@ -1,6 +1,5 @@
 //! Defines the Weld abstract syntax tree.
 
-use annotation::Annotations;
 use error::*;
 use util;
 
@@ -10,12 +9,91 @@ use self::BinOpKind::*;
 
 use std::fmt;
 use std::vec;
+use std::collections::BTreeMap;
 
 #[cfg(test)]
 use tests::*;
 
 /// Name used for placeholder expressions.
 const PLACEHOLDER_NAME: &'static str = "#placeholder";
+
+/// An annotation over a type or expression.
+///
+/// Annotations are unstructured String key-value pairs. They can be added on expressions and
+/// interpreted in different ways by the compiler.
+#[derive(Clone,Debug,PartialEq,Eq,Hash)]
+pub struct Annotations {
+    /// Holds the annotations.
+    ///
+    /// This is wrapped in an option so we don't need to allocate memory in cases where the HashMap
+    /// is empty (which will usually be the case).
+    values: Option<BTreeMap<String, String>>,
+}
+
+impl Annotations {
+    /// Create a new set of empty annotations.
+    pub fn new() -> Annotations {
+        Annotations {
+            values: None,
+        }
+    }
+
+    /// Set an annotation with key associated with value.
+    ///
+    /// The previous value for this key is returned if there was one. 
+    pub fn set<K: Into<String>, V: Into<String>>(&mut self, key: K, value: V) -> Option<String> {
+        if self.values.is_none() {
+            self.values = Some(BTreeMap::new());
+        }
+        self.values
+            .as_mut()
+            .unwrap()
+            .insert(key.into(), value.into())
+    }
+
+    /// Get the annotation value associated with a key.
+    ///
+    /// Returns `None` if the key was not found.
+    pub fn get<K: AsRef<str>>(&self, key: K) -> Option<&str> {
+        if self.values.is_none() {
+            return None
+        }
+        self.values
+            .as_ref()
+            .unwrap()
+            .get(key.as_ref())
+            .map(|v| v.as_ref())
+    }
+
+    /// Return whether the annotations are empty.
+    pub fn is_empty(&self) -> bool {
+        self.values.as_ref().map(|f| f.len()).unwrap_or(0) == 0
+    }
+
+    /// Clears the annotations.
+    pub fn clear(&mut self) {
+        self.values = None;
+    }
+}
+
+impl fmt::Display for Annotations {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.values.is_none() {
+            return write!(f, "");
+        }
+
+        let mut annotations = self.values.as_ref().unwrap()
+            .iter()
+            .map(|(k, v)| format!("{}:{}", k, v))
+            .collect::<Vec<String>>();
+
+        annotations.sort();
+        let annotations = annotations.join(",");
+
+        // Sort the annotations alphabetically when displaying them so the result is deterministic.
+        write!(f, "@({})", annotations)
+    }
+}
 
 /// Types in the Weld IR.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/weld/ast/ast.rs
+++ b/weld/ast/ast.rs
@@ -21,6 +21,15 @@ const PLACEHOLDER_NAME: &'static str = "#placeholder";
 ///
 /// Annotations are unstructured String key-value pairs. They can be added on expressions and
 /// interpreted in different ways by the compiler.
+///
+/// ## Limitations
+///
+/// Currently, the parser is only capable of parsing annotation values that are either identifiers (i.e.,
+/// single-token strings), boolean literals, floating point literals, and signed integer literals.
+/// Keys must be identifiers (i.e., non-numeric, non-boolean strings that are not reserved words).
+///
+/// The annotation system should in theory support arbitrary string key/value pairs: the parser
+/// will eventually be updated to support this.
 #[derive(Clone,Debug,PartialEq,Eq,Hash)]
 pub struct Annotations {
     /// Holds the annotations.

--- a/weld/ast/constructors.rs
+++ b/weld/ast/constructors.rs
@@ -7,7 +7,6 @@ use ast::Type::*;
 use ast::BuilderKind::*;
 use ast::LiteralKind::*;
 use error::*;
-use annotation::*;
 
 pub fn new_expr(kind: ExprKind, ty: Type) -> WeldResult<Expr> {
     Ok(Expr {

--- a/weld/ast/type_inference.rs
+++ b/weld/ast/type_inference.rs
@@ -13,10 +13,6 @@ use error::*;
 
 use fnv::FnvHashMap;
 
-#[cfg(test)]
-use tests::*;
-#[cfg(test)]
-use annotation::*;
 
 type TypeMap = FnvHashMap<Symbol, Type>;
 type Binding = (Symbol, Option<Type>);
@@ -889,6 +885,7 @@ impl InferTypesInternal for Expr {
 
 #[test]
 fn infer_types_test() {
+    use tests::*;
     let e = parse_expr("a").unwrap();
     assert_eq!(print_typed_expr_without_indent(&e).as_str(), "a:?");
 

--- a/weld/codegen/llvm2/builder/mod.rs
+++ b/weld/codegen/llvm2/builder/mod.rs
@@ -10,8 +10,6 @@
 
 extern crate llvm_sys;
 
-use annotation::Annotations;
-
 use ast::*;
 use ast::BuilderKind::*;
 use ast::Type::*;

--- a/weld/data/mod.rs
+++ b/weld/data/mod.rs
@@ -141,9 +141,7 @@ pub struct GroupMerger<K, V> {
 // Ensures that the sizes of the types defined here match the sizes of the types in the backend.
 #[test]
 fn size_check() {
-    use annotation::Annotations;
-    use ast::Type;
-    use ast::BuilderKind;
+    use ast::*;
     use ast::ScalarKind::I32;
     use ast::BinOpKind::Add;
     use codegen::size_of;

--- a/weld/lib.rs
+++ b/weld/lib.rs
@@ -171,7 +171,6 @@ pub const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
 #[macro_use]
 mod error;
 
-mod annotation;
 mod codegen;
 mod conf;
 mod optimizer;

--- a/weld/optimizer/transforms/inliner.rs
+++ b/weld/optimizer/transforms/inliner.rs
@@ -11,8 +11,6 @@ use fnv::FnvHashMap;
 
 use std::mem;
 
-use annotation::*;
-
 #[cfg(test)]
 use tests::*;
 

--- a/weld/optimizer/transforms/loop_fusion.rs
+++ b/weld/optimizer/transforms/loop_fusion.rs
@@ -7,7 +7,6 @@ use ast::Type::*;
 use ast::BuilderKind::*;
 use ast::LiteralKind::*;
 use error::*;
-use annotation::*;
 use ast::constructors;
 
 use super::inliner::inline_apply;

--- a/weld/sir/mod.rs
+++ b/weld/sir/mod.rs
@@ -106,9 +106,6 @@ pub struct ParallelForData {
     pub idx_arg: Symbol,
     pub body: FunctionId,
     pub innermost: bool,
-    /// If `true`, always invoke parallel runtime for the loop.
-    pub always_use_runtime: bool,
-    pub grain_size: Option<i32>
 }
 
 impl StatementKind {
@@ -1386,8 +1383,6 @@ fn gen_expr(expr: &Expr,
                                     data_arg: params[2].name.clone(),
                                     body: body_func,
                                     innermost: is_innermost,
-                                    always_use_runtime: expr.annotations.always_use_runtime(),
-                                    grain_size: expr.annotations.grain_size().clone()
                                 });
 
                 let res_sym = tracker.symbol_for_statement(prog, cur_func, cur_block, &builder.ty, kind);

--- a/weld/syntax/macro_processor.rs
+++ b/weld/syntax/macro_processor.rs
@@ -13,7 +13,6 @@ use super::parser::*;
 use super::program::*;
 use error::*;
 use util::SymbolGenerator;
-use annotation::*;
 
 #[cfg(test)]
 use tests::print_expr_without_indent;

--- a/weld/syntax/parser.rs
+++ b/weld/syntax/parser.rs
@@ -6,7 +6,6 @@
 use std::vec::Vec;
 use std::cmp::min;
 
-use annotation::*;
 use ast::*;
 use ast::Type::*;
 use ast::BinOpKind::*;
@@ -602,106 +601,33 @@ impl<'t> Parser<'t> {
     fn parse_annotations(&mut self, annotations: &mut Annotations) -> WeldResult<()> {
         if *self.peek() == TAtMark {
             self.consume(TAtMark)?;
-            try!(self.consume(TOpenParen));
+            self.consume(TOpenParen)?;
             while *self.peek() != TCloseParen {
-                match *self.peek() {
-                    TIdent(ref value) => {
-                        match value.as_ref() {
-                            "impl" => {
-                                self.consume(TIdent("impl".to_string()))?;
-                                try!(self.consume(TColon));
-                                let implementation = match *self.next() {
-                                    TIdent(ref inner_value) => {
-                                        match inner_value.as_ref() {
-                                            "global" => BuilderImplementationKind::Global,
-                                            "local" => BuilderImplementationKind::Local,
-                                            _ => return compile_err!("Invalid implementation type"),
-                                        }
-                                    }
-                                    _ => return compile_err!("Invalid implementation type"),
-                                };
-                                annotations.set_builder_implementation(implementation);
-                            }
-                            "predicate" => {
-                                self.consume(TIdent("predicate".to_string()))?;
-                                try!(self.consume(TColon));
-                                if let TBoolLiteral(l) = *self.next() {
-                                    annotations.set_predicate(l);
-                                } else {
-                                    return compile_err!("Invalid predicate type (must be a bool)");
-                                }
-                            }
-                            "vectorize" => {
-                                self.consume(TIdent("vectorize".to_string()))?;
-                                try!(self.consume(TColon));
-                                if let TBoolLiteral(l) = *self.next() {
-                                    annotations.set_vectorize(l);
-                                } else {
-                                    return compile_err!("Invalid vectorize type (must be a bool)");
-                                }
-                            }
-                            "tile_size" => {
-                                self.consume(TIdent("tile_size".to_string()))?;
-                                try!(self.consume(TColon));
-                                if let TI32Literal(l) = *self.next() {
-                                    annotations.set_tile_size(l);
-                                } else {
-                                    return compile_err!("Invalid tile size (must be a i32)");
-                                }
-                            }
-                            "grain_size" => {
-                                self.consume(TIdent("grain_size".to_string()))?;
-                                try!(self.consume(TColon));
-                                if let TI32Literal(l) = *self.next() {
-                                    annotations.set_grain_size(l);
-                                } else {
-                                    return compile_err!("Invalid tile size (must be a i32)");
-                                }
-                            }
-                            "size" => {
-                                self.consume(TIdent("size".to_string()))?;
-                                try!(self.consume(TColon));
-                                if let TI64Literal(l) = *self.next() {
-                                    annotations.set_size(l);
-                                } else {
-                                    return compile_err!("Invalid vector size (must be a i64)");
-                                }
-                            }
-                            "loopsize" => {
-                                self.consume(TIdent("loopsize".to_string()))?;
-                                try!(self.consume(TColon));
-                                if let TI64Literal(l) = *self.next() {
-                                    annotations.set_loopsize(l);
-                                } else {
-                                    return compile_err!("Invalid vector size (must be a i64)");
-                                }
-                            }
-                            "selectivity" => {
-                                self.consume(TIdent("selectivity".to_string()))?;
-                                try!(self.consume(TColon));
-                                if let TF32Literal(l) = *self.next() {
-                                    annotations.set_branch_selectivity((l * 100000.0) as i32);
-                                } else {
-                                    return compile_err!("Invalid selectivity (must be a f32)");
-                                }
-                            }
-                            "num_keys" => {
-                                self.consume(TIdent("num_keys".to_string()))?;
-                                try!(self.consume(TColon));
-                                if let TI64Literal(l) = *self.next() {
-                                    annotations.set_num_keys(l);
-                                } else {
-                                    return compile_err!("Invalid number of keys (must be a i64)");
-                                }
-                            }
-                            _ => return compile_err!("Invalid annotation type"),
-                        }
+                let key = self.symbol()?;
+                self.consume(TColon)?;
+                let value = match *self.peek() {
+                    TI32Literal(ref v) => v.to_string(),
+                    TI64Literal(ref v) => v.to_string(),
+                    TF32Literal(ref v) => v.to_string(),
+                    TF64Literal(ref v) => v.to_string(),
+                    TI16Literal(ref v) => v.to_string(),
+                    TI8Literal(ref v) => v.to_string(),
+                    TBoolLiteral(ref v) => v.to_string(),
+                    TStringLiteral(ref v) => v.clone(),
+                    TIdent(ref v) => v.clone(),
+                    _ => {
+                        return compile_err!("Annotation value must be a literal or identifier/string");
                     }
-                    _ => return compile_err!("Invalid annotation type -- expected an identifier"),
-                }
+                };
+
+                // Consume whatever we saw.
+                let token = self.peek().clone();
+                self.consume(token)?;
+
+                annotations.set(key.to_string(), value);
 
                 if *self.peek() == TComma {
-                    self.next();
+                    self.consume(TComma)?;
                 } else if *self.peek() != TCloseParen {
                     return compile_err!("Expected ',' or ')'");
                 }
@@ -1248,7 +1174,7 @@ impl<'t> Parser<'t> {
                        id: 0,
                    })
             }
-            ref other => compile_err!("Expected identifier but got '{}'", other),
+            ref other => compile_err!("Expected identifier but got {}", other),
         }
     }
 
@@ -1487,8 +1413,6 @@ fn basic_parsing() {
     let e = parse_expr("@(impl:local, num_keys:12l) dictmerger[i32,i32,+]").unwrap();
     assert_eq!(print_expr_without_indent(&e),
                "@(impl:local,num_keys:12)dictmerger[i32,i32,+]");
-
-    assert!(parse_expr("@(impl:local, num_keys:12) dictmerger[i32,i32,+]").is_err());
 
     let e = parse_expr("a: i32 + b").unwrap();
     assert_eq!(print_typed_expr_without_indent(&e), "(a:i32+b:?)");


### PR DESCRIPTION
Annotations are now unstructured string key/value pairs. Only a few annotation kinds were actually used, and adding new annotations required changes to the compiler. This allows users to add any kind of annotation over the language. When the optimizer is changed to allow external registration of passes, users can add new optimizer-specific annotations as required. It also allows new backends to define custom annotations.

## Limitations

See the limitations on the `pub struct Annotations` definition in `ast.rs`. In short, because of the way the parser is setup, annotation keys must be identifiers and values must be identifiers or literals. Eventually, we'll change this so the system supports arbitrary key/value pairs.