### PR TITLE
LLVM External Error fix for Ubuntu

### DIFF
--- a/weld/codegen/llvm2/intrinsic.rs
+++ b/weld/codegen/llvm2/intrinsic.rs
@@ -286,7 +286,8 @@ impl Intrinsics {
         let name = CString::new("weld_runst_init").unwrap();
         let fn_type = LLVMFunctionType(self.run_handle_type(), params.as_mut_ptr(), params.len() as u32, 0);
         let function = LLVMAddFunction(self.module, name.as_ptr(), fn_type);
-        self.intrinsics.insert(name.into_string().unwrap(), function);
+        self.intrinsics.insert(name.clone().into_string().unwrap(), function);
+        self.pointers.insert(name.into_string().unwrap(), ffi::weld_runst_init as *mut c_void);
 
         let mut params = vec![self.run_handle_type()];
         let name = CString::new("weld_runst_get_result").unwrap();
@@ -294,7 +295,8 @@ impl Intrinsics {
         let function = LLVMAddFunction(self.module, name.as_ptr(), fn_type);
         LLVMExtAddAttrsOnFunction(self.context, function, &[NoUnwind]);
         LLVMExtAddAttrsOnParameter(self.context, function, &[NoCapture, NoAlias, NonNull, ReadOnly], 0);
-        self.intrinsics.insert(name.into_string().unwrap(), function);
+        self.intrinsics.insert(name.clone().into_string().unwrap(), function);
+        self.pointers.insert(name.into_string().unwrap(), ffi::weld_runst_get_result as *mut c_void);
 
         let mut params = vec![self.run_handle_type(), int8p];
         let name = CString::new("weld_runst_set_result").unwrap();
@@ -311,7 +313,8 @@ impl Intrinsics {
         let function = LLVMAddFunction(self.module, name.as_ptr(), fn_type);
         LLVMExtAddAttrsOnParameter(self.context, function, &[NoCapture, NoAlias, NonNull], 0);
         LLVMExtAddAttrsOnReturn(self.context, function, &[NoAlias]);
-        self.intrinsics.insert(name.into_string().unwrap(), function);
+        self.intrinsics.insert(name.clone().into_string().unwrap(), function);
+        self.pointers.insert(name.into_string().unwrap(), ffi::weld_runst_malloc as *mut c_void);
 
         let mut params = vec![self.run_handle_type(), int8p, self.i64_type()];
         let name = CString::new("weld_runst_realloc").unwrap();
@@ -334,7 +337,8 @@ impl Intrinsics {
         let function = LLVMAddFunction(self.module, name.as_ptr(), fn_type);
         LLVMExtAddAttrsOnFunction(self.context, function, &[NoUnwind]);
         LLVMExtAddAttrsOnParameter(self.context, function, &[NoCapture, NoAlias, NonNull, ReadOnly], 0);
-        self.intrinsics.insert(name.into_string().unwrap(), function);
+        self.intrinsics.insert(name.clone().into_string().unwrap(), function);
+        self.pointers.insert(name.into_string().unwrap(), ffi::weld_runst_get_errno as *mut c_void);
 
         let mut params = vec![self.run_handle_type(), self.i64_type()];
         let name = CString::new("weld_runst_set_errno").unwrap();

--- a/weld/codegen/llvm2/intrinsic.rs
+++ b/weld/codegen/llvm2/intrinsic.rs
@@ -79,7 +79,6 @@ impl Intrinsics {
         for (name, entry) in self.intrinsics.iter() {
             match *entry {
                 Intrinsic::FunctionPointer(_, ptr) => {
-                    trace!("Adding {} to mappings", name);
                     mappings.push((CString::new(name.as_str()).unwrap(), ptr)) 
                 }
                 _ => ()

--- a/weld/codegen/llvm2/intrinsic.rs
+++ b/weld/codegen/llvm2/intrinsic.rs
@@ -124,7 +124,7 @@ impl Intrinsics {
     }
 
     /// Get the intrinsic function value with the given name.
-    pub fn get<T: AsRef<str>>(&mut self, key: T) -> Option<LLVMValueRef> {
+    pub fn get<T: AsRef<str>>(&self, key: T) -> Option<LLVMValueRef> {
         self.intrinsics.get(key.as_ref()).map(|r| r.value())
     }
 

--- a/weld/codegen/llvm2/intrinsic.rs
+++ b/weld/codegen/llvm2/intrinsic.rs
@@ -76,10 +76,11 @@ impl Intrinsics {
     /// Builtins are filtered out of this list.
     pub fn mappings(&self) -> Vec<Mapping> {
         let mut mappings = vec![];
-        for (_name, entry) in self.intrinsics.iter() {
+        for (name, entry) in self.intrinsics.iter() {
+            trace!("{} -> {:?}", name, entry);
             match *entry {
-                Intrinsic::FunctionPointer(ref value, ref ptr) => {
-                    mappings.push((value.clone(), ptr.clone())) 
+                Intrinsic::FunctionPointer(value, ptr) => {
+                    mappings.push((value, ptr)) 
                 }
                 Intrinsic::Builtin(_) => ()
             }

--- a/weld/codegen/llvm2/intrinsic.rs
+++ b/weld/codegen/llvm2/intrinsic.rs
@@ -47,7 +47,7 @@ impl Intrinsic {
 }
 
 /// A mapping from an LLVM value to its function pointer.
-pub type Mapping = (LLVMValueRef, *mut c_void);
+pub type Mapping = (CString, *mut c_void);
 
 /// Intrinsics defined in the code generator.
 ///
@@ -79,10 +79,10 @@ impl Intrinsics {
     pub fn mappings(&self) -> Vec<Mapping> {
         let mut mappings = vec![];
         for (name, entry) in self.intrinsics.iter() {
-            trace!("{} -> {:?}", name, entry);
             match *entry {
-                Intrinsic::FunctionPointer(value, ptr) if self.used.contains(name) => {
-                    mappings.push((value, ptr)) 
+                Intrinsic::FunctionPointer(_, ptr) if self.used.contains(name) => {
+                    trace!("Adding {} to mappings", name);
+                    mappings.push((CString::new(name.as_str()).unwrap(), ptr)) 
                 }
                 _ => ()
             }

--- a/weld/codegen/llvm2/jit.rs
+++ b/weld/codegen/llvm2/jit.rs
@@ -118,7 +118,7 @@ pub unsafe fn init() {
 /// Compile a constructed module in the given LLVM context.
 pub unsafe fn compile(context: LLVMContextRef,
                module: LLVMModuleRef,
-               mappings: &Vec<intrinsic::Mapping>,
+               mappings: &[intrinsic::Mapping],
                conf: &ParsedConf,
                stats: &mut CompilationStats) -> WeldResult<CompiledModule> {
     init();
@@ -326,7 +326,7 @@ unsafe fn optimize_module(module: LLVMModuleRef, conf: &ParsedConf) -> WeldResul
 
 /// Create an MCJIT execution engine for a given module.
 unsafe fn create_exec_engine(module: LLVMModuleRef,
-                             mappings: &Vec<intrinsic::Mapping>,
+                             mappings: &[intrinsic::Mapping],
                              conf: &ParsedConf) -> WeldResult<LLVMExecutionEngineRef> {
 
     // Create a filtered list of globals. Needs to be done before creating the execution engine

--- a/weld/codegen/llvm2/jit.rs
+++ b/weld/codegen/llvm2/jit.rs
@@ -333,7 +333,7 @@ unsafe fn create_exec_engine(module: LLVMModuleRef,
     // since we lose ownership of the module. (?)
     let mut globals = vec![];
     for mapping in mappings.iter() {
-        let global = LLVMGetNamedGlobal(module, mapping.0.as_ptr());
+        let global = LLVMGetNamedFunction(module, mapping.0.as_ptr());
         // The LLVM optimizer can delete globals, so we need this check here!
         if global != ptr::null_mut() {
             trace!("Adding mapping {:?}.", mapping);

--- a/weld/codegen/llvm2/jit.rs
+++ b/weld/codegen/llvm2/jit.rs
@@ -336,10 +336,9 @@ unsafe fn create_exec_engine(module: LLVMModuleRef,
         let global = LLVMGetNamedFunction(module, mapping.0.as_ptr());
         // The LLVM optimizer can delete globals, so we need this check here!
         if global != ptr::null_mut() {
-            trace!("Adding mapping {:?}.", mapping);
             globals.push((global, mapping.1));
         } else {
-            trace!("Function {:?} was deleted by optimizer", mapping.0);
+            trace!("Function {:?} was deleted from module by optimizer", mapping.0);
         }
     }
 
@@ -357,8 +356,6 @@ unsafe fn create_exec_engine(module: LLVMModuleRef,
                                                        options_size,
                                                        &mut error_str);
 
-    trace!("Created execution engine.");
-
     if result_code != 0 {
         compile_err!("Creating execution engine failed: {}",
                      CStr::from_ptr(error_str).to_str().unwrap())
@@ -366,7 +363,6 @@ unsafe fn create_exec_engine(module: LLVMModuleRef,
         for global in globals {
             LLVMAddGlobalMapping(engine, global.0, global.1);
         }
-        trace!("Finished adding mappings.");
         Ok(engine)
     }
 }

--- a/weld/codegen/llvm2/jit.rs
+++ b/weld/codegen/llvm2/jit.rs
@@ -346,6 +346,22 @@ unsafe fn create_exec_engine(module: LLVMModuleRef,
                          *intrinsics.intrinsics.get("weld_runst_set_result").unwrap(),
                          *intrinsics.pointers.get("weld_runst_set_result").unwrap());
 
+    LLVMAddGlobalMapping(engine,
+                         *intrinsics.intrinsics.get("weld_runst_get_result").unwrap(),
+                         *intrinsics.pointers.get("weld_runst_get_result").unwrap());
+
+    LLVMAddGlobalMapping(engine,
+                         *intrinsics.intrinsics.get("weld_runst_init").unwrap(),
+                         *intrinsics.pointers.get("weld_runst_init").unwrap());
+
+    LLVMAddGlobalMapping(engine,
+                         *intrinsics.intrinsics.get("weld_runst_malloc").unwrap(),
+                         *intrinsics.pointers.get("weld_runst_malloc").unwrap());
+
+    LLVMAddGlobalMapping(engine,
+                         *intrinsics.intrinsics.get("weld_runst_get_errno").unwrap(),
+                         *intrinsics.pointers.get("weld_runst_get_errno").unwrap());
+
     if result_code != 0 {
         compile_err!("Creating execution engine failed: {}",
                           CStr::from_ptr(error_str).to_str().unwrap())

--- a/weld/codegen/llvm2/jit.rs
+++ b/weld/codegen/llvm2/jit.rs
@@ -342,15 +342,17 @@ unsafe fn create_exec_engine(module: LLVMModuleRef,
                                                        options_size,
                                                        &mut error_str);
 
-
-    for mapping in mappings.iter() {
-        LLVMAddGlobalMapping(engine, mapping.0, mapping.1);
-    }
+    trace!("Created execution engine.");
 
     if result_code != 0 {
         compile_err!("Creating execution engine failed: {}",
-                          CStr::from_ptr(error_str).to_str().unwrap())
+                     CStr::from_ptr(error_str).to_str().unwrap())
     } else {
+        for mapping in mappings.iter() {
+            trace!("Adding mapping {:?}.", mapping);
+            LLVMAddGlobalMapping(engine, mapping.0, mapping.1);
+        }
+        trace!("Finished adding mappings.");
         Ok(engine)
     }
 }

--- a/weld/codegen/llvm2/mod.rs
+++ b/weld/codegen/llvm2/mod.rs
@@ -149,7 +149,8 @@ pub fn compile(program: &SirProgram,
         runtime::ffi::weld_init();
     }
 
-    let module = unsafe { jit::compile(codegen.context, codegen.module, &codegen.intrinsics, conf, stats)? };
+    let ref mappings = codegen.intrinsics.mappings();
+    let module = unsafe { jit::compile(codegen.context, codegen.module, mappings, conf, stats)? };
 
     nonfatal!(write_code(module.asm()?, DumpCodeFormat::Assembly, &conf.dump_code));
     nonfatal!(write_code(module.llvm()?, DumpCodeFormat::LLVMOpt, &conf.dump_code));

--- a/weld/codegen/llvm2/mod.rs
+++ b/weld/codegen/llvm2/mod.rs
@@ -149,7 +149,7 @@ pub fn compile(program: &SirProgram,
         runtime::ffi::weld_init();
     }
 
-    let module = unsafe { jit::compile(codegen.context, codegen.module, conf, stats)? };
+    let module = unsafe { jit::compile(codegen.context, codegen.module, &codegen.intrinsics, conf, stats)? };
 
     nonfatal!(write_code(module.asm()?, DumpCodeFormat::Assembly, &conf.dump_code));
     nonfatal!(write_code(module.llvm()?, DumpCodeFormat::LLVMOpt, &conf.dump_code));


### PR DESCRIPTION
This patch registers functions using the globals API in LLVM to fix the "external error" issue (#394).

@Max-Meldrum could you confirm that this works on your machine for your code? I tried it with the example on 16.04 on EC2 and it works there, but just to double check.