### PR TITLE
Revert Jemalloc allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ llvm-sys = "60.0.3"
 fnv = "1.0.5"
 clap = "2.31.1"
 code_builder = "0.1.0"
-jemallocator = "0.1.9"
 uuid = { version = "0.7.1", features = ["v4"] }
 
 [lib]

--- a/weld/lib.rs
+++ b/weld/lib.rs
@@ -123,11 +123,6 @@ extern crate lazy_static;
 #[macro_use]
 extern crate log;
 
-extern crate jemallocator;
-
-#[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 extern crate regex;
 extern crate libc;
 extern crate env_logger;


### PR DESCRIPTION
This allocator does not seem to work from within the JVM without some special build flags, so disabling them for now.