### PR TITLE
Sort Fixes

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -136,10 +136,11 @@ refer to types.
 
 * `lookup(dict, key)` and `lookup(vec, index)` return an element from a dictionary and vector respectively. `index` must be of type `i64`. It is an error to call `lookup` on a dictionary
   with a key that does not exist: see `keyexists`.
+* `optlookup(dict, key)` batches `keyexists and `lookup` into a single call. This can be more efficient since the key only needs to be hashed a single time. This operator returns `{bool, V}` where the boolean indicates whether the key was present in the dictionary. If the boolean is false, it is an error to access `V`; although this is not enforced at the moment, the type system may be extended to support it eventually (e.g., by adding an `option` type).
 * `keyexists(dict, key)` returns whether the `key` is in `dict`.
 * `len(vec)` return its length as an `i64`.
 * `slice(vec, index, size)` creates a view into a vector without allocating memory starting at `index` and containing `size` elements. Both must be of type `i64`.
-* `sort(vec, func)` sorts a vector. `func` is of type `T => U`, where `T` is the input vector type and `U` is the type we want to compare. Currently, the comparison for each type is done in ascending order for scalars, left to right for structs, and element by element for vectors. Vectors of dictionaries and SIMD values do not support sorting. The sort is also not guaranteed to be stable.
+* `sort(vec, func)` sorts a vector. `func` is of type `|T, T| => i32`, where `T` is the input vector element type. The function should return a positive integer if `left > right`, an negative number if `left < right`, and zero if `left == right`. By default, using the comparison binary operators, vectors are compared lexigraphically and structs are compared field-by-field from left to right. Sorting on vectors of dictionaries, builders, and SIMD values is currently disallowed.
 * `struct.$0`, `struct.$1`, etc. are used to access fields of a struct.
 * `tovec(dict)` gets the entries of a dictionary as a vector of `{K, V}` pairs.
 
@@ -284,6 +285,7 @@ Signature | Notes
 `filter(v: vec[T], f: T => bit): vec[T]` |
 `flatten(v: vec[vec[T]]): vec[T]` |
 `zip(v1: vec[T1], v2: vec[T2], ...): vec[{T1, T2, ...}]` | Only allowed in the `vec` argument of the `for` loop.
+`compare(x: T, y: T) => i32` | Implements a default comparator for `sort`. Expands to `if(x > y, 1, if(x < y, -1, 0))`.
 
 All of these operations can straightforwardly be translated into `for` expressions.
 For example, the macro rules for `map` and `filter` would be implemented as follows:
@@ -346,14 +348,12 @@ In addition, it's possible to specify annotations on both builder types and expr
 @(name1:value1, name2:value2, ...) dictmerger[K,V,bin_op]
 ```
 
-Annotations need to be specified before the builder type or expression, and multiple annotations need to be comma-separated. Currently, we support the following annotations on builder types:
-* `impl`: Specifies the builder's implementation strategy -- permitted values are `global` and `local`.
+Annotations need to be specified before the builder type or expression, and
+multiple annotations need to be comma-separated. Annotations are unstructured
+string to string maps, and their definition and behavior is dependent on the
+transforms and backends that use them.
 
 In addition, we support the following annotations on generic expressions:
 * `predicate`: Specifies whether the expression should be predicated or not -- value must be a `bool`.
 * `vectorize`: Specifies whether the expression should be vectorized or not -- value must be a `bool`.
-* `tile_size`: Specifies the tile size to be used to tile the expression -- value must be a `i32`.
-* `grain_size`: Specifies the grain size for the expression -- value must be a `i32`.
 * `size`: Specifies the size of the expression -- value must be a `i64`.
-* `branch_selectivity`: Specifies the selectivity of a branch in the expression -- value must be a `i32` (fraction of `10,000`).
-* `num_keys`: Specifies the number of keys in the expression -- value must be a `i64`.

--- a/docs/language.md
+++ b/docs/language.md
@@ -136,11 +136,11 @@ refer to types.
 
 * `lookup(dict, key)` and `lookup(vec, index)` return an element from a dictionary and vector respectively. `index` must be of type `i64`. It is an error to call `lookup` on a dictionary
   with a key that does not exist: see `keyexists`.
-* `optlookup(dict, key)` batches `keyexists and `lookup` into a single call. This can be more efficient since the key only needs to be hashed a single time. This operator returns `{bool, V}` where the boolean indicates whether the key was present in the dictionary. If the boolean is false, it is an error to access `V`; although this is not enforced at the moment, the type system may be extended to support it eventually (e.g., by adding an `option` type).
+* `optlookup(dict, key)` batches `keyexists` and `lookup` into a single call. This can be more efficient since the key only needs to be hashed a single time. This operator returns `{bool, V}` (`V` is the value type) where the boolean indicates whether the key was present in the dictionary. If the boolean is false, it is an error to access `V`; although this is not enforced at the moment, the type system may be extended to support it eventually (e.g., by adding an `option` type).
 * `keyexists(dict, key)` returns whether the `key` is in `dict`.
 * `len(vec)` return its length as an `i64`.
 * `slice(vec, index, size)` creates a view into a vector without allocating memory starting at `index` and containing `size` elements. Both must be of type `i64`.
-* `sort(vec, func)` sorts a vector. `func` is of type `|T, T| => i32`, where `T` is the input vector element type. The function should return a positive integer if `left > right`, an negative number if `left < right`, and zero if `left == right`. By default, using the comparison binary operators, vectors are compared lexigraphically and structs are compared field-by-field from left to right. Sorting on vectors of dictionaries, builders, and SIMD values is currently disallowed.
+* `sort(vec, func)` sorts a vector. `func` is of type `|T, T| => i32`, where `T` is the input vector's element type. The function returns a positive `i32` if `left > right`, a negative integer if `left < right`, and zero if `left == right`. By default, using the comparison binary operators, vectors are compared lexigraphically and structs are compared field-by-field from left to right. Sorting on vectors of dictionaries, builders, and SIMD values is currently disallowed.
 * `struct.$0`, `struct.$1`, etc. are used to access fields of a struct.
 * `tovec(dict)` gets the entries of a dictionary as a vector of `{K, V}` pairs.
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -285,7 +285,7 @@ Signature | Notes
 `filter(v: vec[T], f: T => bit): vec[T]` |
 `flatten(v: vec[vec[T]]): vec[T]` |
 `zip(v1: vec[T1], v2: vec[T2], ...): vec[{T1, T2, ...}]` | Only allowed in the `vec` argument of the `for` loop.
-`compare(x: T, y: T) => i32` | Implements a default comparator for `sort`. Expands to `if(x > y, 1, if(x < y, -1, 0))`.
+`compare(x: T, y: T)` | Implements a default comparator for `sort`. Expands to `if(x > y, 1, if(x < y, -1, 0))`.
 
 All of these operations can straightforwardly be translated into `for` expressions.
 For example, the macro rules for `map` and `filter` would be implemented as follows:

--- a/python/grizzly/grizzly/grizzly_impl.py
+++ b/python/grizzly/grizzly/grizzly_impl.py
@@ -741,7 +741,7 @@ def pivot_table(expr, value_index, value_ty, index_index, index_ty, columns_inde
                        merge(b.$2, {e.$%(cd)s, 1L})}
           );
           let agg_dict = result(bs.$0);
-          let ind_vec = sort(map(tovec(result(bs.$1)), |x| x.$0), |x| x);
+          let ind_vec = sort(map(tovec(result(bs.$1)), |x| x.$0), |x, y| compare(x,y));
           let col_vec = map(tovec(result(bs.$2)), |x| x.$0);
           let pivot = map(
             col_vec,
@@ -760,7 +760,7 @@ def pivot_table(expr, value_index, value_ty, index_index, index_ty, columns_inde
                        merge(b.$2, {e.$%(cd)s, 1L})}
           );
           let agg_dict = result(bs.$0);
-          let ind_vec = sort(map(tovec(result(bs.$1)), |x| x.$0), |x| x);
+          let ind_vec = sort(map(tovec(result(bs.$1)), |x| x.$0), |x, y| compare(x,y));
           let col_vec = map(tovec(result(bs.$2)), |x| x.$0);
           let pivot = map(
             col_vec,
@@ -838,7 +838,7 @@ def pivot_sort(pivot, column_name, index_type, column_type, pivot_type):
               |b,i,e| merge(b, {e,i})
             )
           ),
-          |x| x.$0
+          |x,y| compare(x.$0, y.$0)
         ),
         |x| x.$1
       );
@@ -1229,7 +1229,7 @@ def groupby_size(columns, column_tys, grouping_columns, grouping_column_tys):
           )
         )
       ),
-      |x:{%(gty)s, i64}| x.$0
+      |x:{%(gty)s, i64}, y:{%(gty)s, i64}| compare(x.$0, y.$0)
     );
     {
       map(
@@ -1330,9 +1330,11 @@ def groupby_sort(columns, column_tys, grouping_columns, grouping_column_tys, key
         result_str = "merge(b, {%s})" % ", ".join(result_str_list)
 
     if key_index == None:
-        key_str = "x"
+        key_str_x = "x"
+        key_str_y = "y"
     else :
-        key_str = "x.$%d" % key_index
+        key_str_x = "x.$%d" % key_index
+        key_str_y = "y.$%d" % key_index
 
     if ascending == False:
         key_str = key_str + "* %s(-1)" % column_tys[key_index]
@@ -1348,7 +1350,7 @@ def groupby_sort(columns, column_tys, grouping_columns, grouping_column_tys, key
          )
        )
      ),
-    |a:{%(gty)s, vec[%(ty)s]}| {a.$0, sort(a.$1, |x:%(ty)s| %(key_str)s)}
+    |a:{%(gty)s, vec[%(ty)s]}| {a.$0, sort(a.$1, |x:%(ty)s| compare(%(key_str_x)s, %(key_str_y)s))}
     )
   """
 

--- a/tests/binop_tests.rs
+++ b/tests/binop_tests.rs
@@ -2,8 +2,6 @@
 
 extern crate weld;
 
-use weld::runtime::WeldRuntimeErrno;
-
 mod common;
 use common::*;
 

--- a/weld/ast/ast.rs
+++ b/weld/ast/ast.rs
@@ -695,7 +695,13 @@ pub enum ExprKind {
         index: Box<Expr>,
         size: Box<Expr>,
     },
-    /// Sort a vector.
+    /// Sorts a vector.
+    /// 
+    /// The sort operator takes a vector comprised of any non-builder, SIMD, or non-dictionary type
+    /// and returns a new sorted vector. The sort order is determined by `cmpfunc`.
+    ///
+    /// The comparator takes two arguments `x` and `y` whose type is the vector element type and
+    /// returns a positive `i32` if `x > y`, zero if `x == y`, and a negative number of `x < y`.
     Sort {
         data: Box<Expr>,
         cmpfunc: Box<Expr>,

--- a/weld/ast/ast.rs
+++ b/weld/ast/ast.rs
@@ -697,7 +697,7 @@ pub enum ExprKind {
     },
     /// Sorts a vector.
     /// 
-    /// The sort operator takes a vector comprised of any non-builder, SIMD, or non-dictionary type
+    /// The sort operator takes a vector comprised of any non-builder, non-SIMD, or non-dictionary type
     /// and returns a new sorted vector. The sort order is determined by `cmpfunc`.
     ///
     /// The comparator takes two arguments `x` and `y` whose type is the vector element type and

--- a/weld/ast/constructors.rs
+++ b/weld/ast/constructors.rs
@@ -228,11 +228,14 @@ pub fn sort_expr(data: Expr, cmpfunc: Expr) -> WeldResult<Expr> {
 
     if let Vector(ref vec_ty) = data.ty {
         if let Function(ref params, ref body) = cmpfunc.ty {
-            if params.len() == 1 && params[0] == **vec_ty {
-                if let Scalar(_) = **body {
-                    type_checked = true;
+            if params.len() == 2 && params[0] == **vec_ty {
+                // Return type must be i32.
+                if let Scalar(ScalarKind::I32) = **body {
+                    // Both parameters must be of the same type.
+                    if params[0] == params[1] {
+                        type_checked = true;
+                    }
                 }
-
             }
         }
     }

--- a/weld/codegen/llvm2/cmp.rs
+++ b/weld/codegen/llvm2/cmp.rs
@@ -2,11 +2,11 @@
 
 extern crate llvm_sys;
 
-use std::ffi::{CStr, CString};
+use std::ffi::CStr;
 
 use ast::BinOpKind::*;
 use ast::Type;
-use ast::ScalarKind::{I32, I64};
+use ast::ScalarKind::I64;
 use codegen::llvm2::numeric::gen_binop;
 use codegen::llvm2::SIR_FUNC_CALL_CONV;
 use error::*;

--- a/weld/codegen/llvm2/cmp.rs
+++ b/weld/codegen/llvm2/cmp.rs
@@ -61,8 +61,15 @@ pub trait GenCmp {
 
     /// Generates an opaque comparator using the specified comparator function.
     ///
-    /// The comparator should return a value <0 if the first element is smaller, 0 if the elements are equal,
+    /// The comparator should return a value < 0 if the first element is smaller, 0 if the elements are equal,
     /// and >0 if the first element is larger.
+    ///
+    /// # Portability Notes
+    ///
+    /// The opaque comparator is generated with a function signature compatible with the `libc`
+    /// `qsort_r` function. Note that the function signature is slightly different for Linux
+    /// platforms and FreeBSD platforms: as such, the code generated will differ by platform as
+    /// well.
     unsafe fn gen_custom_cmp(&mut self,
                              elem_ty: LLVMTypeRef,
                              cf_id: FunctionId,

--- a/weld/codegen/llvm2/intrinsic.rs
+++ b/weld/codegen/llvm2/intrinsic.rs
@@ -225,17 +225,6 @@ impl Intrinsics {
                       args.as_mut_ptr(), args.len() as u32, c_str!(""))
     }
 
-    /// Convinience wrapper for calling the `weld_run_print` intrinsic.
-    pub unsafe fn call_weld_run_print_int(&mut self,
-                                      builder: LLVMBuilderRef,
-                                      run: LLVMValueRef,
-                                      value: LLVMValueRef) -> LLVMValueRef {
-        let mut args = [run, value];
-        LLVMBuildCall(builder,
-                      self.get("weld_runst_print_int").unwrap(),
-                      args.as_mut_ptr(), args.len() as u32, c_str!(""))
-    }
-
     /// Convinience wrapper for calling `memcpy`.
     ///
     /// This assumes the `memcpy` is non-volatile and uses an default alignment value of 8.
@@ -343,12 +332,6 @@ impl Intrinsics {
         let function = LLVMAddFunction(self.module, name.as_ptr(), fn_type);
         LLVMExtAddAttrsOnParameter(self.context, function, &[NoCapture, NoAlias, NonNull, ReadOnly], 0);
         LLVMExtAddAttrsOnParameter(self.context, function, &[NoCapture, NoAlias, NonNull, ReadOnly], 1);
-        self.intrinsics.insert(name.into_string().unwrap(), function);
-
-        let mut params = vec![self.run_handle_type(), self.i64_type()];
-        let name = CString::new("weld_runst_print_int").unwrap();
-        let fn_type = LLVMFunctionType(self.void_type(), params.as_mut_ptr(), params.len() as u32, 0);
-        let function = LLVMAddFunction(self.module, name.as_ptr(), fn_type);
         self.intrinsics.insert(name.into_string().unwrap(), function);
 
         let mut params = vec![int8p, int8p, self.i64_type(), self.i32_type(), self.i1_type()];

--- a/weld/codegen/llvm2/mod.rs
+++ b/weld/codegen/llvm2/mod.rs
@@ -1292,7 +1292,6 @@ impl LlvmGenerator {
                     //
                     // MacOS and Linux pass arguments to qsort_r in different order.
                     let (mut args, mut arg_tys) = if cfg!(target_os = "macos") {
-                        println!("macos");
                         let mut args = vec![elems_ptr, size, ty_size, run, comparator];
                         let mut arg_tys = vec![
                             LLVMTypeOf(elems_ptr),

--- a/weld/codegen/llvm2/mod.rs
+++ b/weld/codegen/llvm2/mod.rs
@@ -1317,7 +1317,6 @@ impl LlvmGenerator {
                     };
 
                     // Generate the call to qsort.
-                    // In-place sort. TODO: clone vector before sorting.
                     let void_type = self.void_type();
                     self.intrinsics.add("qsort_r", void_type, &mut arg_tys);
                     self.intrinsics.call(context.builder, "qsort_r", &mut args)?;

--- a/weld/runtime/ffi.rs
+++ b/weld/runtime/ffi.rs
@@ -88,9 +88,3 @@ pub unsafe extern "C" fn weld_runst_print(_run: WeldRuntimeContextRef, string: *
     let string = CStr::from_ptr(string).to_str().unwrap();
     println!("{} ", string);
 }
-
-#[no_mangle]
-/// Print a value from generated code.
-pub unsafe extern "C" fn weld_runst_print_int(_run: WeldRuntimeContextRef, i: uint64_t) {
-    println!("{}", i);
-}

--- a/weld/runtime/mod.rs
+++ b/weld/runtime/mod.rs
@@ -10,7 +10,7 @@ pub mod ffi;
 use self::ffi::*;
 
 use std::alloc::System as Allocator;
-use libc::{c_char, int32_t, int64_t, uint64_t};
+use libc::{c_char, int32_t, int64_t};
 
 use fnv::FnvHashMap;
 

--- a/weld/runtime/mod.rs
+++ b/weld/runtime/mod.rs
@@ -247,7 +247,6 @@ unsafe fn initialize() {
         x += weld_runst_get_errno as i64;
         x += weld_runst_set_errno as i64;
 
-        x += weld_runst_print_int as i64;
         x += weld_runst_print as i64;
         trace!("Runtime initialized with hashed values {}", x);
     });


### PR DESCRIPTION
Addresses a few issues with the newly added Sort functionality from #421:

* Adds MacOS compatibility
   - The `libc` `qsort_r` function takes arguments in a different order on Linux vs. FreeBSD, and also takes a comparator that takes arguments in a different order. This is fixed by checking the target OS when compiling.
* Clones a vector before sorting it.
* Fixes the constructor type checking in `constructors.rs`
* Updates `language.md` to reflect new sorting API
* Updates Grizzly code to use new sorting API (untested)