### PR TITLE
Use ::libc::c_char as the character type

### DIFF
--- a/weld/src/codegen/llvm2/mod.rs
+++ b/weld/src/codegen/llvm2/mod.rs
@@ -86,7 +86,7 @@ pub const SIR_FUNC_CALL_CONV: u32 = llvm_sys::LLVMCallConv::LLVMFastCallConv as 
 /// Convert a string literal into a C string.
 macro_rules! c_str {
     ($s:expr) => {
-        concat!($s, "\0").as_ptr() as *const i8
+        concat!($s, "\0").as_ptr() as *const ::libc::c_char
     };
 }
 


### PR DESCRIPTION
On AArch64 the C char type is u8 not i8, resulting in compilation errors
such as:

error[E0308]: mismatched types
   --> weld/src/codegen/llvm2/mod.rs:89:9
    |
89  |         concat!($s, "\0").as_ptr() as *const i8
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected u8, found
i8
...
930 |             c_str!(""),
    |             ---------- in this macro invocation
    |
    = note: expected type `*const u8`
               found type `*const i8`