### PR TITLE
Aggregation functions for Grizzly Series

### DIFF
--- a/weld-python/tests/grizzly/core/test_agg.py
+++ b/weld-python/tests/grizzly/core/test_agg.py
@@ -1,0 +1,89 @@
+"""
+Tests for aggregation functions in Grizzly.
+
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+import weld.grizzly as gr
+
+def _compare_vs_pandas(aggs, data=None):
+    """
+    Compare the result of aggregations vs. Pandas.
+
+    Returns the code used to compute the result if the result
+    is a `GrizzlySeries`.
+
+    """
+    if data is None:
+        data = list(range(-10, 25))
+
+    pandas_result = pd.Series(data).agg(aggs)
+    grizzly_result = gr.GrizzlySeries(data).agg(aggs)
+
+    if isinstance(pandas_result, pd.Series):
+        assert isinstance(grizzly_result, gr.GrizzlySeries)
+        code = grizzly_result.code
+        grizzly_result = grizzly_result.to_pandas()
+        # Need to reset index since labels in Pandas becoem the aggregation name.
+        # Grizzly doesn't support indices right now.
+        assert pandas_result.reset_index(drop=True).equals(grizzly_result)
+        return code
+    else:
+        assert isinstance(pandas_result, (int, float, np.float64, np.int64))
+        assert isinstance(grizzly_result, (int, float, np.float64, np.int64))
+        assert pandas_result == grizzly_result
+        return None
+
+    return grizzly_result
+
+def test_count():
+    _compare_vs_pandas('count')
+
+def test_sum():
+    _compare_vs_pandas('sum')
+
+def test_prod():
+    _compare_vs_pandas('prod')
+
+def test_prod():
+    _compare_vs_pandas('mean')
+
+def test_min():
+    _compare_vs_pandas('min')
+
+def test_max():
+    _compare_vs_pandas('max')
+
+def test_std():
+    _compare_vs_pandas('std')
+
+def test_var():
+    _compare_vs_pandas('var')
+
+def test_recursive_dependencies():
+    code = _compare_vs_pandas(['count', 'std'])
+    # Each recursive dependency should appear exactly once.
+    assert code.count("let std_result") == 1
+    assert code.count("let var_result") == 1
+    assert code.count("let mean_result") == 1
+    assert code.count("let sum_result") == 1
+    assert code.count("let count_result") == 1
+
+def test_multiple_in_priority_order():
+    _compare_vs_pandas(['count', 'sum', 'mean'])
+
+def test_multiple_out_of_order():
+    # Mean is computed last, since it depends on count and sum. It should
+    # still appear first in the result.
+    _compare_vs_pandas(['mean', 'count', 'sum'])
+
+def test_duplicate():
+    # The mean and its dependencies should only be computed once.
+    code = _compare_vs_pandas(['mean', 'mean', 'mean', 'var'])
+    # Each agg and dependency should only appear one time.
+    assert code.count("let var_result") == 1
+    assert code.count("let mean_result") == 1
+    assert code.count("let sum_result") == 1
+    assert code.count("let count_result") == 1

--- a/weld-python/tests/grizzly/core/test_series.py
+++ b/weld-python/tests/grizzly/core/test_series.py
@@ -94,13 +94,10 @@ def test_basic_fallback():
         # Test 1: abs()
         c = a + b
         yield (c.abs() + a)
-        # Test 2: agg()
-        c = a + b
-        yield cls(c.agg(np.sum)) # wrap with cls for type checking
-        # Test 3: argmin()
+        # Test 2: argmin()
         c = a + b
         yield cls(c.argmin())
-        # Test 4: reindex()
+        # Test 3: reindex()
         c = a + b
         res = c.reindex(index=[2, 0, 1])
         # Falls back to Pandas, since we don't support indices.

--- a/weld-python/weld/compile.py
+++ b/weld-python/weld/compile.py
@@ -158,7 +158,6 @@ def compile(program, arg_types, encoders, restype, decoder, conf=None):
         raw_args_pointer = ctypes.addressof(raw_args)
         value = WeldValue(raw_args_pointer)
 
-
         if context is None:
             context = WeldContext(conf)
 

--- a/weld-python/weld/grizzly/core/series.py
+++ b/weld-python/weld/grizzly/core/series.py
@@ -312,6 +312,16 @@ class GrizzlySeries(pd.Series):
         functions are provided, this returns a `GrizzlySeries`, where the Nth
         element in the series is the result of the Nth aggregation.
 
+        Examples
+        --------
+        >>> s = GrizzlySeries([1,2,3,4])
+        >>> s.agg('sum')
+        10
+        >>> s.agg(['sum', 'mean']).evaluate()
+        0    10.0
+        1     2.5
+        dtype: float64
+
         """
         if isinstance(funcs, str):
             funcs = [funcs]
@@ -336,27 +346,107 @@ class GrizzlySeries(pd.Series):
             return result_weld_value.evaluate()[0]
 
     def count(self):
+        """
+        Computes the count.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([1,2,3,4])
+        >>> s.count()
+        4
+
+        """
         return self.agg('count')
 
     def sum(self):
+        """
+        Computes the sum.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([1,2,3,4])
+        >>> s.sum()
+        10
+
+        """
         return self.agg('sum')
 
     def prod(self):
+        """
+        Computes the product.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([1,2,3,4])
+        >>> s.prod()
+        24
+
+        """
         return self.agg('prod')
 
     def min(self):
+        """
+        Finds the min element.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([1,2,3,4])
+        >>> s.min()
+        1
+
+        """
         return self.agg('min')
 
     def max(self):
+        """
+        Returns the max element.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([1,2,3,4])
+        >>> s.max()
+        4
+
+        """
         return self.agg('max')
 
     def mean(self):
+        """
+        Computes the mean.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([1,2,3,4])
+        >>> s.mean()
+        2.5
+
+        """
         return self.agg('mean')
 
     def var(self):
+        """
+        Computes the variance.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([1,2,3,4])
+        >>> s.var()
+        1.6666666666666667
+
+        """
         return self.agg('var')
 
     def std(self):
+        """
+        Computes the standard deviation.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([1,2,3,4])
+        >>> s.std()
+        1.2909944487358056
+
+        """
         return self.agg('std')
 
     # ---------------------- Indexing ------------------------------

--- a/weld-python/weld/grizzly/core/series.py
+++ b/weld-python/weld/grizzly/core/series.py
@@ -8,7 +8,7 @@ import pandas as pd
 import warnings
 
 import weld.encoders.numpy as wenp
-import weld.grizzly.weld.str as weldstr
+import weld.grizzly.weld.agg as weldagg
 
 from weld.lazy import PhysicalValue, WeldLazy, WeldNode, identity
 from weld.grizzly.weld.ops import *
@@ -292,6 +292,21 @@ class GrizzlySeries(pd.Series):
     def str(self):
         # TODO(shoumik.palkar): Use pandas.core.accessor.CachedAccessor?
         return StringMethods(self)
+
+    # ---------------------- Aggregation ------------------------------
+
+    def agg(self, func):
+        """
+        Apply the provided aggregation functions.
+
+        If a single function is provided, this returns a scalar. If multiple
+        functions are provided, this returns a `GrizzlySeries`, where the Nth
+        element in the series is the result of the Nth aggregation.
+
+        """
+        assert isinstance(func, (str, list))
+        if isinstance(func, list):
+            assert all([weldagg.supported(agg) for agg in func])
 
     # ---------------------- Indexing ------------------------------
 

--- a/weld-python/weld/grizzly/weld/agg.py
+++ b/weld-python/weld/grizzly/weld/agg.py
@@ -24,6 +24,17 @@ def supported(name):
     """
     return name in _agg_supported
 
+def result_elem_type(input_ty, aggs):
+    """
+    Return the resulting element type of a list of aggregations.
+
+    This will either be 'I64' or 'F64'.
+    """
+    aggs.sort(key=lambda x: _agg_priorities[x])
+    for agg in aggs:
+        input_ty = _agg_output_types[agg](input_ty)
+    return input_ty
+
 @weld.lazy.weldfunc
 def agg(array, weld_elem_type, aggs):
     """
@@ -209,16 +220,6 @@ def std(array, _elem_type, deps):
     return "sqrt({var})".format(var=deps['var'])
 
 
-def result_elem_type(input_ty, aggs):
-    """
-    Return the resulting element type of a list of aggregations.
-
-    This will either be 'i64' or 'f64'.
-    """
-    aggs.sort(key=lambda x: _agg_priorities[x])
-    for agg in aggs:
-        input_ty = _agg_output_types[agg](input_ty)
-    return input_ty
 
 
 _agg_supported = {

--- a/weld-python/weld/grizzly/weld/agg.py
+++ b/weld-python/weld/grizzly/weld/agg.py
@@ -276,8 +276,8 @@ _agg_dependencies = {
     'sum': set(),
     'prod': set(),
     'mean': {'sum', 'count'},
-    'var': {'sum', 'mean'},
-    'std': {'sum', 'mean', 'var'}
+    'var': {'count', 'mean'},
+    'std': {'var'}
 }
 
 # to order the aggregations; lower means it comes first

--- a/weld-python/weld/grizzly/weld/agg.py
+++ b/weld-python/weld/grizzly/weld/agg.py
@@ -1,0 +1,290 @@
+"""
+Aggregation functions implemented in Weld.
+
+Supports co-generation of aggregation functions to enable better optimization.
+
+"""
+
+from weld.types import I64, F32, F64
+
+import weld.lazy
+
+def supported(name):
+    """
+    Returns whether codegen for this aggregation is supported.
+
+    Tests
+    -----
+
+    >>> supported('min')
+    True
+    >>> supported('humdinger')
+    False
+
+    """
+    return name in _agg_supported
+
+@weld.lazy.weldfunc
+def agg(array, weld_elem_type, aggs):
+    """
+    Compute aggregations with Weld.
+
+    Aggregation functions with Weld always return either a 'i64' or 'f64',
+    depending on the operations passed. If any operation passed requires use of
+    a 'f64', all outputs will be 'f64'.
+
+    The return type of an aggregation will be a scalar if exactly one function
+    was passed, or a vector if more than one was passed. The output element
+    type can be retrieved with 'result_elem_type()'.
+
+    """
+    # Compute aggregations in order of priorty, and remove duplicates.
+    sorted_aggs = sorted(list(set(aggs)), key=lambda x: _agg_priorities[x])
+    deps = dict()
+    # List of computations.
+    computations = []
+    previous_output_type = weld_elem_type
+
+    for agg in sorted_aggs:
+        # Use the element type produced by the aggregation.
+        # Inputs are cast to this type.
+        elem_type = _agg_output_types[agg](previous_output_type)
+        code = _agg_funcs[agg](array, str(elem_type), deps)
+        name = "{}_result".format(agg)
+        deps[agg] = name
+        computations[agg] = (name, code)
+        previous_output_type = elem_type
+
+    # Construct the final result.
+    final_code = ""
+    for (_, (name, code)) in computations.items():
+        result += "let {name} = {code};\n".format(name=name, code=code)
+
+    if len(computations) == 1:
+        # Just return the scalar if there is only one aggregation.
+        for key in computations:
+            result += computations[key][0]
+            return result
+    else:
+        # If there are multiple aggregations, construct a vector to hold them. The vector
+        # needs to be ordered in the same way that the aggregations were requested in.
+        output_type = result_elem_type(weld_elem_type, aggs)
+        ordered_results = []
+        for agg in aggs:
+            ordered_results.append("{ty}({name})".format(ty=output_type, name=computations[agg][0]))
+        result += "[" + ", ".join(ordered_results) + "]"
+        return result
+
+def agg_template(array, agg_func, elem_type):
+    """
+    Return Weld code for computing an aggregation with a merger.
+
+    """
+    return """result(for({array}, merger[{ty},{agg_func}],
+    |b, i, e|
+        merge(b, {ty}(e))
+    ))""".format(array=array,
+            agg_func=agg_func,
+            ty=elem_type)
+
+
+def count(weldarr, _elem_type, _deps):
+    """
+    Computes the count.
+
+    Tests
+    -----
+    >>> count('[1,2,3]', None, None)
+    'len([1,2,3])'
+    >>> count('weldlazy1', None, None)
+    'len(weldlazy1)'
+
+    """
+    return "len({})".format(weldarr)
+
+
+def weld_min(array, elem_type, _deps):
+    """
+    Computes the min.
+
+    Tests
+    -----
+    >>> weld_min('array', 'i64', None)
+    'result(for(array, merger[i64,min],\\n    |b, i, e|\\n        merge(b, i64(e))\\n    ))'
+
+    """
+    return agg_template(array, 'min', elem_type)
+
+
+def weld_max(array, elem_type, _deps):
+    """
+    Computes the max.
+
+    Tests
+    -----
+    >>> weld_max('array', 'i64', None)
+    'result(for(array, merger[i64,max],\\n    |b, i, e|\\n        merge(b, i64(e))\\n    ))'
+
+    """
+    return agg_template(array, 'max', elem_type)
+
+
+def weld_sum(array, elem_type, _deps):
+    """
+    Computes the max.
+
+    Tests
+    -----
+    >>> weld_sum('array', 'i64', None)
+    'result(for(array, merger[i64,+],\\n    |b, i, e|\\n        merge(b, i64(e))\\n    ))'
+
+    """
+    return agg_template(array, '+', elem_type)
+
+
+def prod(array, elem_type, _deps):
+    """
+    Computes the product.
+
+    Tests
+    -----
+    >>> prod('array', 'i64', None)
+    'result(for(array, merger[i64,*],\\n    |b, i, e|\\n        merge(b, i64(e))\\n    ))'
+
+    """
+    return agg_template(array, '*', elem_type)
+
+
+def mean(_array, elem_type, deps):
+    """
+    Computes the mean.
+
+    deps must be a dictionary with 'sum' and 'count'.
+
+    Tests
+    -----
+    >>> mean(None, 'f64', {'sum': 'weldlazy1', 'count': 'weldlazy2'})
+    'f64(weldlazy1) / f64(weldlazy2)'
+
+    """
+    return """{ty}({sum}) / {ty}({count})""".format(
+            ty=elem_type,
+            sum=deps['sum'],
+            count=deps['count'])
+
+
+def var(array, _elem_type, deps):
+    """
+    Computes the variance.
+
+    deps must be a dictionary with 'count' and 'mean'.
+
+    Tests
+    -----
+    >>> var('array', 'f64', {'count': 'weldlazy1', 'mean': 'weldlazy2'})
+    'result(for(array,\\n        merger[f64, +],\\n        |b, i, e|\\n             merge(b, pow(f64(e) - f64(weldlazy2), 2.0))\\n    )) / f64(weldlazy1 - 1L)'
+
+    """
+    return """result(for({array},
+        merger[f64, +],
+        |b, i, e|
+             merge(b, pow(f64(e) - f64({mean}), 2.0))
+    )) / f64({count} - 1L)""".format(
+            array=array,
+            count=deps['count'],
+            mean=deps['mean'])
+
+def std(array, _elem_type, deps):
+    """
+    Computes the standard deviation.
+
+    deps must be a dictionary with 'var'.
+
+    Tests
+    -----
+    >>> std('array', None, {'var': 'weldlazy1'})
+    'sqrt(weldlazy1)'
+
+    """
+    return "sqrt({var})".format(var=deps['var'])
+
+
+def result_elem_type(input_ty, aggs):
+    """
+    Return the resulting element type of a list of aggregations.
+
+    This will either be 'i64' or 'f64'.
+    """
+    aggs.sort(key=lambda x: _agg_priorities[x])
+    for agg in aggs:
+        input_ty = _agg_output_types[agg](input_ty)
+    return input_ty
+
+
+_agg_supported = {
+    'min',
+    'max',
+    'count',
+    'sum',
+    'prod',
+    'mean',
+    'var',
+    'std',
+}
+
+_agg_funcs = {
+    'min': weld_min,
+    'max': weld_max,
+    'count': count,
+    'sum': weld_sum,
+    'prod': prod,
+    'mean': mean,
+    'var': var,
+    'std': std,
+}
+
+_agg_dependencies = {
+    'min': set(),
+    'max': set(),
+    'count': set(),
+    'sum': set(),
+    'prod': set(),
+    'mean': {'sum', 'count'},
+    'var': {'sum', 'mean'},
+    'std': {'sum', 'mean', 'var'}
+}
+
+# to order the aggregations; lower means it comes first
+_agg_priorities = {
+    'min': 1,
+    'max': 1,
+    'count': 1,
+    'sum': 1,
+    'prod': 1,
+    'mean': 2,
+    'var': 3,
+    'std': 4
+}
+
+# Type specifiers
+_always_i64 = lambda _: I64()
+_i64_or_f64 = lambda x: F64() if isinstance(x, (F32, F64)) else I64()
+_always_f64 = lambda _: F64()
+
+_agg_output_types = {
+    'count': _always_i64,
+    'min': _i64_or_f64,
+    'max': _i64_or_f64,
+    'sum': _i64_or_f64,
+    'prod': _i64_or_f64,
+    'mean': _always_f64,
+    'var': _always_f64,
+    'std': _always_f64,
+}
+
+
+# Assertions to catch mistakes in supported functions.
+assert _agg_supported == set(_agg_priorities.keys())
+assert _agg_supported == set(_agg_dependencies.keys())
+assert _agg_supported == set(_agg_output_types.keys())
+assert _agg_supported == set(_agg_funcs.keys())

--- a/weld-python/weld/types.py
+++ b/weld-python/weld/types.py
@@ -71,6 +71,9 @@ def _define_primitive_type(typename, ir, ctype, classdoc=None, add_to_module=Tru
 
     template = """
 class {typename}(WeldType):
+
+    __slots__ = []
+
     def __str__(self):
         return "{ir}"
 

--- a/weld-python/weld/types.py
+++ b/weld-python/weld/types.py
@@ -133,12 +133,12 @@ class WeldVec(WeldType):
     Examples
     --------
     >>> v1 = WeldVec(I32())
-    >>> print(v1)
-    vec[i32]
+    >>> str(v1)
+    'vec[i32]'
 
     >>> v2 = WeldVec(F32())
-    >>> print(v2)
-    vec[f32]
+    >>> str(v2)
+    'vec[f32]'
 
     >>> v3 = WeldVec(I32())
     >>> assert v1.__class__ is v2.__class__
@@ -193,16 +193,16 @@ class WeldStruct(WeldType):
     Examples
     --------
     >>> v1 = WeldStruct((I32(),))
-    >>> print(v1)
-    {i32}
+    >>> str(v1)
+    '{i32}'
 
     >>> v2 = WeldStruct((WeldVec(I32()), I64()))
-    >>> print(v2)
-    {vec[i32],i64}
+    >>> str(v2)
+    '{vec[i32],i64}'
 
     >>> v3 = WeldStruct((v1, v2))
-    >>> print(v3)
-    {{i32},{vec[i32],i64}}
+    >>> str(v3)
+    '{{i32},{vec[i32],i64}}'
 
     """
     _singletons = {}

--- a/weld/src/optimizer/transforms/inliner.rs
+++ b/weld/src/optimizer/transforms/inliner.rs
@@ -446,7 +446,6 @@ fn inline_lets() {
     let mut e1 = typed_expression("let a = 1; let b = 2; let c = 3; a + b + c");
     inline_let(&mut e1);
     let e2 = typed_expression("1 + 2 + 3");
-    println!("{}, {}", e1.pretty_print(), e2.pretty_print());
     assert!(e1.compare_ignoring_symbols(&e2).unwrap());
 
     let mut e1 = typed_expression(
@@ -460,7 +459,6 @@ fn inline_lets() {
         "|input: vec[i32]|
         result(for(input, merger[i32,+], |b,i,e| merge(b, e + 1))) + 1",
     );
-    println!("{}, {}", e1.pretty_print(), e2.pretty_print());
     assert!(e1.compare_ignoring_symbols(&e2).unwrap());
 
     let mut e1 = typed_expression(
@@ -474,6 +472,5 @@ fn inline_lets() {
         "|input: vec[i32]|
         result(for(input, merger[i32,+], |b,i,e| let a = 1; merge(b, e + a + a))) + 1",
     );
-    println!("{}, {}", e1.pretty_print(), e2.pretty_print());
     assert!(e1.compare_ignoring_symbols(&e2).unwrap());
 }

--- a/weld/src/optimizer/transforms/unroller.rs
+++ b/weld/src/optimizer/transforms/unroller.rs
@@ -34,7 +34,6 @@ trait LoopSizeAnnotation {
 
 impl LoopSizeAnnotation for Expr {
     fn loopsize(&self) -> Option<u64> {
-        println!("{}", self.annotations);
         self.annotations
             .get("loopsize")
             .and_then(|value| value.parse::<u64>().ok())

--- a/weld/src/tests/mod.rs
+++ b/weld/src/tests/mod.rs
@@ -25,13 +25,6 @@ pub fn check_transform(input: &str, expect: &str, transform: fn(&mut Expr)) {
     let expect = &typed_expression(expect);
 
     transform(input);
-
-    println!(
-        "\nInput: {}\nExpect: {}",
-        input.pretty_print_config(&conf),
-        expect.pretty_print_config(&conf)
-    );
-
     assert!(input.compare_ignoring_symbols(expect).unwrap());
 }
 


### PR DESCRIPTION
This PR adds aggregation function support for Grizzly Series. The API follows that of Pandas, with the exception of the index of the returned value: Pandas assigns labels based on the aggregation function, while Grizzly (which does not support custom indexes at the moment) assigns numerical labels.

### Examples of aggregations with Grizzly

```python
>>> s = GrizzlySeries([1,2,3,4])
>>> s.agg('sum')
10
>>> s.agg(['sum', 'mean']).evaluate()
0    10.0
1     2.5
dtype: float64
```

Multiple aggregations are co-optimized to prevent redundant computation, e.g., a requesting a variance and a mean will only compute the mean once and use the result for variance computation.

Currently supports:
* count
* min
* max
* sum
* product
* mean
* variance
* standard deviation

Some of the IR code is taken from https://www.github.com/weld-project/baloo. 