### PR TITLE
Using same verbosity level when evaluating groupedDataFrames

### DIFF
--- a/python/grizzly/grizzly/groupbyweld.py
+++ b/python/grizzly/grizzly/groupbyweld.py
@@ -321,7 +321,7 @@ class GroupedDataFrameWeld(LazyOpResult):
             exprs.append(expr)
             i += 1
 
-        result = utils.group(exprs).evaluate(verbose=True, passes=passes)
+        result = utils.group(exprs).evaluate(verbose=verbose, passes=passes)
         df = pd.DataFrame(columns=[])
         all_columns = self.column_names + self.grouping_column_name
         for i, column_name in enumerate(all_columns):


### PR DESCRIPTION
When evaluating a GroupedDataFrameWeld, the verbosity level should be the same as the one being used and not always True.