### PR TITLE
add namespace std for sort function in llvmext.cpp

### DIFF
--- a/weld/llvmext/llvmext.cpp
+++ b/weld/llvmext/llvmext.cpp
@@ -71,8 +71,8 @@ extern "C" const char *LLVMExtGetHostCPUFeatures() {
     }
   }
 
-  sort(features_present.begin(), features_present.end());
-  sort(features_missing.begin(), features_missing.end());
+  std::sort(features_present.begin(), features_present.end());
+  std::sort(features_missing.begin(), features_missing.end());
 
   string result;
   for (auto it = features_present.begin(); it != features_present.end(); it++) {


### PR DESCRIPTION
because compiling in some environment is failed due to name ambiguous error.