### PR TITLE
Support for custom entry point function name

### DIFF
--- a/weld/codegen/llvm2/jit.rs
+++ b/weld/codegen/llvm2/jit.rs
@@ -132,7 +132,7 @@ pub unsafe fn compile(context: LLVMContextRef,
     stats.llvm_times.push(("Create Exec Engine".to_string(), start.to(end)));
 
     let start = PreciseTime::now();
-    let run_func = find_function(engine, "run")?;
+    let run_func = find_function(engine, &conf.llvm.run_func_name)?;
     let end = PreciseTime::now();
     stats.llvm_times.push(("Find Run Func Address".to_string(), start.to(end)));
 

--- a/weld/codegen/llvm2/mod.rs
+++ b/weld/codegen/llvm2/mod.rs
@@ -774,7 +774,7 @@ impl LlvmGenerator {
         let input_type = WeldInputArgs::llvm_type(self.context);
         let output_type = WeldOutputArgs::llvm_type(self.context);
 
-        let name = CString::new("run").unwrap();
+        let name = CString::new(self.conf.llvm.run_func_name.as_bytes()).unwrap();
         let func_ty = LLVMFunctionType(self.i64_type(), [self.i64_type()].as_mut_ptr(), 1, 0);
         let function = LLVMAddFunction(self.module, name.as_ptr(), func_ty);
 

--- a/weld/conf/constants.rs
+++ b/weld/conf/constants.rs
@@ -80,6 +80,9 @@ pub const CONF_LLVM_MODULE_OPTS_KEY: &'static str = "weld.llvm.optimization.modu
 /// This parameter should be set for compilation.
 pub const CONF_LLVM_FUNC_OPTS_KEY: &'static str = "weld.llvm.optimization.funcOpts";
 
+/// Sets the symbol name of the entry-point function.
+pub const CONF_LLVM_RUN_FUNC_NAME_KEY: &'static str = "weld.llvm.runFunctionName";
+
 /// Enables dumping code during compilation.
 ///
 /// This will produce several files in the directory specified by `weld.compile.dumpCodeDir`:
@@ -146,6 +149,9 @@ pub const CONF_LLVM_MODULE_OPTS_DEFAULT: bool = true;
 /// Default LLVM function passes setting.
 pub const CONF_LLVM_FUNC_OPTS_DEFAULT: bool = true;
 
+/// Default symbol name for LLVM entry-point function.
+pub const CONF_LLVM_RUN_FUNC_NAME_DEFAULT: &'static str = "run";
+
 /// Default setting for whether to dump code.
 pub const CONF_DUMP_CODE_DEFAULT: bool = false;
 
@@ -160,6 +166,7 @@ pub const CONF_ENABLE_BOUNDS_CHECKS_DEFAULT: bool = false;
 
 /// Default directory for dumping code.
 pub const CONF_DUMP_CODE_DIR_DEFAULT: &'static str = ".";
+
 
 /// Default set of optimization passes.
 pub const CONF_OPTIMIZATION_PASSES_DEFAULT: &[&'static str] =  &[

--- a/weld/conf/mod.rs
+++ b/weld/conf/mod.rs
@@ -71,6 +71,11 @@ pub struct LLVMConfig {
     /// This uses the Clang function optimization pipeline. The specific passes are determined by the
     /// optimization level.
     pub func_optimizations: bool,
+    /// Name of the entry-point function.
+    ///
+    /// This setting is useful if the dumped LLVM code is compiled independently and the run
+    /// function needs a unique name.
+    pub run_func_name: String,
 }
 
 impl Default for LLVMConfig {
@@ -82,6 +87,7 @@ impl Default for LLVMConfig {
             target_analysis_passes: CONF_LLVM_TARGET_PASSES_DEFAULT,
             module_optimizations: CONF_LLVM_MODULE_OPTS_DEFAULT,
             func_optimizations: CONF_LLVM_FUNC_OPTS_DEFAULT,
+            run_func_name: CONF_LLVM_RUN_FUNC_NAME_DEFAULT.to_string(),
         }
     }
 }
@@ -187,6 +193,8 @@ impl ParsedConf {
                                                      CONF_LLVM_MODULE_OPTS_DEFAULT)?,
                 func_optimizations: conf.parse_str(CONF_LLVM_FUNC_OPTS_KEY,
                                                    CONF_LLVM_FUNC_OPTS_DEFAULT)?,
+                run_func_name: conf.parse_str(CONF_LLVM_RUN_FUNC_NAME_KEY,
+                                              CONF_LLVM_RUN_FUNC_NAME_DEFAULT.to_string())?,
             },
             dump_code: DumpCodeConfig {
                 enabled: conf.parse_str(CONF_DUMP_CODE_KEY,


### PR DESCRIPTION
This PR adds support for a custom name for the entry-point function in an LLVM module. This is useful, e.g., if the dumped LLVM IR is used to compile multiple shared object files that all need non-conflicting symbol names for the functions.

Usage with C API:

```c
weld_conf_set("weld.llvm.runFunctionName", "myCustomFunctionName");
```

The default name remains `"run"`.
@kraftp this should address your comment.