### PR TITLE
New Constructor API with associated functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ install:
 - sudo rm -f `which llvm-config`
 - export WELD_HOME=`pwd`
 - PATH=$PATH:/home/travis/.cargo/bin
-- sudo -E apt-get -yq update &>> ~/apt-get-update.log
 - sudo -E apt-get --no-install-suggests --no-install-recommends -qy --allow-unauthenticated install gcc make llvm-6.0 llvm-6.0-dev clang-6.0 lib32z1-dev python2.7
   # - pip install virtualenv==15.1.0
   # - bash -e build_tools/travis/init_virtualenvs.sh 2.7 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
 - sudo rm -f `which llvm-config`
 - export WELD_HOME=`pwd`
 - PATH=$PATH:/home/travis/.cargo/bin
+- sudo -E apt-get -yq update
 - sudo -E apt-get --no-install-suggests --no-install-recommends -qy --allow-unauthenticated install gcc make llvm-6.0 llvm-6.0-dev clang-6.0 lib32z1-dev python2.7
   # - pip install virtualenv==15.1.0
   # - bash -e build_tools/travis/init_virtualenvs.sh 2.7 3.6

--- a/weld/ast/ast.rs
+++ b/weld/ast/ast.rs
@@ -12,9 +12,6 @@ use std::fmt;
 use std::vec;
 use std::collections::BTreeMap;
 
-#[cfg(test)]
-use tests::*;
-
 /// Name used for placeholder expressions.
 const PLACEHOLDER_NAME: &'static str = "#placeholder";
 
@@ -1459,33 +1456,3 @@ impl Takeable for Box<Expr> {
     }
 }
 
-#[test]
-fn compare_expressions() {
-    let e1 = parse_expr("for([1,2], appender, |e| e+1)").unwrap();
-    let e2 = parse_expr("for([1,2], appender, |f| f+1)").unwrap();
-    assert!(e1.compare_ignoring_symbols(&e2).unwrap());
-
-    let e1 = parse_expr("let a = 2; a").unwrap();
-    let e2 = parse_expr("let b = 2; b").unwrap();
-    assert!(e1.compare_ignoring_symbols(&e2).unwrap());
-
-    let e2 = parse_expr("let b = 2; c").unwrap();
-    assert!(!e1.compare_ignoring_symbols(&e2).unwrap());
-
-    // Undefined symbols should work as long as the symbol is the same.
-    let e1 = parse_expr("[1, 2, 3, d]").unwrap();
-    let e2 = parse_expr("[1, 2, 3, d]").unwrap();
-    assert!(e1.compare_ignoring_symbols(&e2).unwrap());
-
-    let e2 = parse_expr("[1, 2, 3, e]").unwrap();
-    assert!(!e1.compare_ignoring_symbols(&e2).unwrap());
-
-    // Symbols can be substituted, so equal.
-    let e1 = parse_expr("|a, b| a + b").unwrap();
-    let e2 = parse_expr("|c, d| c + d").unwrap();
-    assert!(e1.compare_ignoring_symbols(&e2).unwrap());
-
-    // Symbols don't match up.
-    let e2 = parse_expr("|c, d| d + c").unwrap();
-    assert!(!e1.compare_ignoring_symbols(&e2).unwrap());
-}

--- a/weld/ast/builder.rs
+++ b/weld/ast/builder.rs
@@ -1,0 +1,584 @@
+//! Builder API for Weld expressions.
+
+use ast::*;
+use ast::ExprKind::*;
+use ast::Type::*;
+use ast::BuilderKind::*;
+use ast::LiteralKind::*;
+use error::*;
+
+pub trait NewExpr {
+    fn new(kind: ExprKind, ty: Type) -> WeldResult<Expr>;
+    fn literal(kind: LiteralKind) -> WeldResult<Expr>;
+    fn ident(symbol: Symbol, ty: Type) -> WeldResult<Expr>;
+    fn binop(kind: BinOpKind, left: Expr, right: Expr) -> WeldResult<Expr>;
+    fn unaryop(kind: UnaryOpKind, value: Expr) -> WeldResult<Expr>;
+    fn cast(kind: ScalarKind, expr: Expr) -> WeldResult<Expr>;
+    fn negate(expr: Expr) -> WeldResult<Expr>;
+    fn not(expr: Expr) -> WeldResult<Expr>;
+    fn broadcast(expr: Expr) -> WeldResult<Expr>;
+    fn tovec(expr: Expr) -> WeldResult<Expr>;
+    fn makestruct(exprs: Vec<Expr>) -> WeldResult<Expr>;
+    fn makevector(exprs: Vec<Expr>) -> WeldResult<Expr>;
+    fn makevector_typed(exprs: Vec<Expr>, ty: Type) -> WeldResult<Expr>;
+    fn getfield(expr: Expr, index: u32) -> WeldResult<Expr>;
+    fn length(expr: Expr) -> WeldResult<Expr>;
+    fn lookup(data: Expr, index: Expr) -> WeldResult<Expr>;
+    fn keyexists(data: Expr, key: Expr) -> WeldResult<Expr>;
+    fn slice(data: Expr, index: Expr, size: Expr) -> WeldResult<Expr>;
+    fn sort(data: Expr, cmpfunc: Expr) -> WeldResult<Expr>;
+    fn let(name: Symbol, value: Expr, body: Expr) -> WeldResult<Expr>;
+    fn if(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr>;
+    fn select(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr>;
+    fn lambda(params: Vec<Parameter>, body: Expr) -> WeldResult<Expr>;
+    fn apply(func: Expr, params: Vec<Expr>) -> WeldResult<Expr>;
+    fn cudf(sym_name: String, args: Vec<Expr>, return_ty: Type) -> WeldResult<Expr>;
+    fn newbuilder(kind: BuilderKind, expr: Option<Expr>) -> WeldResult<Expr>;
+    fn for(iters: Vec<Iter>, builder: Expr, func: Expr, vectorized: bool) -> WeldResult<Expr>;
+    fn merge(builder: Expr, value: Expr) -> WeldResult<Expr>;
+    fn result(builder: Expr) -> WeldResult<Expr>;
+}
+
+impl NewExpr for Expr {
+
+    pub fn new(kind: ExprKind, ty: Type) -> WeldResult<Expr> {
+        Ok(Expr {
+            kind: kind,
+            ty: ty,
+            annotations: Annotations::new(),
+        })
+    }
+
+    pub fn literal(kind: LiteralKind) -> WeldResult<Expr> {
+        let ty = match kind {
+            BoolLiteral(_) => Scalar(ScalarKind::Bool),
+            I8Literal(_) => Scalar(ScalarKind::I8),
+            I16Literal(_) => Scalar(ScalarKind::I16),
+            I32Literal(_) => Scalar(ScalarKind::I32),
+            I64Literal(_) => Scalar(ScalarKind::I64),
+            U8Literal(_) => Scalar(ScalarKind::U8),
+            U16Literal(_) => Scalar(ScalarKind::U16),
+            U32Literal(_) => Scalar(ScalarKind::U32),
+            U64Literal(_) => Scalar(ScalarKind::U64),
+            F32Literal(_) => Scalar(ScalarKind::F32),
+            F64Literal(_) => Scalar(ScalarKind::F64),
+            StringLiteral(_) => Vector(Box::new(Scalar(ScalarKind::I8))),
+        };
+
+        Self::new(Literal(kind.clone()), ty)
+    }
+
+    pub fn ident(symbol: Symbol, ty: Type) -> WeldResult<Expr> {
+        Self::new(Ident(symbol), ty)
+    }
+
+    pub fn binop(kind: BinOpKind, left: Expr, right: Expr) -> WeldResult<Expr> {
+        if left.ty != right.ty {
+            return compile_err!("Internal error: Mismatched types in binary operator");
+        }
+
+        let ty = if kind.is_comparison() {
+            Scalar(ScalarKind::Bool)
+        } else {
+            left.ty.clone()
+        };
+
+        Self::new(BinOp { kind: kind, left: Box::new(left), right: Box::new(right) }, ty)
+    }
+
+    pub fn unaryop(kind: UnaryOpKind, value: Expr) -> WeldResult<Expr> {
+        let ty = value.ty.clone();
+        Self::new(UnaryOp { kind: kind, value: Box::new(value) }, value.ty.clone())
+    }
+
+    pub fn cast(kind: ScalarKind, expr: Expr) -> WeldResult<Expr> {
+        let ty = if let Scalar(_) = expr.ty {
+            Scalar(kind)
+        } else {
+            return compile_err!("Internal error: Mismatched types inSelf::cast");
+        };
+        Self::new(Cast {
+            kind: kind,
+            Self::child: Box::new(expr),
+        },
+        ty)
+    }
+
+    pub fn negate(expr: Expr) -> WeldResult<Expr> {
+        let ty = if let Scalar(ref k) = expr.ty {
+            Scalar(k.clone())
+        } else {
+            return compile_err!("Internal error: Mismatched types inSelf::negate");
+        };
+        Self::new(Negate(Box::new(expr)), ty)
+    }
+
+    pub fn not(expr: Expr) -> WeldResult<Expr> {
+        let ty = if let Scalar(ref k) = expr.ty {
+            Scalar(k.clone())
+        } else {
+            return compile_err!("Internal error: Mismatched types inSelf::not");
+        };
+        Self::new(Not(Box::new(expr)), ty)
+    }
+
+    pub fn broadcast(expr: Expr) -> WeldResult<Expr> {
+        let ty = if let Scalar(ref k) = expr.ty {
+            Simd(k.clone())
+        } else {
+            return compile_err!("Internal error: Mismatched types inSelf::broadcast");
+        };
+        Self::new(Broadcast(Box::new(expr)), ty)
+    }
+
+    pub fn tovec(expr: Expr) -> WeldResult<Expr> {
+        let ty = if let Dict(ref kt, ref vt) = expr.ty {
+            Struct(vec![*kt.clone(), *vt.clone()])
+        } else {
+            return compile_err!("Internal error: Mismatched types inSelf::tovec");
+        };
+        Self::new(ToVec {Self::child: Box::new(expr.clone()) }, ty)
+    }
+
+    pub fn makestruct(exprs: Vec<Expr>) -> WeldResult<Expr> {
+        let ty = Struct(exprs.iter().map(|e| e.ty.clone()).collect());
+        Self::new(MakeStruct { elems: exprs }, ty)
+    }
+
+    pub fn makevector(exprs: Vec<Expr>) -> WeldResult<Expr> {
+        let ty = exprs[0].ty.clone();
+        if exprs.iter().all(|e| e.ty == ty) {
+            Self::new(MakeVector { elems: exprs }, Vector(Box::new(ty)))
+        } else {
+            compile_err!("Internal error: Mismatched types inSelf::makevector")
+        }
+    }
+
+    /// Version ofSelf::makevector that is compatible with empty vectors.
+    pub fn makevector_typed(exprs: Vec<Expr>, ty: Type) -> WeldResult<Expr> {
+        if exprs.iter().all(|e| e.ty == ty) {
+            Self::new(MakeVector { elems: exprs }, Vector(Box::new(ty.clone())))
+        } else {
+            compile_err!("Internal error: Mismatched types inSelf::makevector")
+        }
+    }
+
+    pub fn getfield(expr: Expr, index: u32) -> WeldResult<Expr> {
+        let ty = if let Struct(ref tys) = expr.ty {
+            tys[index as usize].clone()
+        } else {
+            return compile_err!("Internal error: Mismatched types inSelf::getfield");
+        };
+        Self::new(GetField {
+            expr: Box::new(expr),
+            index: index,
+        },
+        ty)
+    }
+
+    pub fn length(expr: Expr) -> WeldResult<Expr> {
+        if let Vector(_) = expr.ty {
+            Self::new(Length { data: Box::new(expr) }, Scalar(ScalarKind::I64))
+        } else {
+            compile_err!("Internal error: Mismatched types inSelf::length")
+        }
+    }
+
+    pub fn lookup(data: Expr, index: Expr) -> WeldResult<Expr> {
+        let err = compile_err!("Internal error: Mismatched types inSelf::lookup");
+        let ty = if let Vector(ref ty) = data.ty {
+            *ty.clone()
+        } else {
+            return err;
+        };
+
+        if let Scalar(ScalarKind::I64) = index.ty {
+            Self::new(Lookup {
+                data: Box::new(data),
+                index: Box::new(index),
+            },
+            ty)
+        } else {
+            err
+        }
+    }
+
+    pub fn keyexists(data: Expr, key: Expr) -> WeldResult<Expr> {
+        let err = compile_err!("Internal error: Mismatched types inSelf::keyexists");
+        let kt = if let Dict(ref kt, _) = data.ty {
+            *kt.clone()
+        } else {
+            return err;
+        };
+
+        if key.ty != kt {
+            return err;
+        }
+        Self::new(KeyExists {
+            data: Box::new(data),
+            key: Box::new(key),
+        },
+        Scalar(ScalarKind::Bool))
+    }
+
+    pub fn slice(data: Expr, index: Expr, size: Expr) -> WeldResult<Expr> {
+        let mut type_checked = 0;
+
+        if let Vector(_) = data.ty {
+            type_checked += 1;
+        }
+
+        if let Scalar(ScalarKind::I64) = index.ty {
+            type_checked += 1;
+        }
+
+        if let Scalar(ScalarKind::I64) = size.ty {
+            type_checked += 1;
+        }
+
+        if type_checked != 3 {
+            return compile_err!("Internal error: Mismatched types inSelf::slice");
+        }
+
+        let ty = data.ty.clone();
+        Self::new(Slice {
+            data: Box::new(data),
+            index: Box::new(index),
+            size: Box::new(size),
+        },
+        ty)
+    }
+
+    pub fn sort(data: Expr, cmpfunc: Expr) -> WeldResult<Expr> {
+        let mut type_checked = false;
+
+        if let Vector(ref vec_ty) = data.ty {
+            if let Function(ref params, ref body) = cmpfunc.ty {
+                if params.len() == 2 && params[0] == **vec_ty {
+                    // Return type must be i32.
+                    if let Scalar(ScalarKind::I32) = **body {
+                        // Both parameters must be of the same type.
+                        if params[0] == params[1] {
+                            type_checked = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        if !type_checked {
+            return compile_err!("Internal error: Mismatched types inSelf::sort")
+        }
+
+        let ty = data.ty.clone();
+        Self::new(Sort {
+            data: Box::new(data),
+            cmpfunc: Box::new(cmpfunc),
+        },
+        ty)
+    }
+
+    pub fn let(name: Symbol, value: Expr, body: Expr) -> WeldResult<Expr> {
+        let ty = body.ty.clone();
+        Self::new(Let {
+            name: name,
+            value: Box::new(value),
+            body: Box::new(body),
+        },
+        ty)
+    }
+
+    pub fn if(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr> {
+        let err = compile_err!("Internal error: Mismatched types inSelf::if");
+        if cond.ty != Scalar(ScalarKind::Bool) {
+            return err;
+        }
+
+        if on_true.ty != on_false.ty {
+            return err;
+        }
+
+        let ty = on_true.ty.clone();
+        Self::new(If {
+            cond: Box::new(cond),
+            on_true: Box::new(on_true),
+            on_false: Box::new(on_false),
+        },
+        ty)
+    }
+
+    pub fn select(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr> {
+        let err = compile_err!("Internal error: Mismatched types inSelf::select");
+        if cond.ty != Scalar(ScalarKind::Bool) && cond.ty != Simd(ScalarKind::Bool) {
+            return err;
+        }
+
+        if on_true.ty != on_false.ty {
+            return err;
+        }
+
+        let ty = on_true.ty.clone();
+        Self::new(Select {
+            cond: Box::new(cond),
+            on_true: Box::new(on_true),
+            on_false: Box::new(on_false),
+        },
+        ty)
+    }
+
+    pub fn lambda(params: Vec<Parameter>, body: Expr) -> WeldResult<Expr> {
+        let ty = Function(params.iter().map(|p| p.ty.clone()).collect(),
+        Box::new(body.ty.clone()));
+        Self::new(Lambda {
+            params: params,
+            body: Box::new(body),
+        },
+        ty)
+    }
+
+    pub fn apply(func: Expr, params: Vec<Expr>) -> WeldResult<Expr> {
+        let err = compile_err!("Internal error: Mismatched types inSelf::apply");
+        let mut passed = false;
+        let mut ty = None;
+        if let Function(ref param_tys, ref ret_ty) = func.ty {
+            if params.iter().zip(param_tys).all(|e| e.0.ty == *e.1) {
+                passed = true;
+                ty = Some(ret_ty.clone());
+            }
+        }
+
+        if !passed {
+            return err;
+        }
+
+        Self::new(Apply {
+            func: Box::new(func),
+            params: params,
+        },
+        *ty.unwrap())
+    }
+
+    pub fn cudf(sym_name: String, args: Vec<Expr>, return_ty: Type) -> WeldResult<Expr> {
+        Self::new(CUDF {
+            sym_name: sym_name,
+            args: args,
+            return_ty: Box::new(return_ty.clone()),
+        },
+        return_ty)
+    }
+
+    pub fn newbuilder(kind: BuilderKind, expr: Option<Expr>) -> WeldResult<Expr> {
+        let passed = match kind {
+            Merger(ref ty, _) => {
+                let mut passed = false;
+                if let Some(ref e) = expr {
+                    if &e.ty == ty.as_ref() {
+                        passed = true;
+                    }
+                } else {
+                    // Argument is optional.
+                    passed = true;
+                }
+                passed
+            }
+            VecMerger(ref ty, _) => {
+                let mut passed = false;
+                if let Some(ref e) = expr {
+                    if let Vector(ref elem_ty) = e.ty {
+                        if elem_ty == ty {
+                            passed = true;
+                        }
+                    }
+                }
+                passed
+            }
+            Appender(_) => {
+                let mut passed = false;
+                if let Some(ref e) = expr {
+                    if let Scalar(ScalarKind::I64) = e.ty {
+                        passed = true;
+                    }
+                }
+                passed
+            }
+            _ => expr.is_none(),
+        };
+
+        if !passed {
+            return compile_err!("Internal error: Mismatched types inSelf::newbuilder");
+        }
+
+        Self::new(NewBuilder(expr.map(|e| Box::new(e))),
+        Builder(kind, Annotations::new()))
+    }
+
+    // TODO - the vectorized flag is temporary!
+    pub fn for(iters: Vec<Iter>, builder: Expr, func: Expr, vectorized: bool) -> WeldResult<Expr> {
+
+        let vec_tys = iters.iter().map(|i| i.data.ty.clone()).collect::<Vec<_>>();
+        let mut vec_elem_tys = vec![];
+        for ty in vec_tys.iter() {
+            if let Vector(ref elem_ty) = *ty {
+                vec_elem_tys.push(*elem_ty.clone())
+            }
+        }
+
+        if vec_tys.len() != vec_elem_tys.len() {
+            return compile_err!("Internal error: Mismatched types inSelf::for - non vector type in iter");
+        }
+
+        let builder_ty = builder.ty.clone();
+
+        if let Function(ref params, ref ret_ty) = func.ty {
+            // Make sure the function parameters match.
+            let ref param_0_ty = params[0];
+            let ref param_1_ty = params[1];
+            let ref param_2_ty = params[2];
+
+            // Check builder.
+            if param_0_ty != &builder_ty {
+                return compile_err!("Internal error: Mismatched types inSelf::for - function builder type",);
+            }
+
+            // Check the index.
+            if *param_1_ty != Scalar(ScalarKind::I64) {
+                return compile_err!("Internal error: Mismatched types inSelf::for - function index type");
+            }
+
+            if iters.len() != vec_elem_tys.len() {
+                return compile_err!("Internal error: Mismatched types inSelf::for - iters and vec_tys length",);
+            }
+
+            // Check the element type.
+            if iters.len() == 1 {
+                let elem_ty = if vectorized {
+                    if let Scalar(ref sk) = vec_elem_tys[0] {
+                        Simd(sk.clone())
+                    } else {
+                        return compile_err!("Internal error: Mismatched types inSelf::for - bad vector",);
+                    }
+                } else {
+                    vec_elem_tys[0].clone()
+                };
+                if *param_2_ty != elem_ty {
+                    return compile_err!("Internal error: Mismatched types inSelf::for - function elem type {} != {}",
+                                        param_2_ty, &elem_ty);
+                }
+            } else {
+                let composite_ty = if vectorized {
+                    let mut vec_elem_tys_simd = vec![];
+                    for ty in vec_elem_tys {
+                        if let Scalar(ref sk) = ty {
+                            vec_elem_tys_simd.push(Simd(sk.clone()))
+                        } else {
+                            return compile_err!("Internal error: Mismatched types inSelf::for - bad vector",);
+                        }
+                    }
+                    Struct(vec_elem_tys_simd)
+                } else {
+                    Struct(vec_elem_tys.clone())
+                };
+
+                if *param_2_ty != composite_ty {
+                    return compile_err!("Internal error: Mismatched types inSelf::for - function zipped elem type",);
+                }
+            }
+
+            // Function return type should match builder type.
+            if ret_ty.as_ref() != &builder_ty {
+                return compile_err!("Internal error: Mismatched types inSelf::for - function return type");
+            }
+        }
+
+        Self::new(For {
+            iters: iters,
+            builder: Box::new(builder),
+            func: Box::new(func),
+        },
+        builder_ty)
+    }
+
+    pub fn merge(builder: Expr, value: Expr) -> WeldResult<Expr> {
+        let err = compile_err!("Internal error: Mismatched types inSelf::merge");
+        if let Builder(ref bk, _) = builder.ty {
+            match *bk {
+                Appender(ref elem_ty) => {
+                    if elem_ty.as_ref() != &value.ty {
+                        return err;
+                    }
+                }
+                Merger(ref elem_ty, _) => {
+                    if elem_ty.as_ref() != &value.ty {
+                        return err;
+                    }
+                }
+                DictMerger(ref elem_ty1, ref elem_ty2, _) => {
+                    if let Struct(ref v_ty) = value.ty {
+                        if v_ty.len() < 2 { return err; }
+
+                        if elem_ty1.as_ref() != &v_ty[0] {
+                            return err;
+                        }
+                        if elem_ty2.as_ref() != &v_ty[1] {
+                            return err;
+                        }
+                    } else {
+                        return err;
+                    }
+                }
+                GroupMerger(ref elem_ty1, ref elem_ty2) => {
+                    if let Struct(ref v_ty) = value.ty {
+                        if v_ty.len() < 2 { return err; }
+
+                        if elem_ty1.as_ref() != &v_ty[0] {
+                            return err;
+                        }
+                        if elem_ty2.as_ref() != &v_ty[1] {
+                            return err;
+                        }
+                    } else {
+                        return err;
+                    }
+                }
+                VecMerger(ref elem_ty, _) => {
+                    if let Struct(ref tys) = value.ty {
+                        if tys.len() != 2 {
+                            return err;
+                        }
+                        if tys[0] != Scalar(ScalarKind::I64) {
+                            return err;
+                        }
+                        if &tys[1] != elem_ty.as_ref() {
+                            return err;
+                        }
+                    } else {
+                        return err;
+                    }
+                }
+            }
+        }
+
+        let ty = builder.ty.clone();
+        Self::new(Merge {
+            builder: Box::new(builder),
+            value: Box::new(value),
+        },
+        ty)
+    }
+
+    pub fn result(builder: Expr) -> WeldResult<Expr> {
+        let err = compile_err!("Internal error: Mismatched types inSelf::result");
+        let ty = if let Builder(ref bk, _) = builder.ty {
+            match *bk {
+                Appender(ref elem_ty) => Vector(elem_ty.clone()),
+                Merger(ref elem_ty, _) => *elem_ty.clone(),
+                DictMerger(ref kt, ref vt, _) => Dict(kt.clone(), vt.clone()),
+                GroupMerger(ref kt, ref vt) => Dict(kt.clone(), Box::new(Vector(vt.clone()))),
+                VecMerger(ref elem_ty, _) => Vector(elem_ty.clone()),
+            }
+        } else {
+            return err;
+        };
+        Self::new(Res { builder: Box::new(builder) }, ty)
+    }
+}

--- a/weld/ast/builder.rs
+++ b/weld/ast/builder.rs
@@ -52,7 +52,7 @@ pub trait NewExpr {
     /// Creates a new typed vector literal expression.
     ///
     /// This version can be used if `exprs` is empty and the type cannot be inferred with
-    /// `new_make_vector.
+    /// `new_make_vector`.
     fn new_make_vector_typed(exprs: Vec<Expr>, ty: Type) -> WeldResult<Expr>;
     /// Creates a new field access expression on struct.
     fn new_get_field(expr: Expr, index: u32) -> WeldResult<Expr>;

--- a/weld/ast/builder.rs
+++ b/weld/ast/builder.rs
@@ -2,6 +2,7 @@
 
 use ast::*;
 use ast::ExprKind::*;
+use ast::Type::*;
 use error::*;
 
 pub trait NewExpr {
@@ -25,36 +26,36 @@ pub trait NewExpr {
     fn keyexists(data: Expr, key: Expr) -> WeldResult<Expr>;
     fn slice(data: Expr, index: Expr, size: Expr) -> WeldResult<Expr>;
     fn sort(data: Expr, cmpfunc: Expr) -> WeldResult<Expr>;
-    fn let(name: Symbol, value: Expr, body: Expr) -> WeldResult<Expr>;
-    fn if(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr>;
+    fn r#let(name: Symbol, value: Expr, body: Expr) -> WeldResult<Expr>;
+    fn r#if(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr>;
     fn select(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr>;
     fn lambda(params: Vec<Parameter>, body: Expr) -> WeldResult<Expr>;
     fn apply(func: Expr, params: Vec<Expr>) -> WeldResult<Expr>;
     fn cudf(sym_name: String, args: Vec<Expr>, return_ty: Type) -> WeldResult<Expr>;
     fn newbuilder(kind: BuilderKind, expr: Option<Expr>) -> WeldResult<Expr>;
-    fn for(iters: Vec<Iter>, builder: Expr, func: Expr, vectorized: bool) -> WeldResult<Expr>;
+    fn r#for(iters: Vec<Iter>, builder: Expr, func: Expr) -> WeldResult<Expr>;
     fn merge(builder: Expr, value: Expr) -> WeldResult<Expr>;
     fn result(builder: Expr) -> WeldResult<Expr>;
 }
 
 impl NewExpr for Expr {
 
-    pub fn new(kind: ExprKind) -> WeldResult<Expr> {
+    fn new(kind: ExprKind) -> WeldResult<Expr> {
         Self::new_with_type(kind, Unknown)
     }
 
-    pub fn new_with_type(kind: ExprKind, ty: Type) -> WeldResult<Expr> {
+    fn new_with_type(kind: ExprKind, ty: Type) -> WeldResult<Expr> {
         let mut expr = Expr {
             kind: kind,
             ty: ty,
             annotations: Annotations::new(),
-        }
+        };
 
         expr.infer_local()?;
         Ok(expr)
     }
 
-    pub fn literal(kind: LiteralKind) -> WeldResult<Expr> {
+    fn literal(kind: LiteralKind) -> WeldResult<Expr> {
         use ast::LiteralKind::*;
         use ast::Type::Scalar;
 
@@ -76,94 +77,94 @@ impl NewExpr for Expr {
         Self::new_with_type(Literal(kind.clone()), ty)
     }
 
-    pub fn ident(symbol: Symbol, ty: Type) -> WeldResult<Expr> {
+    fn ident(symbol: Symbol, ty: Type) -> WeldResult<Expr> {
         Self::new_with_type(Ident(symbol), ty)
     }
 
-    pub fn binop(kind: BinOpKind, left: Expr, right: Expr) -> WeldResult<Expr> {
-        let mut expr = Self::new(BinOp {
+    fn binop(kind: BinOpKind, left: Expr, right: Expr) -> WeldResult<Expr> {
+        Self::new(BinOp {
             kind: kind,
             left: Box::new(left),
             right: Box::new(right) 
         })
     }
 
-    pub fn unaryop(kind: UnaryOpKind, value: Expr) -> WeldResult<Expr> {
+    fn unaryop(kind: UnaryOpKind, value: Expr) -> WeldResult<Expr> {
         Self::new(UnaryOp {
             kind: kind,
             value: Box::new(value)
         })
     }
 
-    pub fn cast(kind: ScalarKind, expr: Expr) -> WeldResult<Expr> {
+    fn cast(kind: ScalarKind, expr: Expr) -> WeldResult<Expr> {
         Self::new(Cast {
             kind: kind,
             child_expr: Box::new(expr),
         })
     }
 
-    pub fn negate(expr: Expr) -> WeldResult<Expr> {
+    fn negate(expr: Expr) -> WeldResult<Expr> {
         Self::new(Negate(Box::new(expr)))
     }
 
-    pub fn not(expr: Expr) -> WeldResult<Expr> {
+    fn not(expr: Expr) -> WeldResult<Expr> {
         Self::new(Not(Box::new(expr)))
     }
 
-    pub fn broadcast(expr: Expr) -> WeldResult<Expr> {
-        Self::new(Broadcast(Box::new(expr)), ty)
+    fn broadcast(expr: Expr) -> WeldResult<Expr> {
+        Self::new(Broadcast(Box::new(expr)))
     }
 
-    pub fn tovec(expr: Expr) -> WeldResult<Expr> {
+    fn tovec(expr: Expr) -> WeldResult<Expr> {
         Self::new(ToVec {
             child_expr: Box::new(expr.clone())
         })
     }
 
-    pub fn makestruct(exprs: Vec<Expr>) -> WeldResult<Expr> {
+    fn makestruct(exprs: Vec<Expr>) -> WeldResult<Expr> {
         Self::new(MakeStruct {
             elems: exprs,
         })
     }
 
-    pub fn makevector(exprs: Vec<Expr>) -> WeldResult<Expr> {
+    fn makevector(exprs: Vec<Expr>) -> WeldResult<Expr> {
         Self::new(MakeVector {
             elems: exprs,
         })
     }
 
-    pub fn makevector_typed(exprs: Vec<Expr>, ty: Type) -> WeldResult<Expr> {
+    fn makevector_typed(exprs: Vec<Expr>, ty: Type) -> WeldResult<Expr> {
         Self::new_with_type(MakeVector { elems: exprs }, Vector(Box::new(ty)))
     }
 
-    pub fn getfield(expr: Expr, index: u32) -> WeldResult<Expr> {
+    fn getfield(expr: Expr, index: u32) -> WeldResult<Expr> {
         Self::new(GetField {
             expr: Box::new(expr),
             index: index,
         })
     }
 
-    pub fn length(expr: Expr) -> WeldResult<Expr> {
+    fn length(expr: Expr) -> WeldResult<Expr> {
         Self::new(Length {
             data: Box::new(expr)
         })
     }
 
-    pub fn lookup(data: Expr, index: Expr) -> WeldResult<Expr> {
+    fn lookup(data: Expr, index: Expr) -> WeldResult<Expr> {
         Self::new(Lookup {
             data: Box::new(data),
             index: Box::new(index),
         })
     }
 
-    pub fn keyexists(data: Expr, key: Expr) -> WeldResult<Expr> {
+    fn keyexists(data: Expr, key: Expr) -> WeldResult<Expr> {
         Self::new(KeyExists {
             data: Box::new(data),
             key: Box::new(key),
         })
     }
 
-    pub fn slice(data: Expr, index: Expr, size: Expr) -> WeldResult<Expr> {
+    fn slice(data: Expr, index: Expr, size: Expr) -> WeldResult<Expr> {
         Self::new(Slice {
             data: Box::new(data),
             index: Box::new(index),
@@ -171,14 +172,14 @@ impl NewExpr for Expr {
         })
     }
 
-    pub fn sort(data: Expr, cmpfunc: Expr) -> WeldResult<Expr> {
+    fn sort(data: Expr, cmpfunc: Expr) -> WeldResult<Expr> {
         Self::new(Sort {
             data: Box::new(data),
             cmpfunc: Box::new(cmpfunc),
         })
     }
 
-    pub fn let(name: Symbol, value: Expr, body: Expr) -> WeldResult<Expr> {
+    fn r#let(name: Symbol, value: Expr, body: Expr) -> WeldResult<Expr> {
         Self::new(Let {
             name: name,
             value: Box::new(value),
@@ -186,7 +187,7 @@ impl NewExpr for Expr {
         })
     }
 
-    pub fn if(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr> {
+    fn r#if(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr> {
         Self::new(If {
             cond: Box::new(cond),
             on_true: Box::new(on_true),
@@ -194,7 +195,7 @@ impl NewExpr for Expr {
         })
     }
 
-    pub fn select(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr> {
+    fn select(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr> {
         Self::new(Select {
             cond: Box::new(cond),
             on_true: Box::new(on_true),
@@ -202,21 +203,21 @@ impl NewExpr for Expr {
         })
     }
 
-    pub fn lambda(params: Vec<Parameter>, body: Expr) -> WeldResult<Expr> {
+    fn lambda(params: Vec<Parameter>, body: Expr) -> WeldResult<Expr> {
         Self::new(Lambda {
             params: params,
             body: Box::new(body),
         })
     }
 
-    pub fn apply(func: Expr, params: Vec<Expr>) -> WeldResult<Expr> {
+    fn apply(func: Expr, params: Vec<Expr>) -> WeldResult<Expr> {
         Self::new(Apply {
             func: Box::new(func),
             params: params,
         })
     }
 
-    pub fn cudf(sym_name: String, args: Vec<Expr>, return_ty: Type) -> WeldResult<Expr> {
+    fn cudf(sym_name: String, args: Vec<Expr>, return_ty: Type) -> WeldResult<Expr> {
         Self::new(CUDF {
             sym_name: sym_name,
             args: args,
@@ -224,11 +225,12 @@ impl NewExpr for Expr {
         })
     }
 
-    pub fn newbuilder(kind: BuilderKind, expr: Option<Expr>) -> WeldResult<Expr> {
-        Self::new(NewBuilder(expr.map(|e| Box::new(e))))
+    fn newbuilder(kind: BuilderKind, expr: Option<Expr>) -> WeldResult<Expr> {
+        let expr = expr.map(|e| Box::new(e));
+        Self::new_with_type(NewBuilder(expr), Builder(kind, Annotations::new()))
     }
 
-    pub fn for(iters: Vec<Iter>, builder: Expr, func: Expr) -> WeldResult<Expr> {
+    fn r#for(iters: Vec<Iter>, builder: Expr, func: Expr) -> WeldResult<Expr> {
         Self::new(For {
             iters: iters,
             builder: Box::new(builder),
@@ -236,14 +238,14 @@ impl NewExpr for Expr {
         })
     }
 
-    pub fn merge(builder: Expr, value: Expr) -> WeldResult<Expr> {
+    fn merge(builder: Expr, value: Expr) -> WeldResult<Expr> {
         Self::new(Merge {
             builder: Box::new(builder),
             value: Box::new(value),
         })
     }
 
-    pub fn result(builder: Expr) -> WeldResult<Expr> {
+    fn result(builder: Expr) -> WeldResult<Expr> {
         Self::new(Res {
             builder: Box::new(builder)
         })

--- a/weld/ast/builder.rs
+++ b/weld/ast/builder.rs
@@ -2,13 +2,11 @@
 
 use ast::*;
 use ast::ExprKind::*;
-use ast::Type::*;
-use ast::BuilderKind::*;
-use ast::LiteralKind::*;
 use error::*;
 
 pub trait NewExpr {
-    fn new(kind: ExprKind, ty: Type) -> WeldResult<Expr>;
+    fn new(kind: ExprKind) -> WeldResult<Expr>;
+    fn new_with_type(kind: ExprKind, ty: Type) -> WeldResult<Expr>;
     fn literal(kind: LiteralKind) -> WeldResult<Expr>;
     fn ident(symbol: Symbol, ty: Type) -> WeldResult<Expr>;
     fn binop(kind: BinOpKind, left: Expr, right: Expr) -> WeldResult<Expr>;
@@ -41,15 +39,25 @@ pub trait NewExpr {
 
 impl NewExpr for Expr {
 
-    pub fn new(kind: ExprKind, ty: Type) -> WeldResult<Expr> {
-        Ok(Expr {
+    pub fn new(kind: ExprKind) -> WeldResult<Expr> {
+        Self::new_with_type(kind, Unknown)
+    }
+
+    pub fn new_with_type(kind: ExprKind, ty: Type) -> WeldResult<Expr> {
+        let mut expr = Expr {
             kind: kind,
             ty: ty,
             annotations: Annotations::new(),
-        })
+        }
+
+        expr.infer_local()?;
+        Ok(expr)
     }
 
     pub fn literal(kind: LiteralKind) -> WeldResult<Expr> {
+        use ast::LiteralKind::*;
+        use ast::Type::Scalar;
+
         let ty = match kind {
             BoolLiteral(_) => Scalar(ScalarKind::Bool),
             I8Literal(_) => Scalar(ScalarKind::I8),
@@ -65,297 +73,147 @@ impl NewExpr for Expr {
             StringLiteral(_) => Vector(Box::new(Scalar(ScalarKind::I8))),
         };
 
-        Self::new(Literal(kind.clone()), ty)
+        Self::new_with_type(Literal(kind.clone()), ty)
     }
 
     pub fn ident(symbol: Symbol, ty: Type) -> WeldResult<Expr> {
-        Self::new(Ident(symbol), ty)
+        Self::new_with_type(Ident(symbol), ty)
     }
 
     pub fn binop(kind: BinOpKind, left: Expr, right: Expr) -> WeldResult<Expr> {
-        if left.ty != right.ty {
-            return compile_err!("Internal error: Mismatched types in binary operator");
-        }
-
-        let ty = if kind.is_comparison() {
-            Scalar(ScalarKind::Bool)
-        } else {
-            left.ty.clone()
-        };
-
-        Self::new(BinOp { kind: kind, left: Box::new(left), right: Box::new(right) }, ty)
+        let mut expr = Self::new(BinOp {
+            kind: kind,
+            left: Box::new(left),
+            right: Box::new(right) 
+        })
     }
 
     pub fn unaryop(kind: UnaryOpKind, value: Expr) -> WeldResult<Expr> {
-        let ty = value.ty.clone();
-        Self::new(UnaryOp { kind: kind, value: Box::new(value) }, value.ty.clone())
+        Self::new(UnaryOp {
+            kind: kind,
+            value: Box::new(value)
+        })
     }
 
     pub fn cast(kind: ScalarKind, expr: Expr) -> WeldResult<Expr> {
-        let ty = if let Scalar(_) = expr.ty {
-            Scalar(kind)
-        } else {
-            return compile_err!("Internal error: Mismatched types inSelf::cast");
-        };
         Self::new(Cast {
             kind: kind,
-            Self::child: Box::new(expr),
-        },
-        ty)
+            child_expr: Box::new(expr),
+        })
     }
 
     pub fn negate(expr: Expr) -> WeldResult<Expr> {
-        let ty = if let Scalar(ref k) = expr.ty {
-            Scalar(k.clone())
-        } else {
-            return compile_err!("Internal error: Mismatched types inSelf::negate");
-        };
-        Self::new(Negate(Box::new(expr)), ty)
+        Self::new(Negate(Box::new(expr)))
     }
 
     pub fn not(expr: Expr) -> WeldResult<Expr> {
-        let ty = if let Scalar(ref k) = expr.ty {
-            Scalar(k.clone())
-        } else {
-            return compile_err!("Internal error: Mismatched types inSelf::not");
-        };
-        Self::new(Not(Box::new(expr)), ty)
+        Self::new(Not(Box::new(expr)))
     }
 
     pub fn broadcast(expr: Expr) -> WeldResult<Expr> {
-        let ty = if let Scalar(ref k) = expr.ty {
-            Simd(k.clone())
-        } else {
-            return compile_err!("Internal error: Mismatched types inSelf::broadcast");
-        };
         Self::new(Broadcast(Box::new(expr)), ty)
     }
 
     pub fn tovec(expr: Expr) -> WeldResult<Expr> {
-        let ty = if let Dict(ref kt, ref vt) = expr.ty {
-            Struct(vec![*kt.clone(), *vt.clone()])
-        } else {
-            return compile_err!("Internal error: Mismatched types inSelf::tovec");
-        };
-        Self::new(ToVec {Self::child: Box::new(expr.clone()) }, ty)
+        Self::new(ToVec {
+            child_expr: Box::new(expr.clone())
+        })
     }
 
     pub fn makestruct(exprs: Vec<Expr>) -> WeldResult<Expr> {
-        let ty = Struct(exprs.iter().map(|e| e.ty.clone()).collect());
-        Self::new(MakeStruct { elems: exprs }, ty)
+        Self::new(MakeStruct {
+            elems: exprs,
+        })
     }
 
     pub fn makevector(exprs: Vec<Expr>) -> WeldResult<Expr> {
-        let ty = exprs[0].ty.clone();
-        if exprs.iter().all(|e| e.ty == ty) {
-            Self::new(MakeVector { elems: exprs }, Vector(Box::new(ty)))
-        } else {
-            compile_err!("Internal error: Mismatched types inSelf::makevector")
-        }
+        Self::new(MakeVector {
+            elems: exprs,
+        })
     }
 
-    /// Version ofSelf::makevector that is compatible with empty vectors.
     pub fn makevector_typed(exprs: Vec<Expr>, ty: Type) -> WeldResult<Expr> {
-        if exprs.iter().all(|e| e.ty == ty) {
-            Self::new(MakeVector { elems: exprs }, Vector(Box::new(ty.clone())))
-        } else {
-            compile_err!("Internal error: Mismatched types inSelf::makevector")
-        }
+        Self::new_with_type(MakeVector { elems: exprs }, Vector(Box::new(ty)))
     }
 
     pub fn getfield(expr: Expr, index: u32) -> WeldResult<Expr> {
-        let ty = if let Struct(ref tys) = expr.ty {
-            tys[index as usize].clone()
-        } else {
-            return compile_err!("Internal error: Mismatched types inSelf::getfield");
-        };
         Self::new(GetField {
             expr: Box::new(expr),
             index: index,
-        },
-        ty)
+        })
     }
 
     pub fn length(expr: Expr) -> WeldResult<Expr> {
-        if let Vector(_) = expr.ty {
-            Self::new(Length { data: Box::new(expr) }, Scalar(ScalarKind::I64))
-        } else {
-            compile_err!("Internal error: Mismatched types inSelf::length")
-        }
+        Self::new(Length {
+            data: Box::new(expr)
+        })
     }
 
     pub fn lookup(data: Expr, index: Expr) -> WeldResult<Expr> {
-        let err = compile_err!("Internal error: Mismatched types inSelf::lookup");
-        let ty = if let Vector(ref ty) = data.ty {
-            *ty.clone()
-        } else {
-            return err;
-        };
-
-        if let Scalar(ScalarKind::I64) = index.ty {
-            Self::new(Lookup {
-                data: Box::new(data),
-                index: Box::new(index),
-            },
-            ty)
-        } else {
-            err
-        }
+        Self::new(Lookup {
+            data: Box::new(data),
+            index: Box::new(index),
+        })
     }
 
     pub fn keyexists(data: Expr, key: Expr) -> WeldResult<Expr> {
-        let err = compile_err!("Internal error: Mismatched types inSelf::keyexists");
-        let kt = if let Dict(ref kt, _) = data.ty {
-            *kt.clone()
-        } else {
-            return err;
-        };
-
-        if key.ty != kt {
-            return err;
-        }
         Self::new(KeyExists {
             data: Box::new(data),
             key: Box::new(key),
-        },
-        Scalar(ScalarKind::Bool))
+        })
     }
 
     pub fn slice(data: Expr, index: Expr, size: Expr) -> WeldResult<Expr> {
-        let mut type_checked = 0;
-
-        if let Vector(_) = data.ty {
-            type_checked += 1;
-        }
-
-        if let Scalar(ScalarKind::I64) = index.ty {
-            type_checked += 1;
-        }
-
-        if let Scalar(ScalarKind::I64) = size.ty {
-            type_checked += 1;
-        }
-
-        if type_checked != 3 {
-            return compile_err!("Internal error: Mismatched types inSelf::slice");
-        }
-
-        let ty = data.ty.clone();
         Self::new(Slice {
             data: Box::new(data),
             index: Box::new(index),
             size: Box::new(size),
-        },
-        ty)
+        })
     }
 
     pub fn sort(data: Expr, cmpfunc: Expr) -> WeldResult<Expr> {
-        let mut type_checked = false;
-
-        if let Vector(ref vec_ty) = data.ty {
-            if let Function(ref params, ref body) = cmpfunc.ty {
-                if params.len() == 2 && params[0] == **vec_ty {
-                    // Return type must be i32.
-                    if let Scalar(ScalarKind::I32) = **body {
-                        // Both parameters must be of the same type.
-                        if params[0] == params[1] {
-                            type_checked = true;
-                        }
-                    }
-                }
-            }
-        }
-
-        if !type_checked {
-            return compile_err!("Internal error: Mismatched types inSelf::sort")
-        }
-
-        let ty = data.ty.clone();
         Self::new(Sort {
             data: Box::new(data),
             cmpfunc: Box::new(cmpfunc),
-        },
-        ty)
+        })
     }
 
     pub fn let(name: Symbol, value: Expr, body: Expr) -> WeldResult<Expr> {
-        let ty = body.ty.clone();
         Self::new(Let {
             name: name,
             value: Box::new(value),
             body: Box::new(body),
-        },
-        ty)
+        })
     }
 
     pub fn if(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr> {
-        let err = compile_err!("Internal error: Mismatched types inSelf::if");
-        if cond.ty != Scalar(ScalarKind::Bool) {
-            return err;
-        }
-
-        if on_true.ty != on_false.ty {
-            return err;
-        }
-
-        let ty = on_true.ty.clone();
         Self::new(If {
             cond: Box::new(cond),
             on_true: Box::new(on_true),
             on_false: Box::new(on_false),
-        },
-        ty)
+        })
     }
 
     pub fn select(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr> {
-        let err = compile_err!("Internal error: Mismatched types inSelf::select");
-        if cond.ty != Scalar(ScalarKind::Bool) && cond.ty != Simd(ScalarKind::Bool) {
-            return err;
-        }
-
-        if on_true.ty != on_false.ty {
-            return err;
-        }
-
-        let ty = on_true.ty.clone();
         Self::new(Select {
             cond: Box::new(cond),
             on_true: Box::new(on_true),
             on_false: Box::new(on_false),
-        },
-        ty)
+        })
     }
 
     pub fn lambda(params: Vec<Parameter>, body: Expr) -> WeldResult<Expr> {
-        let ty = Function(params.iter().map(|p| p.ty.clone()).collect(),
-        Box::new(body.ty.clone()));
         Self::new(Lambda {
             params: params,
             body: Box::new(body),
-        },
-        ty)
+        })
     }
 
     pub fn apply(func: Expr, params: Vec<Expr>) -> WeldResult<Expr> {
-        let err = compile_err!("Internal error: Mismatched types inSelf::apply");
-        let mut passed = false;
-        let mut ty = None;
-        if let Function(ref param_tys, ref ret_ty) = func.ty {
-            if params.iter().zip(param_tys).all(|e| e.0.ty == *e.1) {
-                passed = true;
-                ty = Some(ret_ty.clone());
-            }
-        }
-
-        if !passed {
-            return err;
-        }
-
         Self::new(Apply {
             func: Box::new(func),
             params: params,
-        },
-        *ty.unwrap())
+        })
     }
 
     pub fn cudf(sym_name: String, args: Vec<Expr>, return_ty: Type) -> WeldResult<Expr> {
@@ -363,222 +221,31 @@ impl NewExpr for Expr {
             sym_name: sym_name,
             args: args,
             return_ty: Box::new(return_ty.clone()),
-        },
-        return_ty)
+        })
     }
 
     pub fn newbuilder(kind: BuilderKind, expr: Option<Expr>) -> WeldResult<Expr> {
-        let passed = match kind {
-            Merger(ref ty, _) => {
-                let mut passed = false;
-                if let Some(ref e) = expr {
-                    if &e.ty == ty.as_ref() {
-                        passed = true;
-                    }
-                } else {
-                    // Argument is optional.
-                    passed = true;
-                }
-                passed
-            }
-            VecMerger(ref ty, _) => {
-                let mut passed = false;
-                if let Some(ref e) = expr {
-                    if let Vector(ref elem_ty) = e.ty {
-                        if elem_ty == ty {
-                            passed = true;
-                        }
-                    }
-                }
-                passed
-            }
-            Appender(_) => {
-                let mut passed = false;
-                if let Some(ref e) = expr {
-                    if let Scalar(ScalarKind::I64) = e.ty {
-                        passed = true;
-                    }
-                }
-                passed
-            }
-            _ => expr.is_none(),
-        };
-
-        if !passed {
-            return compile_err!("Internal error: Mismatched types inSelf::newbuilder");
-        }
-
-        Self::new(NewBuilder(expr.map(|e| Box::new(e))),
-        Builder(kind, Annotations::new()))
+        Self::new(NewBuilder(expr.map(|e| Box::new(e))))
     }
 
-    // TODO - the vectorized flag is temporary!
-    pub fn for(iters: Vec<Iter>, builder: Expr, func: Expr, vectorized: bool) -> WeldResult<Expr> {
-
-        let vec_tys = iters.iter().map(|i| i.data.ty.clone()).collect::<Vec<_>>();
-        let mut vec_elem_tys = vec![];
-        for ty in vec_tys.iter() {
-            if let Vector(ref elem_ty) = *ty {
-                vec_elem_tys.push(*elem_ty.clone())
-            }
-        }
-
-        if vec_tys.len() != vec_elem_tys.len() {
-            return compile_err!("Internal error: Mismatched types inSelf::for - non vector type in iter");
-        }
-
-        let builder_ty = builder.ty.clone();
-
-        if let Function(ref params, ref ret_ty) = func.ty {
-            // Make sure the function parameters match.
-            let ref param_0_ty = params[0];
-            let ref param_1_ty = params[1];
-            let ref param_2_ty = params[2];
-
-            // Check builder.
-            if param_0_ty != &builder_ty {
-                return compile_err!("Internal error: Mismatched types inSelf::for - function builder type",);
-            }
-
-            // Check the index.
-            if *param_1_ty != Scalar(ScalarKind::I64) {
-                return compile_err!("Internal error: Mismatched types inSelf::for - function index type");
-            }
-
-            if iters.len() != vec_elem_tys.len() {
-                return compile_err!("Internal error: Mismatched types inSelf::for - iters and vec_tys length",);
-            }
-
-            // Check the element type.
-            if iters.len() == 1 {
-                let elem_ty = if vectorized {
-                    if let Scalar(ref sk) = vec_elem_tys[0] {
-                        Simd(sk.clone())
-                    } else {
-                        return compile_err!("Internal error: Mismatched types inSelf::for - bad vector",);
-                    }
-                } else {
-                    vec_elem_tys[0].clone()
-                };
-                if *param_2_ty != elem_ty {
-                    return compile_err!("Internal error: Mismatched types inSelf::for - function elem type {} != {}",
-                                        param_2_ty, &elem_ty);
-                }
-            } else {
-                let composite_ty = if vectorized {
-                    let mut vec_elem_tys_simd = vec![];
-                    for ty in vec_elem_tys {
-                        if let Scalar(ref sk) = ty {
-                            vec_elem_tys_simd.push(Simd(sk.clone()))
-                        } else {
-                            return compile_err!("Internal error: Mismatched types inSelf::for - bad vector",);
-                        }
-                    }
-                    Struct(vec_elem_tys_simd)
-                } else {
-                    Struct(vec_elem_tys.clone())
-                };
-
-                if *param_2_ty != composite_ty {
-                    return compile_err!("Internal error: Mismatched types inSelf::for - function zipped elem type",);
-                }
-            }
-
-            // Function return type should match builder type.
-            if ret_ty.as_ref() != &builder_ty {
-                return compile_err!("Internal error: Mismatched types inSelf::for - function return type");
-            }
-        }
-
+    pub fn for(iters: Vec<Iter>, builder: Expr, func: Expr) -> WeldResult<Expr> {
         Self::new(For {
             iters: iters,
             builder: Box::new(builder),
             func: Box::new(func),
-        },
-        builder_ty)
+        })
     }
 
     pub fn merge(builder: Expr, value: Expr) -> WeldResult<Expr> {
-        let err = compile_err!("Internal error: Mismatched types inSelf::merge");
-        if let Builder(ref bk, _) = builder.ty {
-            match *bk {
-                Appender(ref elem_ty) => {
-                    if elem_ty.as_ref() != &value.ty {
-                        return err;
-                    }
-                }
-                Merger(ref elem_ty, _) => {
-                    if elem_ty.as_ref() != &value.ty {
-                        return err;
-                    }
-                }
-                DictMerger(ref elem_ty1, ref elem_ty2, _) => {
-                    if let Struct(ref v_ty) = value.ty {
-                        if v_ty.len() < 2 { return err; }
-
-                        if elem_ty1.as_ref() != &v_ty[0] {
-                            return err;
-                        }
-                        if elem_ty2.as_ref() != &v_ty[1] {
-                            return err;
-                        }
-                    } else {
-                        return err;
-                    }
-                }
-                GroupMerger(ref elem_ty1, ref elem_ty2) => {
-                    if let Struct(ref v_ty) = value.ty {
-                        if v_ty.len() < 2 { return err; }
-
-                        if elem_ty1.as_ref() != &v_ty[0] {
-                            return err;
-                        }
-                        if elem_ty2.as_ref() != &v_ty[1] {
-                            return err;
-                        }
-                    } else {
-                        return err;
-                    }
-                }
-                VecMerger(ref elem_ty, _) => {
-                    if let Struct(ref tys) = value.ty {
-                        if tys.len() != 2 {
-                            return err;
-                        }
-                        if tys[0] != Scalar(ScalarKind::I64) {
-                            return err;
-                        }
-                        if &tys[1] != elem_ty.as_ref() {
-                            return err;
-                        }
-                    } else {
-                        return err;
-                    }
-                }
-            }
-        }
-
-        let ty = builder.ty.clone();
         Self::new(Merge {
             builder: Box::new(builder),
             value: Box::new(value),
-        },
-        ty)
+        })
     }
 
     pub fn result(builder: Expr) -> WeldResult<Expr> {
-        let err = compile_err!("Internal error: Mismatched types inSelf::result");
-        let ty = if let Builder(ref bk, _) = builder.ty {
-            match *bk {
-                Appender(ref elem_ty) => Vector(elem_ty.clone()),
-                Merger(ref elem_ty, _) => *elem_ty.clone(),
-                DictMerger(ref kt, ref vt, _) => Dict(kt.clone(), vt.clone()),
-                GroupMerger(ref kt, ref vt) => Dict(kt.clone(), Box::new(Vector(vt.clone()))),
-                VecMerger(ref elem_ty, _) => Vector(elem_ty.clone()),
-            }
-        } else {
-            return err;
-        };
-        Self::new(Res { builder: Box::new(builder) }, ty)
+        Self::new(Res {
+            builder: Box::new(builder)
+        })
     }
 }

--- a/weld/ast/builder.rs
+++ b/weld/ast/builder.rs
@@ -1,4 +1,6 @@
-//! Builder API for Weld expressions.
+//! Constructors for Weld expressions.
+//!
+//! This module provides constructors with type checking for Weld expressions.
 
 use ast::*;
 use ast::ExprKind::*;
@@ -6,36 +8,389 @@ use ast::Type::*;
 use error::*;
 
 pub trait NewExpr {
+    /// Creates a new expression with the given kind.
+    ///
+    /// Returns an error if types in the `kind` mismatch.
     fn new(kind: ExprKind) -> WeldResult<Expr>;
+    /// Creates new expression with the given kind and type.
+    ///
+    /// Returns an error if types in the `kind` mismatch.
     fn new_with_type(kind: ExprKind, ty: Type) -> WeldResult<Expr>;
-    fn literal(kind: LiteralKind) -> WeldResult<Expr>;
-    fn ident(symbol: Symbol, ty: Type) -> WeldResult<Expr>;
-    fn binop(kind: BinOpKind, left: Expr, right: Expr) -> WeldResult<Expr>;
-    fn unaryop(kind: UnaryOpKind, value: Expr) -> WeldResult<Expr>;
-    fn cast(kind: ScalarKind, expr: Expr) -> WeldResult<Expr>;
-    fn negate(expr: Expr) -> WeldResult<Expr>;
-    fn not(expr: Expr) -> WeldResult<Expr>;
-    fn broadcast(expr: Expr) -> WeldResult<Expr>;
-    fn tovec(expr: Expr) -> WeldResult<Expr>;
-    fn makestruct(exprs: Vec<Expr>) -> WeldResult<Expr>;
-    fn makevector(exprs: Vec<Expr>) -> WeldResult<Expr>;
-    fn makevector_typed(exprs: Vec<Expr>, ty: Type) -> WeldResult<Expr>;
-    fn getfield(expr: Expr, index: u32) -> WeldResult<Expr>;
-    fn length(expr: Expr) -> WeldResult<Expr>;
-    fn lookup(data: Expr, index: Expr) -> WeldResult<Expr>;
-    fn keyexists(data: Expr, key: Expr) -> WeldResult<Expr>;
-    fn slice(data: Expr, index: Expr, size: Expr) -> WeldResult<Expr>;
-    fn sort(data: Expr, cmpfunc: Expr) -> WeldResult<Expr>;
-    fn r#let(name: Symbol, value: Expr, body: Expr) -> WeldResult<Expr>;
-    fn r#if(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr>;
-    fn select(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr>;
-    fn lambda(params: Vec<Parameter>, body: Expr) -> WeldResult<Expr>;
-    fn apply(func: Expr, params: Vec<Expr>) -> WeldResult<Expr>;
-    fn cudf(sym_name: String, args: Vec<Expr>, return_ty: Type) -> WeldResult<Expr>;
-    fn newbuilder(kind: BuilderKind, expr: Option<Expr>) -> WeldResult<Expr>;
-    fn r#for(iters: Vec<Iter>, builder: Expr, func: Expr) -> WeldResult<Expr>;
-    fn merge(builder: Expr, value: Expr) -> WeldResult<Expr>;
-    fn result(builder: Expr) -> WeldResult<Expr>;
+    /// Creates a new literal expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let expr = Expr::new_literal(I32Literal(1)).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_literal(kind: LiteralKind) -> WeldResult<Expr>;
+    /// Creates a new typed identifier expression.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let name = Symbol::new("a", 0);
+    /// let ty = Scalar(I32);
+    /// let expr = Expr::new_ident(name, ty.clone()).unwrap();
+    /// assert_eq!(expr.ty, ty);
+    /// ```
+    fn new_ident(symbol: Symbol, ty: Type) -> WeldResult<Expr>;
+    /// Creates a new binary operator expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_bin_op(kind: BinOpKind, left: Expr, right: Expr) -> WeldResult<Expr>;
+    /// Creates a new unary operator expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(F32Literal((1.0_f32).to_bits())).unwrap();
+    /// let expr = Expr::new_unary_op(Cos, one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(F32));
+    /// ```
+    fn new_unary_op(kind: UnaryOpKind, value: Expr) -> WeldResult<Expr>;
+    /// Creates a new cast operator expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_cast(F32, one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(F32));
+    /// ```
+    fn new_cast(kind: ScalarKind, expr: Expr) -> WeldResult<Expr>;
+    /// Creates a new negation operator expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_negate(one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_negate(expr: Expr) -> WeldResult<Expr>;
+    /// Creates a new not operator expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let value = Expr::new_literal(BoolLiteral(false)).unwrap();
+    /// let expr = Expr::new_not(value).unwrap();
+    /// assert_eq!(expr.ty, Scalar(Bool));
+    /// ```
+    fn new_not(expr: Expr) -> WeldResult<Expr>;
+    /// Creates a new scalar to SIMD broadcast expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_broadcast(one).unwrap();
+    /// assert_eq!(expr.ty, Simd(I32));
+    /// ```
+    fn new_broadcast(expr: Expr) -> WeldResult<Expr>;
+    /// Creates a new dictionary to vector expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let dict_ty = Dict(Box::new(Scalar(I32)), Box::new(Scalar(I32)));
+    /// let dict = Expr::new_ident(Symbol::new("d", 0), dict_ty).unwrap();
+    /// let expr = Expr::new_to_vec(dict).unwrap();
+    /// assert_eq!(expr.ty, Vector(Box::new(Struct(vec![Scalar(I32), Scalar(I32)]))));
+    /// ```
+    fn new_to_vec(expr: Expr) -> WeldResult<Expr>;
+    /// Creates a new struct literal expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_make_struct(vec![one.clone(), one.clone(), one]).unwrap();
+    /// assert_eq!(expr.ty, Struct(vec![Scalar(I32), Scalar(I32), Scalar(I32)]));
+    /// ```
+    fn new_make_struct(exprs: Vec<Expr>) -> WeldResult<Expr>;
+    /// Creates a new vector literal expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_make_vector(vec![one.clone(), one.clone(), one]).unwrap();
+    /// assert_eq!(expr.ty, Vector(Box::new(Scalar(I32))));
+    /// ```
+    fn new_make_vector(exprs: Vec<Expr>) -> WeldResult<Expr>;
+    /// Creates a new typed vector literal expression.
+    ///
+    /// This version can be used if `exprs` is empty and the type cannot be inferred with
+    /// `new_make_vector.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_make_vector_typed(exprs: Vec<Expr>, ty: Type) -> WeldResult<Expr>;                   ///////////////////////////// IM HERE!
+    /// Creates a new field access expression on struct.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_get_field(expr: Expr, index: u32) -> WeldResult<Expr>;
+    /// Creates a new vector length expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_length(expr: Expr) -> WeldResult<Expr>;
+    /// Creates a new vector or dictionary lookup expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_lookup(data: Expr, index: Expr) -> WeldResult<Expr>;
+    /// Creates a new dictionary optional lookup expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_opt_lookup(data: Expr, index: Expr) -> WeldResult<Expr>;
+    /// Creates a new dictionary key exists expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_key_exists(data: Expr, key: Expr) -> WeldResult<Expr>;
+    /// Creates a new vector slicing expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_slice(data: Expr, index: Expr, size: Expr) -> WeldResult<Expr>;
+    /// Creates a new vector sort expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_sort(data: Expr, cmpfunc: Expr) -> WeldResult<Expr>;
+    /// Creates a new let expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_let(name: Symbol, value: Expr, body: Expr) -> WeldResult<Expr>;
+    /// Creates a new if expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_if(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr>;
+    /// Creates a new select expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_select(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr>;
+    /// Creates a new lambda expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_lambda(params: Vec<Parameter>, body: Expr) -> WeldResult<Expr>;
+    /// Creates a new apply expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_apply(func: Expr, params: Vec<Expr>) -> WeldResult<Expr>;
+    /// Creates a new CUDF expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_cudf(sym_name: String, args: Vec<Expr>, return_ty: Type) -> WeldResult<Expr>;
+    /// Creates a builder initialization expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_new_builder(kind: BuilderKind, expr: Option<Expr>) -> WeldResult<Expr>;
+    /// Creates a new parallel for loop expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_for(iters: Vec<Iter>, builder: Expr, func: Expr) -> WeldResult<Expr>;
+    /// Creates a new merge expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_merge(builder: Expr, value: Expr) -> WeldResult<Expr>;
+    /// Creates a new result expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_result(builder: Expr) -> WeldResult<Expr>;
+    /// Creates a new serialize expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_serialize(value: Expr) -> WeldResult<Expr>;
+    /// Creates a new deserialize expression.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use weld::ast::prelude::*;
+    ///
+    /// let one = Expr::new_literal(I32Literal(1)).unwrap();
+    /// let expr = Expr::new_bin_op(Add, one.clone(), one).unwrap();
+    /// assert_eq!(expr.ty, Scalar(I32));
+    /// ```
+    fn new_deserialize(value: Expr, ty: Type) -> WeldResult<Expr>;
 }
 
 impl NewExpr for Expr {
@@ -55,7 +410,7 @@ impl NewExpr for Expr {
         Ok(expr)
     }
 
-    fn literal(kind: LiteralKind) -> WeldResult<Expr> {
+    fn new_literal(kind: LiteralKind) -> WeldResult<Expr> {
         use ast::LiteralKind::*;
         use ast::Type::Scalar;
 
@@ -77,11 +432,11 @@ impl NewExpr for Expr {
         Self::new_with_type(Literal(kind.clone()), ty)
     }
 
-    fn ident(symbol: Symbol, ty: Type) -> WeldResult<Expr> {
+    fn new_ident(symbol: Symbol, ty: Type) -> WeldResult<Expr> {
         Self::new_with_type(Ident(symbol), ty)
     }
 
-    fn binop(kind: BinOpKind, left: Expr, right: Expr) -> WeldResult<Expr> {
+    fn new_bin_op(kind: BinOpKind, left: Expr, right: Expr) -> WeldResult<Expr> {
         Self::new(BinOp {
             kind: kind,
             left: Box::new(left),
@@ -89,82 +444,89 @@ impl NewExpr for Expr {
         })
     }
 
-    fn unaryop(kind: UnaryOpKind, value: Expr) -> WeldResult<Expr> {
+    fn new_unary_op(kind: UnaryOpKind, value: Expr) -> WeldResult<Expr> {
         Self::new(UnaryOp {
             kind: kind,
             value: Box::new(value)
         })
     }
 
-    fn cast(kind: ScalarKind, expr: Expr) -> WeldResult<Expr> {
+    fn new_cast(kind: ScalarKind, expr: Expr) -> WeldResult<Expr> {
         Self::new(Cast {
             kind: kind,
             child_expr: Box::new(expr),
         })
     }
 
-    fn negate(expr: Expr) -> WeldResult<Expr> {
+    fn new_negate(expr: Expr) -> WeldResult<Expr> {
         Self::new(Negate(Box::new(expr)))
     }
 
-    fn not(expr: Expr) -> WeldResult<Expr> {
+    fn new_not(expr: Expr) -> WeldResult<Expr> {
         Self::new(Not(Box::new(expr)))
     }
 
-    fn broadcast(expr: Expr) -> WeldResult<Expr> {
+    fn new_broadcast(expr: Expr) -> WeldResult<Expr> {
         Self::new(Broadcast(Box::new(expr)))
     }
 
-    fn tovec(expr: Expr) -> WeldResult<Expr> {
+    fn new_to_vec(expr: Expr) -> WeldResult<Expr> {
         Self::new(ToVec {
             child_expr: Box::new(expr.clone())
         })
     }
 
-    fn makestruct(exprs: Vec<Expr>) -> WeldResult<Expr> {
+    fn new_make_struct(exprs: Vec<Expr>) -> WeldResult<Expr> {
         Self::new(MakeStruct {
             elems: exprs,
         })
     }
 
-    fn makevector(exprs: Vec<Expr>) -> WeldResult<Expr> {
+    fn new_make_vector(exprs: Vec<Expr>) -> WeldResult<Expr> {
         Self::new(MakeVector {
             elems: exprs,
         })
     }
 
-    fn makevector_typed(exprs: Vec<Expr>, ty: Type) -> WeldResult<Expr> {
+    fn new_make_vector_typed(exprs: Vec<Expr>, ty: Type) -> WeldResult<Expr> {
         Self::new_with_type(MakeVector { elems: exprs }, Vector(Box::new(ty)))
     }
 
-    fn getfield(expr: Expr, index: u32) -> WeldResult<Expr> {
+    fn new_get_field(expr: Expr, index: u32) -> WeldResult<Expr> {
         Self::new(GetField {
             expr: Box::new(expr),
             index: index,
         })
     }
 
-    fn length(expr: Expr) -> WeldResult<Expr> {
+    fn new_length(expr: Expr) -> WeldResult<Expr> {
         Self::new(Length {
             data: Box::new(expr)
         })
     }
 
-    fn lookup(data: Expr, index: Expr) -> WeldResult<Expr> {
+    fn new_lookup(data: Expr, index: Expr) -> WeldResult<Expr> {
         Self::new(Lookup {
             data: Box::new(data),
             index: Box::new(index),
         })
     }
 
-    fn keyexists(data: Expr, key: Expr) -> WeldResult<Expr> {
+    fn new_opt_lookup(data: Expr, index: Expr) -> WeldResult<Expr> {
+        Self::new(OptLookup {
+            data: Box::new(data),
+            index: Box::new(index),
+        })
+    }
+
+    fn new_key_exists(data: Expr, key: Expr) -> WeldResult<Expr> {
         Self::new(KeyExists {
             data: Box::new(data),
             key: Box::new(key),
         })
     }
 
-    fn slice(data: Expr, index: Expr, size: Expr) -> WeldResult<Expr> {
+    fn new_slice(data: Expr, index: Expr, size: Expr) -> WeldResult<Expr> {
         Self::new(Slice {
             data: Box::new(data),
             index: Box::new(index),
@@ -172,14 +534,14 @@ impl NewExpr for Expr {
         })
     }
 
-    fn sort(data: Expr, cmpfunc: Expr) -> WeldResult<Expr> {
+    fn new_sort(data: Expr, cmpfunc: Expr) -> WeldResult<Expr> {
         Self::new(Sort {
             data: Box::new(data),
             cmpfunc: Box::new(cmpfunc),
         })
     }
 
-    fn r#let(name: Symbol, value: Expr, body: Expr) -> WeldResult<Expr> {
+    fn new_let(name: Symbol, value: Expr, body: Expr) -> WeldResult<Expr> {
         Self::new(Let {
             name: name,
             value: Box::new(value),
@@ -187,7 +549,7 @@ impl NewExpr for Expr {
         })
     }
 
-    fn r#if(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr> {
+    fn new_if(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr> {
         Self::new(If {
             cond: Box::new(cond),
             on_true: Box::new(on_true),
@@ -195,7 +557,7 @@ impl NewExpr for Expr {
         })
     }
 
-    fn select(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr> {
+    fn new_select(cond: Expr, on_true: Expr, on_false: Expr) -> WeldResult<Expr> {
         Self::new(Select {
             cond: Box::new(cond),
             on_true: Box::new(on_true),
@@ -203,21 +565,21 @@ impl NewExpr for Expr {
         })
     }
 
-    fn lambda(params: Vec<Parameter>, body: Expr) -> WeldResult<Expr> {
+    fn new_lambda(params: Vec<Parameter>, body: Expr) -> WeldResult<Expr> {
         Self::new(Lambda {
             params: params,
             body: Box::new(body),
         })
     }
 
-    fn apply(func: Expr, params: Vec<Expr>) -> WeldResult<Expr> {
+    fn new_apply(func: Expr, params: Vec<Expr>) -> WeldResult<Expr> {
         Self::new(Apply {
             func: Box::new(func),
             params: params,
         })
     }
 
-    fn cudf(sym_name: String, args: Vec<Expr>, return_ty: Type) -> WeldResult<Expr> {
+    fn new_cudf(sym_name: String, args: Vec<Expr>, return_ty: Type) -> WeldResult<Expr> {
         Self::new(CUDF {
             sym_name: sym_name,
             args: args,
@@ -225,12 +587,12 @@ impl NewExpr for Expr {
         })
     }
 
-    fn newbuilder(kind: BuilderKind, expr: Option<Expr>) -> WeldResult<Expr> {
+    fn new_new_builder(kind: BuilderKind, expr: Option<Expr>) -> WeldResult<Expr> {
         let expr = expr.map(|e| Box::new(e));
         Self::new_with_type(NewBuilder(expr), Builder(kind, Annotations::new()))
     }
 
-    fn r#for(iters: Vec<Iter>, builder: Expr, func: Expr) -> WeldResult<Expr> {
+    fn new_for(iters: Vec<Iter>, builder: Expr, func: Expr) -> WeldResult<Expr> {
         Self::new(For {
             iters: iters,
             builder: Box::new(builder),
@@ -238,16 +600,27 @@ impl NewExpr for Expr {
         })
     }
 
-    fn merge(builder: Expr, value: Expr) -> WeldResult<Expr> {
+    fn new_merge(builder: Expr, value: Expr) -> WeldResult<Expr> {
         Self::new(Merge {
             builder: Box::new(builder),
             value: Box::new(value),
         })
     }
 
-    fn result(builder: Expr) -> WeldResult<Expr> {
+    fn new_result(builder: Expr) -> WeldResult<Expr> {
         Self::new(Res {
             builder: Box::new(builder)
+        })
+    }
+
+    fn new_serialize(value: Expr) -> WeldResult<Expr> {
+        Self::new(Serialize(Box::new(value)))
+    }
+
+    fn new_deserialize(value: Expr, ty: Type) -> WeldResult<Expr> {
+        Self::new(Deserialize {
+            value: Box::new(value),
+            value_ty: Box::new(ty),
         })
     }
 }

--- a/weld/ast/builder.rs
+++ b/weld/ast/builder.rs
@@ -7,7 +7,7 @@ use ast::ExprKind::*;
 use ast::Type::*;
 use error::*;
 
-/// A trait that implements constructors for expression variants.
+/// A trait for initializing expressions with type inference.
 ///
 /// This trait provides constructors with type checking to expression variants. The type of each
 /// expression is inferred locally based on its immediate children. Each function returns an error

--- a/weld/ast/builder.rs
+++ b/weld/ast/builder.rs
@@ -107,6 +107,7 @@ impl NewExpr for Expr {
             annotations: Annotations::new(),
         };
 
+        // Check the type/infer unknown types locally.
         expr.infer_local()?;
         Ok(expr)
     }
@@ -130,7 +131,7 @@ impl NewExpr for Expr {
             StringLiteral(_) => Vector(Box::new(Scalar(ScalarKind::I8))),
         };
 
-        Self::new_with_type(Literal(kind.clone()), ty)
+        Self::new_with_type(Literal(kind), ty)
     }
 
     fn new_ident(symbol: Symbol, ty: Type) -> WeldResult<Expr> {
@@ -173,7 +174,7 @@ impl NewExpr for Expr {
 
     fn new_to_vec(expr: Expr) -> WeldResult<Expr> {
         Self::new(ToVec {
-            child_expr: Box::new(expr.clone())
+            child_expr: Box::new(expr)
         })
     }
 
@@ -284,7 +285,7 @@ impl NewExpr for Expr {
         Self::new(CUDF {
             sym_name: sym_name,
             args: args,
-            return_ty: Box::new(return_ty.clone()),
+            return_ty: Box::new(return_ty),
         })
     }
 

--- a/weld/ast/constructors.rs
+++ b/weld/ast/constructors.rs
@@ -1,5 +1,6 @@
 //! Constructors for creating typed expressions.
 #![allow(dead_code)]
+#[deprecated(since="0.2.0", note="Please use the `NewExpr` trait on `Expr` instead")]
 
 use ast::*;
 use ast::ExprKind::*;

--- a/weld/ast/mod.rs
+++ b/weld/ast/mod.rs
@@ -15,6 +15,7 @@ pub use self::uniquify::Uniquify;
 pub mod constructors;
 
 mod ast;
+mod builder;
 mod cmp;
 mod hash;
 mod pretty_print;

--- a/weld/ast/mod.rs
+++ b/weld/ast/mod.rs
@@ -6,6 +6,7 @@
 pub use self::ast::*;
 
 // Various convinience methods on the AST.
+pub use self::builder::NewExpr;
 pub use self::cmp::CompareIgnoringSymbols;
 pub use self::hash::HashIgnoringSymbols;
 pub use self::pretty_print::{PrettyPrint, PrettyPrintConfig};
@@ -13,6 +14,7 @@ pub use self::type_inference::InferTypes;
 pub use self::uniquify::Uniquify;
 
 pub mod constructors;
+pub mod prelude;
 
 mod ast;
 mod builder;

--- a/weld/ast/prelude.rs
+++ b/weld/ast/prelude.rs
@@ -1,0 +1,13 @@
+//! A prelude for using the AST.
+//!
+//! This brings the variants of the all enums into scope.
+
+pub use super::*;
+
+pub use super::ast::BinOpKind::*;
+pub use super::ast::BuilderKind::*;
+pub use super::ast::ExprKind::*;
+pub use super::ast::LiteralKind::*;
+pub use super::ast::ScalarKind::*;
+pub use super::ast::UnaryOpKind::*;
+pub use super::ast::Type::*;


### PR DESCRIPTION
Creates a more "Rusty" constructor API for expressions. This also changes the API to directly use the type checking logic in the `InferTypes` trait rather than effectively re-implementing type checking in the constructor like before.

This deprecates the `weld::ast::constructors` module (it will be removed eventually). Users should use the equivalent associated functions in the `NewExpr` trait instead. For example:

```rust
use ast::constructors;

let expr = constructors::binop_expr(BinOpKind::Add, left, right).unwrap();
```

Becomes

```rust
use ast::*;

let expr = Expr::new_bin_op(BinOpKind::Add, left, right).unwrap();
```

## Other Changes

* This patch also adds a `prelude` module to `ast`, to bring all structs/enums and their variants into scope at once.

* Moves some tests around