### PR TITLE
Add element access and masking support to Series

### DIFF
--- a/weld-python/tests/grizzly/test_series.py
+++ b/weld-python/tests/grizzly/test_series.py
@@ -32,22 +32,13 @@ def _test_binop(grizzly_op, pandas_op, name):
             assert result.equals(expect), "{}, {} (op={})".format(left, right, name)
 
 def test_add():
+    # Exhaustive type-to-type test.
     _test_binop(gr.GrizzlySeries.add, pd.Series.add, "add")
-    _test_binop(gr.GrizzlySeries.__add__, pd.Series.__add__, "__add__")
 
-def test_sub():
-    _test_binop(gr.GrizzlySeries.sub, pd.Series.sub, "sub")
-    _test_binop(gr.GrizzlySeries.__sub__, pd.Series.__sub__, "__sub__")
-
-def test_mul():
-    _test_binop(gr.GrizzlySeries.mul, pd.Series.mul, "mul")
-    _test_binop(gr.GrizzlySeries.__mul__, pd.Series.__mul__, "__mul__")
-
-def test_truediv():
+def test_div():
+    # Exhaustive type-to-type test.
     _test_binop(gr.GrizzlySeries.truediv, pd.Series.truediv, "truediv")
     _test_binop(gr.GrizzlySeries.div, pd.Series.div, "div")
-    _test_binop(gr.GrizzlySeries.divide, pd.Series.divide, "divide")
-    _test_binop(gr.GrizzlySeries.__truediv__, pd.Series.__truediv__, "__truediv__")
 
 def _compare_vs_pandas(func):
     """
@@ -128,6 +119,18 @@ def test_scalar():
             a = pd.Series([1, 2, 3], dtype=left)
             expect = a + b
             assert result.equals(expect), "{}, {} (op={})".format(left, right, "scalar")
+
+def test_indexing():
+    # We don't compare with Pandas in these tests because the output
+    # doesn't always match (this is because we don't currently support indexes).
+    x = gr.GrizzlySeries(list(range(100)), dtype='int64')
+    assert x[0] == 0
+    assert x[50] == 50
+    assert np.array_equal(x[10:50].evaluate().values, np.arange(10, 50, dtype='int64'))
+    assert np.array_equal(x[:50].evaluate().values, np.arange(50, dtype='int64'))
+    assert np.array_equal(x[x > 50].evaluate().values, np.arange(51, 100, dtype='int64'))
+    assert np.array_equal(x[x == 2].evaluate().values, np.array([2], dtype='int64'))
+    assert np.array_equal(x[x < 0].evaluate().values, np.array([], dtype='int64'))
 
 def test_unsupported_binop_error():
     # Test unsupported

--- a/weld-python/weld/grizzly/ops.py
+++ b/weld-python/weld/grizzly/ops.py
@@ -183,3 +183,34 @@ def binary_map(op, left_type, right_type, leftval, rightval, cast_type, infix=Tr
                  leftval=leftval, rightval=rightval,
                  left_type=left_type, right_type=right_type,
                  binary_apply=binary_apply(op, "e.$0", "e.$1", cast_type, infix=infix))
+
+def lookup_expr(collection, key):
+    """
+    Lookup a value in a Weld vector. This will add a cast for the key to an `I64`.
+
+    Examples
+    --------
+    >>> lookup("v", "i64(1.0f)")
+    'lookup(v, i64(i64(1.0f)))'
+    >>> lookup("[1,2,3]", "1.0f")
+    'lookup([1,2,3], i64(1.0f))'
+    >>> lookup("[1,2,3]", 1)
+    'lookup([1,2,3], i64(1))'
+
+    """
+    return "lookup({collection}, i64({key}))".format(
+            collection=collection,
+            key=key)
+
+def slice_expr(collection, start, stop):
+    """
+    Lookup a value in a Weld vector. This will add a cast the start and stop to 'I64'.
+
+    Examples
+    --------
+    >>> slice_expr("v", 1, 2, 1)
+    'slice(v, i64(1), i64(2))'
+
+    """
+    return "slice({collection}, i64({start}), i64({stop}))".format(
+            collection=collection, start=start, stop=stop)

--- a/weld-python/weld/grizzly/ops.py
+++ b/weld-python/weld/grizzly/ops.py
@@ -1,127 +1,7 @@
 """
-Basic element-wise operations supported in Grizzly.
+Basic Weld element-wise operations supported in Grizzly.
 
 """
-
-from abc import ABC, abstractmethod
-import operator
-
-class Op(ABC):
-
-    @property
-    @abstractmethod
-    def name(self):
-        pass
-
-    def __eq__(self, other):
-        return self.name == other.name
-
-    def __hash__(self):
-        return hash(self.name)
-
-
-class UnaryOp(Op):
-
-    __slots__ = ['name', 'special', 'weld_name']
-
-    def __init__(self, name, special=None, weld_name=None):
-        if special is not None:
-            special.startswith("__") and special.endswith("__")
-        self.name = name
-        self.special = special
-        self.weld_name = weld_name
-
-class BinaryOp(Op):
-
-    __slots__ = ['name', "infix", 'special', 'weld_name']
-
-    def __init__(self, name, infix, special=None, weld_name=None):
-        """ Create a binary operator.
-
-        Names when doing Weld code generation are chosen as follows:
-
-        If infix is provided:
-            LEFT <infix> RIGHT
-        If weld_name is provided and infix is provided:
-            LEFT <infix> RIGHT
-        If weld_name is provided and infix is not provided:
-            weld_name(LEFT, RIGHT)
-        If weld_name is not provided and infix is not provided:
-            not allowed.
-
-        Parameters
-        ----------
-        name : str
-            The API name of this operator.
-        infix : str
-            The infix string of this operator, or None if one
-            does not exist.
-        special : str
-            A Python special method name if one exists for this op.
-        weld_name : str
-            The Weld operator name, if it doesn't exist.
-
-        """
-        assert infix is not None or weld_name is not None
-        if special is not None:
-            assert special.startswith("__") and special.endswith("__")
-        self.name = name
-        self.infix = infix
-        self.special = special
-        self.weld_name = weld_name
-
-class CompareOp(BinaryOp):
-    pass
-
-class OpRegistry(object):
-    """
-    A singleton for holding the supported operations.
-
-    Examples
-    --------
-    >>> OpRegistry.get('add')
-    <weld.grizzly.ops.BinaryOp object at ...>
-    >>> OpRegistry.get('lt')
-    <weld.grizzly.ops.CompareOp object at ...>
-    >>> OpRegistry.supports('add')
-    True
-    >>> OpRegistry.supports('fakeOperator')
-    False
-
-    """
-    OPS = {
-        # Binary operations
-        "add": BinaryOp("add", "+", "__add__"),
-        "sub": BinaryOp("sub", "-", "__sub__"),
-        "mul": BinaryOp("mul", "*", "__mul__"),
-        "div": BinaryOp("div", "/", "__truediv__"),
-        "truediv": BinaryOp("truediv", "/", "__truediv__"),
-        "mod": BinaryOp("mod", "%", "__mod__"),
-        "pow": BinaryOp("pow", None, weld_name="pow"),
-        "radd": BinaryOp("radd", "+", "__add__"),
-        "rsub": BinaryOp("rsub", "-", "__sub__"),
-        "and": BinaryOp("and", "&", "__and__"),
-        "or": BinaryOp("or", "|", "__or__"),
-        "xor": BinaryOp("xor", "^", "__xor__"),
-        # Unary operations
-        "sqrt": UnaryOp("sqrt", weld_name="sqrt"),
-        "exp": UnaryOp("exp", weld_name="exp"),
-        # Compare operations
-        "lt": CompareOp("lt", "<", "__lt__"),
-        "gt": CompareOp("gt", ">", "__gt__"),
-        "le": CompareOp("le", "<=", "__le__"),
-        "ge": CompareOp("ge", ">=", "__ge__"),
-        "ne": CompareOp("ne", "!=", "__ne__"),
-        "eq": CompareOp("eq", "==", "__eq__"),
-        }
-
-    @classmethod
-    def get(cls, name):
-        return OpRegistry.OPS[name]
-
-    @classmethod
-    def supports(cls, name):
-        return name in OpRegistry.OPS
 
 def unary_apply(op, value):
     """
@@ -190,11 +70,11 @@ def lookup_expr(collection, key):
 
     Examples
     --------
-    >>> lookup("v", "i64(1.0f)")
+    >>> lookup_expr("v", "i64(1.0f)")
     'lookup(v, i64(i64(1.0f)))'
-    >>> lookup("[1,2,3]", "1.0f")
+    >>> lookup_expr("[1,2,3]", "1.0f")
     'lookup([1,2,3], i64(1.0f))'
-    >>> lookup("[1,2,3]", 1)
+    >>> lookup_expr("[1,2,3]", 1)
     'lookup([1,2,3], i64(1))'
 
     """
@@ -202,15 +82,30 @@ def lookup_expr(collection, key):
             collection=collection,
             key=key)
 
-def slice_expr(collection, start, stop):
+def slice_expr(collection, start, count):
     """
     Lookup a value in a Weld vector. This will add a cast the start and stop to 'I64'.
 
     Examples
     --------
-    >>> slice_expr("v", 1, 2, 1)
+    >>> slice_expr("v", 1, 2)
     'slice(v, i64(1), i64(2))'
 
     """
-    return "slice({collection}, i64({start}), i64({stop}))".format(
-            collection=collection, start=start, stop=stop)
+    return "slice({collection}, i64({start}), i64({count}))".format(
+            collection=collection, start=start, count=count)
+
+def mask(collection, collection_ty, booleans):
+    """
+    Returns a masking operation that filters values from 'collection' using
+    the bitvector 'booleans'.
+
+    Examples
+    --------
+    >>> mask("v", "i64", "mask")
+    'map(filter(zip(v, mask), |e: {i64,bool}| e.$1), |e: {i64,bool}| e.$0)'
+
+    """
+    struct_ty = "{{{collection_ty},bool}}".format(collection_ty=collection_ty)
+    template = "map(filter(zip({collection}, {mask}), |e: {struct_ty}| e.$1), |e: {struct_ty}| e.$0)"
+    return template.format(collection=collection, mask=booleans, struct_ty=struct_ty)

--- a/weld-python/weld/grizzly/series.py
+++ b/weld-python/weld/grizzly/series.py
@@ -89,6 +89,13 @@ class GrizzlySeries(pd.Series):
         return self.weld_value_.is_identity or hasattr(self, "evaluating_")
 
     @property
+    def code(self):
+        """
+        Returns the Weld code for this computation.
+        """
+        return self.weld_value_.code
+
+    @property
     def values(self):
         """
         Returns the raw data values of this `GrizzlySeries`. If `self.is_value`
@@ -268,6 +275,14 @@ class GrizzlySeries(pd.Series):
 
     # ---------------------- Indexing ------------------------------
 
+    def __setitem__(self, key, value):
+        """
+        Point access is not allowed in Grizzly -- require conversion to
+        Pandas first.
+
+        """
+        raise GrizzlyError("Grizzly does not support point access: use 'to_pandas()' first.")
+
     def __getitem__(self, key):
         """
         Access elements in a `GrizzlySeries`.
@@ -282,6 +297,31 @@ class GrizzlySeries(pd.Series):
         Note that `__getitem__()` will call `evaluate()` when a scalar key is passed,
         but will produce a lazy value when a non-scalar key is passed (i.e., when a
         non-scalar value will be returned).
+
+        Differences from Pandas
+        -----------------------
+
+        * In Pandas, many indexing operations just modify the index on the Series. In
+        Grizzly, we instead register a lazy computation and return a new GrizzlySeries
+        that always effectively has a RangeIndex (note that Grizzly does not actually
+        support indexes at the moment). This means that some indexing information is
+        lost in Grizzly. Here is an example of where a difference arises:
+
+        >>> p1 = pd.Series([1,2,3])
+        >>> p2 = pd.Series([4,5])
+        >>> p2 + p1[1:3] # Aligns indexes
+        0    NaN
+        1    7.0
+        2    NaN
+        dtype: float64
+        >>> p1 = GrizzlySeries([1,2,3])
+        >>> p2 = GrizzlySeries([4,5])
+        >>> (p2 + p1[1:3]).evaluate() # No alignment
+        0    6
+        1    8
+        dtype: int64
+
+        Note that this behavior may change in the future when we add support for indexes.
 
         Basic Examples
         --------
@@ -306,6 +346,17 @@ class GrizzlySeries(pd.Series):
 
         Examples with Masking
         ---------------------
+        >>> x = GrizzlySeries([1,2,3,4,5])
+        >>> y = x[GrizzlySeries([True, False, False, False, False])]
+        >>> y.evaluate()
+        0    1
+        dtype: int64
+        >>> y = x[x % 2 == 0]
+        >>> y.evaluate()
+        0    2
+        1    4
+        dtype: int64
+
         """
         # If the key is a scalar
         scalar_key = GrizzlySeries._scalar_ty(key, I64())
@@ -336,13 +387,50 @@ class GrizzlySeries(pd.Series):
                 return self.values[key]
             start = normalize_slice_arg(key.start, default=0)
             stop = normalize_slice_arg(key.stop, default=None)
-            code = slice_expr(self.weld_value_.id, start, stop)
+            # Weld's slice operator takes a size instead of a stopping index.
+            code = slice_expr(self.weld_value_.id, start, stop - start)
             dependencies = [self.weld_value_]
             lazy = WeldLazy(code, dependencies, self.output_type, GrizzlySeries._decoder)
             return GrizzlySeries(lazy, dtype=self.dtype)
 
-        # TODO
-        raise GrizzlyError("Series-like key in __getitem__ must be a GrizzlySeries.")
+        if not isinstance(key, GrizzlySeries):
+            raise GrizzlyError("array-like key in __getitem__ must be a GrizzlySeries.")
+
+        if isinstance(key.output_type.elem_type, Bool):
+            return self.mask(key)
+
+    def mask(self, bool_mask, other=None):
+        """
+        Mask out values from `self` using the `GrizzlySeries` `bool_mask`.
+
+        Parameters
+        ----------
+        bool_mask : GrizzlySeries
+            A boolean GrizzlySeries used for the masking
+        other : unused
+            A value to replace values that evaluate to `False` in the mask.
+            Currently unsupported -- this method will throw an error if it is not None.
+
+        Examples
+        --------
+
+        >>> x = GrizzlySeries([1, 2, 3, 4, 5])
+        >>> x.mask(GrizzlySeries([True, False, True, False, True])).evaluate()
+        0    1
+        1    3
+        2    5
+        dtype: int64
+
+        """
+        assert other is None
+        if not isinstance(bool_mask, GrizzlySeries) or\
+                not isinstance(bool_mask.output_type.elem_type, Bool):
+                    raise GrizzlyError("bool_mask must be a GrizzlySeries with dtype=bool")
+
+        code = mask(self.weld_value_.id, self.output_type.elem_type, bool_mask.weld_value_.id)
+        dependencies = [self.weld_value_, bool_mask.weld_value_]
+        lazy = WeldLazy(code, dependencies, self.output_type, GrizzlySeries._decoder)
+        return GrizzlySeries(lazy, dtype=self.dtype)
 
     # ---------------------- Operators ------------------------------
 
@@ -384,7 +472,6 @@ class GrizzlySeries(pd.Series):
             # as dependencies.
             right_ty = scalar_ty
             rightval = str(other)
-            print(rightval)
             dependencies = [self.weld_value_]
         else:
             # Value is not a scalar -- for now, we require collection types to be
@@ -419,6 +506,9 @@ class GrizzlySeries(pd.Series):
 
     def sub(self, other):
         return self._arithmetic_binop_impl(other, '-')
+
+    def mod(self, other):
+        return self._arithmetic_binop_impl(other, '%')
 
     def mul(self, other):
         return self._arithmetic_binop_impl(other, '*')
@@ -461,6 +551,9 @@ class GrizzlySeries(pd.Series):
 
     def __divmod__(self, other):
         return self.divmod(other)
+
+    def __mod__(self, other):
+        return self.mod(other)
 
     def __eq__(self, other):
         return self.eq(other)


### PR DESCRIPTION
Adds support for masking and indexing operations on GrizzlySeries. These operations differ slightly from their Pandas counterparts in that they don't use indexes -- rather, they operate more similarly to NumPy arrays for more efficient execution, and forego alignment of indexes across the vertical axis.

This behavior may change in the future if we choose to add indexes.

## Examples

```python
        >>> x = GrizzlySeries([1,2,3])
        >>> x[1]
        2
        >>> y = x + x
        >>> y[1] # Causes evaluation
        4
        >>> y = x + x
        >>> z = y[0:2]
        >>> z.evaluate()
        0    2
        1    4
        dtype: int64
        >>> y = x + x
        >>> z = y[:2]
        >>> z.evaluate()
        0    2
        1    4
        dtype: int64
        >>> x = GrizzlySeries([1,2,3,4,5])
        >>> y = x[GrizzlySeries([True, False, False, False, False])]
        >>> y.evaluate()
        0    1
        dtype: int64
        >>> y = x[x % 2 == 0]
        >>> y.evaluate()
        0    2
        1    4
        dtype: int64
```