### PR TITLE
CSE Fixes

### DIFF
--- a/weld/optimizer/transforms/cse.rs
+++ b/weld/optimizer/transforms/cse.rs
@@ -278,11 +278,19 @@ impl SiteList {
         self.sites.swap_remove(site);
     }
 
-    /// Adds a new site if that site or a ancestor of it does not exist in the list and returns
-    /// the first counter value where the expression was added on this path.
+    /// Adds a new site if that site or a ancestor of it does not exist.
     ///
-    /// `new` will not be added if an ancestor already exists in the last. Conversely, if
-    /// children of `new` exist in the list, they will be removed when `new` is added.
+    /// Returns the first counter value recorded for this site if the site was added, or `None` if
+    /// the site was not added.
+    ///
+    /// In order to enable backtracking for symbols that need to be redefined at a higher site,
+    /// this method also takes the current counter value of the CSE, and tracks the counter value
+    /// for the first time the site was added. When the symbol is redefined, the counter
+    /// should be reset to this value so the site list and `generate_bindings` will maintain
+    /// consistent counter values.
+    ///
+    /// `new` will not be added if an ancestor already exists. Conversely, if children of `new`
+    /// exist in the list, they will be removed when `new` is added.
     fn add_site(&mut self, mut new: Site, counter: i32) -> Option<i32> {
         // If any of the existing sites do not contain the new one already...
         if !self.sites.iter().any(|s| s.contains(&new)) {

--- a/weld/optimizer/transforms/cse.rs
+++ b/weld/optimizer/transforms/cse.rs
@@ -343,26 +343,8 @@ impl Cse {
         let ref mut generated = HashSet::new();
         let ref mut stack = vec![];
 
-        // Debug.
-        {
-            let mut debug = String::new();
-            for (k, v) in bindings.iter() {
-                debug.push_str(&format!("{} -> {}\n", k, v.pretty_print()));
-            }
-            trace!("bindings: {}", debug);
-            trace!("Expression after assigning cse symbols: {}", expr.pretty_print());
-             let mut debug = String::new();
-            for (k, v) in sites.iter() {
-                debug.push_str(&format!("{} -> {:?}\n", k, v));
-            }
-            trace!("scopes: {}", debug);
-        }
-
         cse.counter = 0;
         cse.generate_bindings(expr, bindings, generated, &mut Site::new(), stack, sites);
-
-        trace!("After CSE: {}", expr.pretty_print());
-
     }
 
     /// Removes common subexpressions and remove bindings.
@@ -414,10 +396,6 @@ impl Cse {
                            bindings: &HashMap<Symbol, Expr>,
                            site_map: &mut SiteMap,
                            current_site: &mut Site) {
-
-        trace!("site builder expression {} (current site={:?})",
-               expr.pretty_print(),
-               current_site);
 
         let mut handled = true;
         match expr.kind {
@@ -475,19 +453,15 @@ impl Cse {
 
                     let new = first_seen == self.counter;
                     let current_counter = self.counter;
+
                     // If this is the first time we are seeing this expression, this is a no-op.
                     self.counter = first_seen;
-
-                    trace!("Set counter to {} ({})", self.counter, name);
-
                     self.build_site_map_helper(expr, bindings, site_map, current_site);
 
                     // We only want to "fix" the counter if we replaced some site!
                     if !new {
                         self.counter = current_counter;
                     }
-
-                    trace!("Reset counter to {} ({})", self.counter, name);
                 }
             }
             _ => {
@@ -518,11 +492,6 @@ impl Cse {
                          current_site: &mut Site,
                          stack: &mut Vec<Vec<Binding>>,
                          sites: &mut SiteMap) {
-
-        trace!("scoped expression {} (current site={:?})",
-               expr.pretty_print(),
-               current_site);
-
         // NOTE: Because of the way paths are built, this method must traverse Lambdas and If
         // statements in the exact same order as build_site_map_helper!
         let handled = match expr.kind {

--- a/weld/optimizer/transforms/cse.rs
+++ b/weld/optimizer/transforms/cse.rs
@@ -731,7 +731,7 @@ fn if_test_7() {
 fn if_test_8() {
     // Tests whether seeing an expression and then seeing it at a higher scope messes up the path
     // counter.
-    
+
     // Things will get inlined -- this is just for readability. cse2 shouldn't cause
     // the counter to go out of sync in `gen_site_map` and `generate_bindings`.
     let input = "|x: i32|
@@ -740,7 +740,7 @@ fn if_test_8() {
         let cse3 = if (x > 3, cse2, 2) + cse2;
         let cse1 = if (x > 1, cse2, cse3);
         if (x > 0, cse1, cse4)";
-    
+
     let expect = "|x: i32|
         let cse2 = if (x > 2, 1, 2);
         if (x > 0,
@@ -771,6 +771,14 @@ fn for_test_2() {
 fn for_test_3() {
     let input = "|| result(for([1], merger[i32,+], |b,i,e| merge(b, e + (1+2) + (1+2))))";
     let expect = "|| result(for([1], merger[i32,+], |b,i,e| let cse = (1+2); merge(b, e + cse + cse)))";
+    check_cse(input, expect);
+}
+
+#[test]
+fn for_test_4() {
+    // Make sure defined symbols don't get inlined.
+    let input = "|| let x = (1+2); result(for([1], merger[i32,+], |b,i,e| merge(b, e + x + x)))";
+    let expect = input;
     check_cse(input, expect);
 }
 


### PR DESCRIPTION
Addresses various fixes to the CSE transform. Also handles Let statements in a cleaner way -- previously, lets defined before CSE were erroneously being inlined (e.g., into a Lambda): this is now fixed. This also improves the overall performance of the transform.