### PR TITLE
0.3.0 fixes

### DIFF
--- a/examples/cpp/add_repl/add_repl.cpp
+++ b/examples/cpp/add_repl/add_repl.cpp
@@ -5,7 +5,7 @@
 #include <string.h>
 
 // Include the Weld API.
-#include "../../../c/weld.h"
+#include "../../../weld-capi/weld.h"
 
 int main() {
     // Compile Weld module.

--- a/examples/cpp/composite_types/composite_types.cpp
+++ b/examples/cpp/composite_types/composite_types.cpp
@@ -5,7 +5,7 @@
 #include <string.h>
 
 // Include the Weld API.
-#include "../../../c/weld.h"
+#include "../../../weld-capi/weld.h"
 
 const char *program = "|x:i32, ys:vec[i64]|\
 let a = result(for(ys, appender[i32], |b, i, y| merge(b, x)));\

--- a/examples/cpp/serialization/deserialize_vec_pointers/deserialize_test.cpp
+++ b/examples/cpp/serialization/deserialize_vec_pointers/deserialize_test.cpp
@@ -7,7 +7,7 @@
 #include <assert.h>
 
 // Include the Weld API.
-#include "../../../../c/weld.h"
+#include "../../../../weld-capi/weld.h"
 
 
 template <class T>

--- a/examples/cpp/serialization/serialize_dictionary/serialize_test.cpp
+++ b/examples/cpp/serialization/serialize_dictionary/serialize_test.cpp
@@ -7,7 +7,7 @@
 #include <assert.h>
 
 // Include the Weld API.
-#include "../../../../c/weld.h"
+#include "../../../../weld-capi/weld.h"
 
 
 template <class T>

--- a/examples/cpp/serialization/serialize_vec/serialize_test.cpp
+++ b/examples/cpp/serialization/serialize_vec/serialize_test.cpp
@@ -7,7 +7,7 @@
 #include <assert.h>
 
 // Include the Weld API.
-#include "../../../../c/weld.h"
+#include "../../../../weld-capi/weld.h"
 
 
 template <class T>

--- a/examples/cpp/udfs/udfs.cpp
+++ b/examples/cpp/udfs/udfs.cpp
@@ -5,7 +5,7 @@
 #include <string.h>
 
 // Include the Weld API.
-#include "../../../c/weld.h"
+#include "../../../weld-capi/weld.h"
 
 extern "C" void add_five(int64_t *x, int64_t *result) {
     *result = *x + 5;

--- a/examples/cpp/udfs_from_library/udfs.cpp
+++ b/examples/cpp/udfs_from_library/udfs.cpp
@@ -7,7 +7,7 @@
 #include <string.h>
 
 // Include the Weld API.
-#include "../../../c/weld.h"
+#include "../../../weld-capi/weld.h"
 
 int main() {
     // Load our shared library; its name will be passed by make as the macro UDFLIB

--- a/examples/cpp/vector_benchmark/vector_benchmark.cpp
+++ b/examples/cpp/vector_benchmark/vector_benchmark.cpp
@@ -6,7 +6,7 @@
 #include <string.h>
 
 // Include the Weld API.
-#include "../../../c/weld.h"
+#include "../../../weld-capi/weld.h"
 
 struct weld_vector {
     int32_t *data;

--- a/weld-capi/build.rs
+++ b/weld-capi/build.rs
@@ -3,10 +3,22 @@ use std::env;
 
 fn main() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    let header = r##"
+#ifdef __cplusplus
+extern "C" {
+#endif
+"##
+    .trim();
+
+    let trailer = "}";
+
     cbindgen::Builder::new()
         .with_crate(crate_dir)
         .with_language(cbindgen::Language::C)
         .with_include_guard("_WELD_H_")
+        .with_header(header)
+        .with_trailer(trailer)
         .generate()
         .expect("Unable to generate bindings")
         .write_to_file("weld.h");

--- a/weld-capi/src/lib.rs
+++ b/weld-capi/src/lib.rs
@@ -15,11 +15,28 @@ use std::ptr;
 // Re-export the FFI for the runtime.
 pub use weld::runtime::ffi::*;
 
-pub enum WeldConf {}
-pub enum WeldContext {}
-pub enum WeldError {}
-pub enum WeldModule {}
-pub enum WeldValue {}
+// These variants should never be constructed: they aren't 0-variant structs to enforce their
+// pointer alignment.
+#[repr(u64)]
+pub enum WeldConf {
+    _A,
+}
+#[repr(u64)]
+pub enum WeldContext {
+    _A,
+}
+#[repr(u64)]
+pub enum WeldError {
+    _A,
+}
+#[repr(u64)]
+pub enum WeldModule {
+    _A,
+}
+#[repr(u64)]
+pub enum WeldValue {
+    _A,
+}
 
 /// An opaque handle to a Weld configuration.
 #[allow(non_camel_case_types)]

--- a/weld-capi/src/lib.rs
+++ b/weld-capi/src/lib.rs
@@ -5,29 +5,45 @@
 //!
 //! See the docs for the main Weld crate for more details on these functions.
 
-use weld::*;
+use weld;
 
-use libc::{c_char, c_void, int64_t};
+use libc::{c_char, c_void, int64_t, uint64_t};
 
 use std::ffi::CStr;
 use std::ptr;
 
 // Re-export the FFI for the runtime.
-pub use crate::runtime::ffi::*;
+pub use weld::runtime::ffi::*;
 
-/// An opauqe handle to a Weld configuration.
-pub type WeldConfRef = *mut WeldConf;
-/// An opauqe handle to a Weld error.
-pub type WeldErrorRef = *mut WeldError;
-/// An opauqe handle to a Weld module.
-pub type WeldModuleRef = *mut WeldModule;
-/// An opauqe handle to a Weld data value.
-pub type WeldValueRef = *mut WeldValue;
-/// An opauqe handle to a Weld context.
-pub type WeldContextRef = *mut WeldContext;
+pub enum WeldConf {}
+pub enum WeldContext {}
+pub enum WeldError {}
+pub enum WeldModule {}
+pub enum WeldValue {}
+
+/// An opaque handle to a Weld configuration.
+#[allow(non_camel_case_types)]
+pub type weld_conf_t = *mut WeldConf;
+/// An opaque handle to a Weld context.
+#[allow(non_camel_case_types)]
+pub type weld_context_t = *mut WeldContext;
+/// An opaque handle to a Weld error.
+#[allow(non_camel_case_types)]
+pub type weld_error_t = *mut WeldError;
+/// An opaque handle to a Weld module.
+#[allow(non_camel_case_types)]
+pub type weld_module_t = *mut WeldModule;
+/// An opaque handle to a Weld data value.
+#[allow(non_camel_case_types)]
+pub type weld_value_t = *mut WeldValue;
 
 pub use weld::WeldLogLevel;
 pub use weld::WeldRuntimeErrno;
+
+#[allow(non_camel_case_types)]
+pub type weld_log_level_t = WeldLogLevel;
+#[allow(non_camel_case_types)]
+pub type weld_errno_t = WeldRuntimeErrno;
 
 trait ToRustStr {
     fn to_str(&self) -> &str;
@@ -48,10 +64,11 @@ impl ToRustStr for *const c_char {
 /// Creates a new context.
 ///
 /// This function is a wrapper for `WeldContext::new`.
-pub unsafe extern "C" fn weld_context_new(conf: WeldConfRef) -> WeldContextRef {
+pub unsafe extern "C" fn weld_context_new(conf: weld_conf_t) -> weld_context_t {
+    let conf = conf as *mut weld::WeldConf;
     let conf = &*conf;
-    if let Ok(context) = WeldContext::new(conf) {
-        Box::into_raw(Box::new(context))
+    if let Ok(context) = weld::WeldContext::new(conf) {
+        Box::into_raw(Box::new(context)) as _
     } else {
         // XXX Should this take an error too?
         ptr::null_mut()
@@ -62,7 +79,8 @@ pub unsafe extern "C" fn weld_context_new(conf: WeldConfRef) -> WeldContextRef {
 /// Gets the memory allocated by a Weld context.
 ///
 /// This includes all live memory allocated in the given context.
-pub unsafe extern "C" fn weld_context_memory_usage(context: WeldContextRef) -> int64_t {
+pub unsafe extern "C" fn weld_context_memory_usage(context: weld_context_t) -> int64_t {
+    let context = context as *mut weld::WeldContext;
     let context = &*context;
     context.memory_usage() as int64_t
 }
@@ -72,9 +90,10 @@ pub unsafe extern "C" fn weld_context_memory_usage(context: WeldContextRef) -> i
 ///
 /// All contexts created by the FFI should be freed. This includes contexts obtained from
 /// `weld_context_new` and `weld_value_context`.
-pub unsafe extern "C" fn weld_context_free(ptr: WeldContextRef) {
-    if !ptr.is_null() {
-        Box::from_raw(ptr);
+pub unsafe extern "C" fn weld_context_free(context: weld_context_t) {
+    let context = context as *mut weld::WeldContext;
+    if !context.is_null() {
+        Box::from_raw(context);
     }
 }
 
@@ -82,17 +101,18 @@ pub unsafe extern "C" fn weld_context_free(ptr: WeldContextRef) {
 /// Creates a new configuration.
 ///
 /// This function is a wrapper for `WeldConf::new`.
-pub extern "C" fn weld_conf_new() -> WeldConfRef {
-    Box::into_raw(Box::new(WeldConf::new()))
+pub extern "C" fn weld_conf_new() -> weld_conf_t {
+    Box::into_raw(Box::new(weld::WeldConf::new())) as _
 }
 
 #[no_mangle]
 /// Free a configuration.
 ///
 /// The passsed configuration should have been allocated using `weld_conf_new`.
-pub unsafe extern "C" fn weld_conf_free(ptr: WeldConfRef) {
-    if !ptr.is_null() {
-        Box::from_raw(ptr);
+pub unsafe extern "C" fn weld_conf_free(conf: weld_conf_t) {
+    let conf = conf as *mut weld::WeldConf;
+    if !conf.is_null() {
+        Box::from_raw(conf);
     }
 }
 
@@ -100,8 +120,9 @@ pub unsafe extern "C" fn weld_conf_free(ptr: WeldConfRef) {
 /// Get a value associated with a key for a configuration.
 ///
 /// This function is a wrapper for `WeldConf::get`.
-pub unsafe extern "C" fn weld_conf_get(ptr: WeldConfRef, key: *const c_char) -> *const c_char {
-    let conf = &*ptr;
+pub unsafe extern "C" fn weld_conf_get(conf: weld_conf_t, key: *const c_char) -> *const c_char {
+    let conf = conf as *mut weld::WeldConf;
+    let conf = &*conf;
     match conf.get(key.to_str()) {
         Some(k) => k.as_ptr(),
         None => ptr::null_mut(),
@@ -112,8 +133,13 @@ pub unsafe extern "C" fn weld_conf_get(ptr: WeldConfRef, key: *const c_char) -> 
 /// Set the value of `key` to `value`.
 ///
 /// This function is a wrapper for `WeldConf::set`.
-pub unsafe extern "C" fn weld_conf_set(ptr: WeldConfRef, key: *const c_char, value: *const c_char) {
-    let conf = &mut *ptr;
+pub unsafe extern "C" fn weld_conf_set(
+    conf: weld_conf_t,
+    key: *const c_char,
+    value: *const c_char,
+) {
+    let conf = conf as *mut weld::WeldConf;
+    let conf = &mut *conf;
     let key = key.to_string();
     let val = CStr::from_ptr(value).to_owned();
     conf.set(key, val);
@@ -126,15 +152,16 @@ pub unsafe extern "C" fn weld_conf_set(ptr: WeldConfRef, key: *const c_char, val
 /// to must be managed by the caller. The created value will always have a NULL context.
 ///
 /// This function is a wrapper for `WeldValue::new_from_data`.
-pub extern "C" fn weld_value_new(data: *const c_void) -> WeldValueRef {
-    Box::into_raw(Box::new(WeldValue::new_from_data(data)))
+pub extern "C" fn weld_value_new(data: *const c_void) -> weld_value_t {
+    Box::into_raw(Box::new(weld::WeldValue::new_from_data(data))) as _
 }
 
 #[no_mangle]
 /// Returns the Run ID of the value.
 ///
 /// If this value was not returned by a Weld program, this function returns `-1`.
-pub unsafe extern "C" fn weld_value_run(value: WeldValueRef) -> int64_t {
+pub unsafe extern "C" fn weld_value_run(value: weld_value_t) -> int64_t {
+    let value = value as *mut weld::WeldValue;
     let value = &*value;
     value.run_id().unwrap_or(-1) as int64_t
 }
@@ -146,12 +173,13 @@ pub unsafe extern "C" fn weld_value_run(value: WeldValueRef) -> int64_t {
 /// the context. The context must be freed with `weld_context_free` to decrement the internal
 /// reference count. Since Weld values owned by a context internally hold a reference to the
 /// context, the value is guaranteed to be live until `weld_value_free` is called.
-pub unsafe extern "C" fn weld_value_context(value: WeldValueRef) -> WeldContextRef {
+pub unsafe extern "C" fn weld_value_context(value: weld_value_t) -> weld_context_t {
+    let value = value as *mut weld::WeldValue;
     let value = &*value;
     if let Some(context) = value.context() {
-        Box::into_raw(Box::new(context))
+        Box::into_raw(Box::new(context)) as _
     } else {
-        ptr::null_mut()
+        ptr::null_mut() as _
     }
 }
 
@@ -160,9 +188,10 @@ pub unsafe extern "C" fn weld_value_context(value: WeldValueRef) -> WeldContextR
 ///
 /// This function is a wrapper for `WeldValue::data`. If this value is owned by the runtime, the
 /// returned pointer should never be freed -- instead, use `weld_value_free` to free the data.
-pub unsafe extern "C" fn weld_value_data(value: WeldValueRef) -> *const c_void {
+pub unsafe extern "C" fn weld_value_data(value: weld_value_t) -> *mut c_void {
+    let value = value as *mut weld::WeldValue;
     let value = &*value;
-    value.data()
+    value.data() as _
 }
 
 #[no_mangle]
@@ -171,7 +200,8 @@ pub unsafe extern "C" fn weld_value_data(value: WeldValueRef) -> *const c_void {
 /// All Weld values must be freed using this call. Weld values which are owned by the runtime also
 /// free the data they contain.  Weld values which are not owned by the runtime only free the
 /// structure used to wrap the data; the actual data itself is owned by the caller.
-pub unsafe extern "C" fn weld_value_free(value: WeldValueRef) {
+pub unsafe extern "C" fn weld_value_free(value: weld_value_t) {
+    let value = value as *mut weld::WeldValue;
     if !value.is_null() {
         Box::from_raw(value);
     }
@@ -186,20 +216,22 @@ pub unsafe extern "C" fn weld_value_free(value: WeldValueRef) {
 /// This function is a wrapper for `WeldModule::compile`.
 pub unsafe extern "C" fn weld_module_compile(
     code: *const c_char,
-    conf: WeldConfRef,
-    err: WeldErrorRef,
-) -> WeldModuleRef {
+    conf: weld_conf_t,
+    err: weld_error_t,
+) -> weld_module_t {
     let code = code.to_str();
+    let conf = conf as *mut weld::WeldConf;
     let conf = &*conf;
+    let err = err as *mut weld::WeldError;
     let err = &mut *err;
-    match WeldModule::compile(code, conf) {
+    match weld::WeldModule::compile(code, conf) {
         Ok(module) => {
-            *err = WeldError::new_success();
-            Box::into_raw(Box::new(module))
+            *err = weld::WeldError::new_success();
+            Box::into_raw(Box::new(module)) as _
         }
         Err(compile_err) => {
             *err = compile_err;
-            ptr::null_mut()
+            ptr::null_mut() as _
         }
     }
 }
@@ -213,25 +245,29 @@ pub unsafe extern "C" fn weld_module_compile(
 ///
 /// This function is a wrapper for `WeldModule::run`.
 pub unsafe extern "C" fn weld_module_run(
-    module: WeldModuleRef,
-    context: WeldContextRef,
-    arg: WeldValueRef,
-    err: WeldErrorRef,
-) -> WeldValueRef {
+    module: weld_module_t,
+    context: weld_context_t,
+    arg: weld_value_t,
+    err: weld_error_t,
+) -> weld_value_t {
+    let module = module as *mut weld::WeldModule;
     let module = &mut *module;
+    let context = context as *mut weld::WeldContext;
     let context = &mut *context;
+    let arg = arg as *mut weld::WeldValue;
     let arg = &*arg;
+    let err = err as *mut weld::WeldError;
     let err = &mut *err;
 
     match module.run(context, arg) {
         Ok(result) => {
-            *err = WeldError::new_success();
-            Box::into_raw(Box::new(result))
+            *err = weld::WeldError::new_success();
+            Box::into_raw(Box::new(result)) as _
         }
         Err(runtime_err) => {
             eprintln!("{:?}", runtime_err);
             *err = runtime_err;
-            ptr::null_mut()
+            ptr::null_mut() as _
         }
     }
 }
@@ -241,39 +277,43 @@ pub unsafe extern "C" fn weld_module_run(
 ///
 /// Freeing a module does not free the memory it may have allocated. Values returned by the module
 /// must be freed explicitly using `weld_value_free`.
-pub unsafe extern "C" fn weld_module_free(ptr: WeldModuleRef) {
-    if !ptr.is_null() {
-        Box::from_raw(ptr);
+pub unsafe extern "C" fn weld_module_free(module: weld_module_t) {
+    let module = module as *mut weld::WeldModule;
+    if !module.is_null() {
+        Box::from_raw(module);
     }
 }
 
 #[no_mangle]
 /// Creates a new Weld error object.
-pub extern "C" fn weld_error_new() -> WeldErrorRef {
-    Box::into_raw(Box::new(WeldError::default()))
+pub extern "C" fn weld_error_new() -> weld_error_t {
+    Box::into_raw(Box::new(weld::WeldError::default())) as _
 }
 
 #[no_mangle]
 /// Returns the error code for a Weld error.
 ///
 /// This function is a wrapper for `WeldError::code`.
-pub unsafe extern "C" fn weld_error_code(err: WeldErrorRef) -> WeldRuntimeErrno {
+pub unsafe extern "C" fn weld_error_code(err: weld_error_t) -> uint64_t {
+    let err = err as *mut weld::WeldError;
     let err = &*err;
-    err.code()
+    err.code() as _
 }
 
 #[no_mangle]
 /// Returns a Weld error message.
 ///
 /// This function is a wrapper for `WeldError::message`.
-pub unsafe extern "C" fn weld_error_message(err: WeldErrorRef) -> *const c_char {
+pub unsafe extern "C" fn weld_error_message(err: weld_error_t) -> *const c_char {
+    let err = err as *mut weld::WeldError;
     let err = &*err;
     err.message().as_ptr()
 }
 
 #[no_mangle]
 /// Frees a Weld error object.
-pub unsafe extern "C" fn weld_error_free(err: WeldErrorRef) {
+pub unsafe extern "C" fn weld_error_free(err: weld_error_t) {
+    let err = err as *mut weld::WeldError;
     if !err.is_null() {
         Box::from_raw(err);
     }
@@ -284,13 +324,14 @@ pub unsafe extern "C" fn weld_error_free(err: WeldErrorRef) {
 ///
 /// The dynamic library is a C dynamic library identified by its filename.
 /// This function is a wrapper for `load_linked_library`.
-pub unsafe extern "C" fn weld_load_library(filename: *const c_char, err: WeldErrorRef) {
+pub unsafe extern "C" fn weld_load_library(filename: *const c_char, err: weld_error_t) {
+    let err = err as *mut weld::WeldError;
     let err = &mut *err;
     let filename = filename.to_str();
-    if let Err(e) = load_linked_library(filename) {
+    if let Err(e) = weld::load_linked_library(filename) {
         *err = e;
     } else {
-        *err = WeldError::new_success();
+        *err = weld::WeldError::new_success();
     }
 }
 
@@ -299,6 +340,6 @@ pub unsafe extern "C" fn weld_load_library(filename: *const c_char, err: WeldErr
 ///
 /// This function is ignored if it has already been called once, or if some other code in the
 /// process has initialized logging using Rust's `log` crate.
-pub extern "C" fn weld_set_log_level(level: WeldLogLevel) {
-    set_log_level(level)
+pub extern "C" fn weld_set_log_level(level: uint64_t) {
+    weld::set_log_level(level.into())
 }

--- a/weld/build.rs
+++ b/weld/build.rs
@@ -39,8 +39,9 @@ fn build_llvmext(project_dir: &str) {
         .unwrap();
     assert!(status.success());
 
+    let ref out_dir = env::var("OUT_DIR").unwrap();
     println!("cargo:rustc-link-lib=static=llvmext");
-    println!("cargo:rustc-link-search=native={}/llvmext", project_dir);
+    println!("cargo:rustc-link-search=native={}", out_dir);
 }
 
 fn main() {

--- a/weld/llvmext/Makefile
+++ b/weld/llvmext/Makefile
@@ -20,13 +20,13 @@ endif
 all: $(LIB)
 
 test: $(LIB) test.cpp
-	$(CLANG) $(CFLAGS) -L$(LIBDIR) $(LLVMLIBS) $(LIB) test.cpp -o test
+	$(CLANG) $(CFLAGS) -L$(LIBDIR) $(LLVMLIBS) $(LIB) test.cpp -o $(OUT_DIR)/test
 
 llvmext.o: llvmext.cpp
-	$(CLANG) $(CFLAGS) -c $< -o $@
+	$(CLANG) $(CFLAGS) -c $< -o $(OUT_DIR)/$@
 
 $(LIB): llvmext.o
-	ar rcs $@ $^
+	ar rcs $(OUT_DIR)/$@ $(OUT_DIR)/$^
 
 clean:
-	rm -f *.o $(LIB)
+	rm -f $(OUT_DIR)/*.o $(OUT_DIR)/$(LIB)

--- a/weld/src/lib.rs
+++ b/weld/src/lib.rs
@@ -912,6 +912,20 @@ pub enum WeldLogLevel {
     Trace,
 }
 
+impl From<u64> for WeldLogLevel {
+    fn from(value: u64) -> WeldLogLevel {
+        use WeldLogLevel::*;
+        match value {
+            0 => Off,
+            1 => Error,
+            2 => Warn,
+            3 => Info,
+            4 => Debug,
+            _ => Trace,
+        }
+    }
+}
+
 impl fmt::Display for WeldLogLevel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)

--- a/weld/src/syntax/parser.rs
+++ b/weld/src/syntax/parser.rs
@@ -518,7 +518,10 @@ impl<'t> Parser<'t> {
                                     expr = expr_box(GetField { expr, index }, Annotations::new())
                                 }
                                 _ => {
-                                    return compile_err!("Expected field index but got '{}'", value);
+                                    return compile_err!(
+                                        "Expected field index but got '{}'",
+                                        value
+                                    );
                                 }
                             }
                         }


### PR DESCRIPTION
Fixes a number of issues with the recent 0.3.0 release:

* FFI bugs that prevented existing code from building due to incorrect `weld.h` generation
* Cleaner build that allows for `cargo publish` to work
* Fix pointer alignment for FFI.
* Update broken C examples