### PR TITLE
Fix for applying let inliner to Apply

### DIFF
--- a/weld/src/conf/constants.rs
+++ b/weld/src/conf/constants.rs
@@ -170,8 +170,8 @@ pub const CONF_DUMP_CODE_DIR_DEFAULT: &str = ".";
 /// Default set of optimization passes.
 pub const CONF_OPTIMIZATION_PASSES_DEFAULT: &[&str] = &[
     "inline-zip",
-    "inline-let",
     "inline-apply",
+    "inline-let",
     "loop-fusion",
     "unroll-static-loop",
     "infer-size",

--- a/weld/src/optimizer/transforms/inliner.rs
+++ b/weld/src/optimizer/transforms/inliner.rs
@@ -139,6 +139,9 @@ fn count_symbols(expr: &Expr, usage: &mut FnvHashMap<Symbol, SymbolTracker>) {
         }
         | Sort {
             cmpfunc: ref func, ..
+        }
+        | Apply {
+            ref func, ..
         } => {
             // Mark all symbols seen so far as "in a loop"
             for value in usage.values_mut() {

--- a/weld/src/optimizer/transforms/inliner.rs
+++ b/weld/src/optimizer/transforms/inliner.rs
@@ -140,9 +140,7 @@ fn count_symbols(expr: &Expr, usage: &mut FnvHashMap<Symbol, SymbolTracker>) {
         | Sort {
             cmpfunc: ref func, ..
         }
-        | Apply {
-            ref func, ..
-        } => {
+        | Apply { ref func, .. } => {
             // Mark all symbols seen so far as "in a loop"
             for value in usage.values_mut() {
                 value.loop_nest += 1;


### PR DESCRIPTION
Fixes a bug where variables declared outside an Apply expression could be eliminated because the inliner didn't count their usage properly.