### PR TITLE
Corect weld-capi build.rs to support not only C++ but also C

### DIFF
--- a/weld-capi/build.rs
+++ b/weld-capi/build.rs
@@ -11,7 +11,12 @@ extern "C" {
 "##
     .trim();
 
-    let trailer = "}";
+    let trailer = r##"
+#ifdef __cplusplus
+}
+#endif
+"##
+    .trim();
 
     cbindgen::Builder::new()
         .with_crate(crate_dir)


### PR DESCRIPTION
Hi,

Thank you for distributing weld.  We've found one problem regarding to weld-capi when we tried CUDF from C.

The weld.h generated by weld-capi looks like something below.  We needed `#ifdef` and `#endif` around the last line to use this from C.

```
#ifdef __cplusplus
extern "C" {
#endif

#ifndef _WELD_H_
#define _WELD_H_
...
#endif /* _WELD_H_ */

}
```

This PR should fix above problem.

Unfortunately, weld.h is not re-generateed automatically.  In order to update weld.h, I needed following steps.

1. rm weld-capi/weld.h
2. cargo clean
3. cargo build --releasae