### PR TITLE
Reference count Symbol names

### DIFF
--- a/weld/ast/ast.rs
+++ b/weld/ast/ast.rs
@@ -7,6 +7,7 @@ use self::ExprKind::*;
 use self::ScalarKind::*;
 use self::BinOpKind::*;
 
+use std::rc::Rc;
 use std::fmt;
 use std::vec;
 use std::collections::BTreeMap;
@@ -486,14 +487,14 @@ impl fmt::Display for BuilderKind {
 /// A named symbol in the Weld AST.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Symbol {
-    name: String,
+    name: Rc<String>,
     id: i32,
 }
 
 impl Symbol {
     pub fn new<T: Into<String>>(name: T, id: i32) -> Symbol {
         Symbol {
-            name: name.into(),
+            name: Rc::new(name.into()),
             id: id,
         }
     }
@@ -1354,7 +1355,7 @@ pub trait Placeholder {
 impl Placeholder for Expr {
     fn is_placeholder(&self) -> bool {
         if let Ident(ref name) = self.kind {
-            return name.name == PLACEHOLDER_NAME
+            return name.name.as_ref() == PLACEHOLDER_NAME
         }
         return false
     }

--- a/weld/ast/ast.rs
+++ b/weld/ast/ast.rs
@@ -486,12 +486,12 @@ impl fmt::Display for BuilderKind {
 /// A named symbol in the Weld AST.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Symbol {
-    pub name: String,
-    pub id: i32,
+    name: String,
+    id: i32,
 }
 
 impl Symbol {
-    pub fn new(name: &str, id: i32) -> Symbol {
+    pub fn new<T: Into<String>>(name: T, id: i32) -> Symbol {
         Symbol {
             name: name.into(),
             id: id,
@@ -502,11 +502,12 @@ impl Symbol {
         Symbol::new(PLACEHOLDER_NAME, 0)
     }
 
-    pub fn name(name: &str) -> Symbol {
-        Symbol {
-            name: name.into(),
-            id: 0,
-        }
+    pub fn name(&self) -> String {
+        self.name.to_string()
+    }
+
+    pub fn id(&self) -> i32 {
+        self.id
     }
 }
 

--- a/weld/ast/type_inference.rs
+++ b/weld/ast/type_inference.rs
@@ -890,10 +890,7 @@ fn infer_types_test() {
     assert_eq!(print_typed_expr_without_indent(&e).as_str(), "a:?");
 
     let e = Expr {
-        kind: ExprKind::Ident(Symbol {
-                                  name: "a".to_string(),
-                                  id: 1,
-                              }),
+        kind: ExprKind::Ident(Symbol::new("a", 1)),
         ty: Type::Unknown,
         annotations: Annotations::new(),
     };

--- a/weld/ast/uniquify.rs
+++ b/weld/ast/uniquify.rs
@@ -48,7 +48,7 @@ impl SymbolStack {
     fn symbol(&mut self, sym: Symbol) -> WeldResult<Symbol> {
         match self.stack.entry(sym.clone()) {
             Entry::Occupied(ref ent) => {
-                let name = ent.key().name.as_str();
+                let name = ent.key().name();
                 let id = ent.get()
                     .last()
                     .map(|v| *v)
@@ -64,9 +64,9 @@ impl SymbolStack {
     /// the name. The symbol can be retrieved with `symbol()`.
     fn push_symbol(&mut self, sym: Symbol) {
         let stack_entry = self.stack.entry(sym.clone()).or_insert(Vec::new());
-        let next_entry = self.next_unique_symbol.entry(sym.name).or_insert(-1);
-        *next_entry = if sym.id > *next_entry {
-            sym.id
+        let next_entry = self.next_unique_symbol.entry(sym.name()).or_insert(-1);
+        *next_entry = if sym.id() > *next_entry {
+            sym.id()
         } else {
            *next_entry + 1 
         };

--- a/weld/optimizer/transforms/loop_fusion.rs
+++ b/weld/optimizer/transforms/loop_fusion.rs
@@ -94,9 +94,9 @@ pub fn fuse_loops_horizontal(expr: &mut Expr) {
                     // Parameters for the new fused function. Symbols names are generated using symbol
                     // names for the builder and element from an existing function.
                     let new_params = vec![
-                        Parameter{ty: builder_type.clone(), name: sym_gen.new_symbol(&lambdas[0].0[0].name.name)},
-                        Parameter{ty: Scalar(ScalarKind::I64), name: sym_gen.new_symbol(&lambdas[0].0[1].name.name)},
-                        Parameter{ty: func_elem_type.clone(), name: sym_gen.new_symbol(&lambdas[0].0[2].name.name)},
+                        Parameter{ty: builder_type.clone(), name: sym_gen.new_symbol(&lambdas[0].0[0].name.name())},
+                        Parameter{ty: Scalar(ScalarKind::I64), name: sym_gen.new_symbol(&lambdas[0].0[1].name.name())},
+                        Parameter{ty: func_elem_type.clone(), name: sym_gen.new_symbol(&lambdas[0].0[2].name.name())},
                     ];
 
                     // Generate Ident expressions for the new symbols and substitute them in the
@@ -268,8 +268,8 @@ fn replace_builder(lambda: &Expr,
             let ref old_bldr = args[0];
             let ref old_index = args[1];
             let ref old_arg = args[2];
-            let new_bldr_sym = sym_gen.new_symbol(&old_bldr.name.name);
-            let new_index_sym = sym_gen.new_symbol(&old_index.name.name);
+            let new_bldr_sym = sym_gen.new_symbol(&old_bldr.name.name());
+            let new_index_sym = sym_gen.new_symbol(&old_index.name.name());
             let new_bldr = constructors::ident_expr(new_bldr_sym.clone(), nested_args[0].ty.clone())?;
             let new_index = constructors::ident_expr(new_index_sym.clone(), nested_args[1].ty.clone())?;
 

--- a/weld/sir/mod.rs
+++ b/weld/sir/mod.rs
@@ -415,7 +415,7 @@ impl SirFunction {
     pub fn symbol_type(&self, sym: &Symbol) -> WeldResult<&Type> {
         self.locals.get(sym).map(|s| Ok(s)).unwrap_or_else(|| {
             self.params.get(sym).map(|s| Ok(s)).unwrap_or_else(|| {
-                compile_err!("Can't find symbol {}#{}", sym.name, sym.id)
+                compile_err!("Can't find symbol {}", sym.to_string())
             })
         })
     }
@@ -831,7 +831,7 @@ fn sir_param_correction(prog: &mut SirProgram) -> WeldResult<()> {
     let ref func = prog.funcs[0];
     for name in closure {
         if func.params.get(&name) == None {
-            compile_err!("Unbound symbol {}#{}", name.name, name.id)?;
+            compile_err!("Unbound symbol {}", name.to_string())?;
         }
     }
     Ok(())

--- a/weld/syntax/macro_processor.rs
+++ b/weld/syntax/macro_processor.rs
@@ -96,15 +96,15 @@ fn update_defined_ids(expr: &mut Expr, sym_gen: &mut SymbolGenerator) {
                ref value,
                ref mut body,
            } = expr.kind {
-        if sym.id == 0 {
-            let new_sym = sym_gen.new_symbol(&sym.name);
+        if sym.id() == 0 {
+            let new_sym = sym_gen.new_symbol(&sym.name());
             let new_ident = Expr {
                 kind: Ident(new_sym.clone()),
                 ty: value.ty.clone(),
                 annotations: Annotations::new(),
             };
             body.substitute(sym, &new_ident);
-            sym.id = new_sym.id;
+            *sym = Symbol::new(sym.name(), new_sym.id());
         }
     }
     if let Lambda {
@@ -113,15 +113,15 @@ fn update_defined_ids(expr: &mut Expr, sym_gen: &mut SymbolGenerator) {
            } = expr.kind {
         for ref mut param in params {
             let sym = &mut param.name;
-            if sym.id == 0 {
-                let new_sym = sym_gen.new_symbol(&sym.name);
+            if sym.id() == 0 {
+                let new_sym = sym_gen.new_symbol(&sym.name());
                 let new_ident = Expr {
                     kind: Ident(new_sym.clone()),
                     ty: param.ty.clone(),
                     annotations: Annotations::new(),
                 };
                 body.substitute(sym, &new_ident);
-                sym.id = new_sym.id;
+                *sym = Symbol::new(sym.name(), new_sym.id());
             }
         }
     }

--- a/weld/syntax/parser.rs
+++ b/weld/syntax/parser.rs
@@ -708,10 +708,7 @@ impl<'t> Parser<'t> {
             }
 
             TIdent(ref name) => {
-                Ok(expr_box(Ident(Symbol {
-                                      name: name.clone(),
-                                      id: 0,
-                                  }),
+                Ok(expr_box(Ident(Symbol::new(name.as_str(), 0)),
                             Annotations::new()))
             }
 
@@ -843,7 +840,7 @@ impl<'t> Parser<'t> {
                 }
                 try!(self.consume(TCloseParen));
                 Ok(expr_box(CUDF {
-                                sym_name: sym_name.name,
+                                sym_name: sym_name.name(),
                                 return_ty: Box::new(return_ty),
                                 args: args,
                             },
@@ -1168,13 +1165,8 @@ impl<'t> Parser<'t> {
     /// Parse a symbol starting at the current input position.
     fn symbol(&mut self) -> WeldResult<Symbol> {
         match *self.next() {
-            TIdent(ref name) => {
-                Ok(Symbol {
-                       name: name.clone(),
-                       id: 0,
-                   })
-            }
-            ref other => compile_err!("Expected identifier but got {}", other),
+            TIdent(ref name) => Ok(Symbol::new(name.as_str(), 0)),
+            ref other => compile_err!("Expected identifier but got {}", other.to_string()),
         }
     }
 

--- a/weld/util/mod.rs
+++ b/weld/util/mod.rs
@@ -42,8 +42,8 @@ impl SymbolGenerator {
         let mut id_map: fnv::FnvHashMap<String, i32> = fnv::FnvHashMap::default();
 
         let update_id = |id_map: &mut fnv::FnvHashMap<String, i32>, symbol: &Symbol| {
-            let id = id_map.entry(symbol.name.clone()).or_insert(0);
-            *id = max(*id, symbol.id);
+            let id = id_map.entry(symbol.name().clone()).or_insert(0);
+            *id = max(*id, symbol.id());
         };
 
         expr.traverse(&mut |e| match e.kind {
@@ -63,10 +63,7 @@ impl SymbolGenerator {
     pub fn new_symbol(&mut self, name: &str) -> Symbol {
         let id = self.id_map.entry(name.to_owned()).or_insert(-1);
         *id += 1;
-        Symbol {
-            name: name.to_owned(),
-            id: *id,
-        }
+        Symbol::new(name, *id)
     }
 }
 


### PR DESCRIPTION
Symbols are often cloned throughout the compiler: to make this cheaper, the symbol names are now reference counted instead of directly cloned.

Performance measurements of cloning symbols:

```
test arc_clone      ... bench:          13 ns/iter (+/- 3)
test rc_clone       ... bench:           3 ns/iter (+/- 2)
test standard_clone ... bench:          32 ns/iter (+/- 5)
```
