### PR TITLE
Addresses issue with incorrect min/max initialization in codegen

### DIFF
--- a/weld/src/codegen/llvm2/mod.rs
+++ b/weld/src/codegen/llvm2/mod.rs
@@ -477,7 +477,9 @@ pub trait CodeGenExt {
                 match op {
                     Add => Ok(LLVMConstInt(ty, 0, signed)),
                     Multiply => Ok(LLVMConstInt(ty, 1, signed)),
+                    Max if kind.is_signed() => Ok(LLVMConstInt(ty, ::std::i64::MIN as u64, signed)),
                     Max => Ok(LLVMConstInt(ty, ::std::u64::MIN, signed)),
+                    Min if kind.is_signed() => Ok(LLVMConstInt(ty, ::std::i64::MAX as u64, signed)),
                     Min => Ok(LLVMConstInt(ty, ::std::u64::MAX, signed)),
                     _ => unreachable!(),
                 }


### PR DESCRIPTION
Previously, the `binop_identity` function in code generation initialized both signed and unsigned integers were initialized with `::std::u32/64::MIN/MAX` for `max` and `min` respectively; however, this is an incorrect initialization value for signed (e.g., `i64`) values.

For example, finding the min of `[1, 2, 3, 4, 5]` with an initial builder value of `::std::u64::MAX` would cause the value in the builder to be `-1`, resulting an an incorrect result. This patch fixes this issue.