### PR TITLE
Use typed null pointers instead of i64 0-values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: rust
 sudo: required
 dist: trusty
-cache: cargo
 addons:
   artifacts:
     paths: results

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can join the discussion on Weld on our [Google Group](https://groups.google.
 
 ## Building
 
-To build Weld, you need [the latest stable version of Rust](http://rust-lang.org) and [LLVM](http://llvm.org) 6.0 or newer.
+To build Weld, you need [the latest stable version of Rust](http://rust-lang.org) and [LLVM/Clang++](http://llvm.org) 6.0.
 
 To install Rust, follow the steps [here](https://rustup.rs). You can verify that Rust was installed correctly on your system by typing `rustc` into your shell. If you already have Rust and  `rustup` installed, you can upgrade to the latest stable version with:
 

--- a/weld/src/codegen/llvm2/dict.rs
+++ b/weld/src/codegen/llvm2/dict.rs
@@ -1248,7 +1248,7 @@ impl Dict {
             let mut zero_vector = LLVMGetUndef(kv_vector.vector_ty);
             zero_vector = LLVMConstInsertValue(
                 zero_vector,
-                self.i64(0),
+                self.null_ptr(kv_vector.elem_ty),
                 [vector::POINTER_INDEX].as_mut_ptr(),
                 1,
             );

--- a/weld/src/codegen/llvm2/dict.rs
+++ b/weld/src/codegen/llvm2/dict.rs
@@ -1656,7 +1656,7 @@ impl GroupingDict for Dict {
             let mut zero_vector = LLVMGetUndef(group_vector.vector_ty);
             zero_vector = LLVMConstInsertValue(
                 zero_vector,
-                self.i64(0),
+                self.null_ptr(group_vector.elem_ty),
                 [vector::POINTER_INDEX].as_mut_ptr(),
                 1,
             );

--- a/weld/src/codegen/llvm2/mod.rs
+++ b/weld/src/codegen/llvm2/mod.rs
@@ -359,34 +359,7 @@ pub trait CodeGenExt {
 
     /// Get a constant zero-value of the given type.
     unsafe fn zero(&self, ty: LLVMTypeRef) -> LLVMValueRef {
-        use self::llvm_sys::LLVMTypeKind::*;
-        use std::ptr;
-        match LLVMGetTypeKind(ty) {
-            LLVMFloatTypeKind => self.f32(0.0),
-            LLVMDoubleTypeKind => self.f64(0.0),
-            LLVMIntegerTypeKind => LLVMConstInt(ty, 0, 0),
-            LLVMStructTypeKind => {
-                let num_fields = LLVMCountStructElementTypes(ty) as usize;
-                let mut fields = vec![ptr::null_mut(); num_fields];
-                LLVMGetStructElementTypes(ty, fields.as_mut_ptr());
-
-                let mut value = LLVMGetUndef(ty);
-                for (i, field) in fields.into_iter().enumerate() {
-                    value =
-                        LLVMConstInsertValue(value, self.zero(field), [i as u32].as_mut_ptr(), 1);
-                }
-                value
-            }
-            LLVMPointerTypeKind => self.null_ptr(ty),
-            LLVMVectorTypeKind => {
-                let size = LLVMGetVectorSize(ty);
-                let zero = self.zero(LLVMGetElementType(ty));
-                let mut constants = vec![zero; size as usize];
-                LLVMConstVector(constants.as_mut_ptr(), size)
-            }
-            // Other types are not used in the backend.
-            other => panic!("Unsupported type kind {:?} in CodeGenExt::zero()", other),
-        }
+        LLVMConstNull(ty)
     }
 
     /// Returns the type of a hash code.


### PR DESCRIPTION
Fixes #473 when using Weld with an LLVM 6.0 distribution that has `LLVM_ENABLE_ASSERTIONS` enabled.

Also fixes some README issues.

The issue was that some places in the code generation used an `i64` 0 literal as a substitute for `null`, which was okay with LLVM's module verifier but caused certain debug assertions to complain.