### PR TITLE
DataFrame foundations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Cargo.lock
 .#*
 *~
 *.swp
+*.swo
 *.bc
 *.pyc
 *.o

--- a/weld-python/tests/grizzly/core/test_frame.py
+++ b/weld-python/tests/grizzly/core/test_frame.py
@@ -1,0 +1,100 @@
+"""
+Test basic DataFrame functionality.
+
+"""
+
+import pandas as pd
+import pytest
+import weld.grizzly as gr
+
+def get_frames(cls, strings):
+    """
+    Returns two DataFrames for testing binary operators.
+
+    The DataFrames have columns of overlapping/different names, types, etc.
+
+    """
+    df1 = pd.DataFrame({
+        'name': ['Bob', 'Sally', 'Kunal', 'Deepak', 'James', 'Pratiksha'],
+        'lastName': ['Kahn', 'Lopez', 'Smith', 'Narayanan', 'Thomas', 'Thaker'],
+        'age': [20, 30, 35, 20, 50, 35],
+        'score': [20.0, 30.0, 35.0, 50.0, 35.0, 25.0]
+        })
+    df2 = pd.DataFrame({
+        'firstName': ['Bob', 'Sally', 'Kunal', 'Deepak', 'James', 'Pratiksha'],
+        'lastName': ['Kahn', 'Lopez', 'smith', 'narayanan', 'Thomas', 'thaker'],
+        'age': [25, 30, 45, 20, 60, 35],
+        'scores': [20.0, 30.0, 35.0, 50.0, 35.0, 25.0]
+        })
+    if not strings:
+        df1 = df1.drop(['name', 'lastName'], axis=1)
+        df2 = df2.drop(['firstName', 'lastName'], axis=1)
+    return (cls(df1), cls(df2))
+
+def _test_binop(pd_op, gr_op, strings=True):
+    """
+    Test a binary operator.
+
+    Binary operators align on column name. For columns that don't exist in both
+    DataFrames, the column is filled with NaN (for non-comparison operations) and
+    or False (for comparison operations).
+
+    If the RHS is a Series, the Series should be added to all columns.
+
+    """
+    df1, df2 = get_frames(pd.DataFrame, strings)
+    gdf1, gdf2 = get_frames(gr.GrizzlyDataFrame, strings)
+
+    expect = pd_op(df1, df2)
+    result = gr_op(gdf1, gdf2).to_pandas()
+    assert expect.equals(result)
+
+def test_evaluation():
+    # Test to make sure that evaluating a DataFrame once caches the result/
+    # doesn't cause another evaluation.
+    df1 = gr.GrizzlyDataFrame({
+        'age': [20, 30, 35, 20, 50, 35],
+        'score': [20.0, 30.0, 35.0, 50.0, 35.0, 25.0]
+        })
+    df2 = gr.GrizzlyDataFrame({
+        'age': [20, 30, 35, 20, 50, 35],
+        'scores': [20.0, 30.0, 35.0, 50.0, 35.0, 25.0]
+        })
+    df3 = (df1 + df2) * df2 + df1 / df2
+    assert not df3.is_value
+    df3.evaluate()
+    assert df3.is_value
+    weld_value = df3.weld_value
+    df3.evaluate()
+    # The same weld_value should be returned.
+    assert weld_value is df3.weld_value
+
+def test_add():
+    _test_binop(pd.DataFrame.add, gr.GrizzlyDataFrame.add, strings=False)
+
+def test_sub():
+    _test_binop(pd.DataFrame.sub, gr.GrizzlyDataFrame.sub, strings=False)
+
+def test_mul():
+    _test_binop(pd.DataFrame.mul, gr.GrizzlyDataFrame.mul, strings=False)
+
+def test_div():
+    _test_binop(pd.DataFrame.div, gr.GrizzlyDataFrame.div, strings=False)
+
+def test_eq():
+    _test_binop(pd.DataFrame.eq, gr.GrizzlyDataFrame.eq, strings=True)
+
+def test_ne():
+    _test_binop(pd.DataFrame.ne, gr.GrizzlyDataFrame.ne, strings=True)
+
+def test_le():
+    _test_binop(pd.DataFrame.le, gr.GrizzlyDataFrame.le, strings=False)
+
+def test_lt():
+    _test_binop(pd.DataFrame.lt, gr.GrizzlyDataFrame.lt, strings=False)
+
+def test_ge():
+    _test_binop(pd.DataFrame.ge, gr.GrizzlyDataFrame.ge, strings=False)
+
+def test_gt():
+    _test_binop(pd.DataFrame.gt, gr.GrizzlyDataFrame.gt, strings=False)

--- a/weld-python/tests/grizzly/core/test_series.py
+++ b/weld-python/tests/grizzly/core/test_series.py
@@ -130,3 +130,8 @@ def test_unsupported_binop_error():
         a = gr.GrizzlySeries([1,2,3])
         b = pd.Series([1,2,3])
         a.add(b)
+
+    with pytest.raises(TypeError):
+        a = gr.GrizzlySeries(["hello", "world"])
+        b = gr.GrizzlySeries(["hello", "world"])
+        a.divide(b)

--- a/weld-python/tests/grizzly/core/test_series.py
+++ b/weld-python/tests/grizzly/core/test_series.py
@@ -129,6 +129,19 @@ def test_indexing():
     assert np.array_equal(x[x == 2].evaluate().values, np.array([2], dtype='int64'))
     assert np.array_equal(x[x < 0].evaluate().values, np.array([], dtype='int64'))
 
+def test_name():
+    # Test that names propagate after operations.
+    x = gr.GrizzlySeries([1,2,3], name="testname")
+    y = x + x
+    assert y.evaluate().name == "testname"
+    y = x.agg(['sum', 'count'])
+    assert y.evaluate().name == "testname"
+    y = x[:2]
+    assert y.evaluate().name == "testname"
+    y = x[x == 1]
+    assert y.evaluate().name == "testname"
+
+
 def test_unsupported_binop_error():
     # Test unsupported
     from weld.grizzly.core.error import GrizzlyError

--- a/weld-python/tests/grizzly/core/test_series.py
+++ b/weld-python/tests/grizzly/core/test_series.py
@@ -85,25 +85,6 @@ def test_float_nan():
         yield a + b + c * d - e
     _compare_vs_pandas(eval_expression)
 
-def test_basic_fallback():
-    # Tests basic unsupported functionality.
-    # NOTE: This test will need to change as more features are added...
-    def eval_expression(cls):
-        a = cls([1, 2, 3])
-        b = cls([-4, 5, -6])
-        # Test 1: abs()
-        c = a + b
-        yield (c.abs() + a)
-        # Test 2: argmin()
-        c = a + b
-        yield cls(c.argmin())
-        # Test 3: reindex()
-        c = a + b
-        res = c.reindex(index=[2, 0, 1])
-        # Falls back to Pandas, since we don't support indices.
-        assert isinstance(res, pd.Series)
-    _compare_vs_pandas(eval_expression)
-
 def test_scalar():
     types = ['int8', 'uint8', 'int16', 'uint16', 'int32',\
             'uint32', 'int64', 'uint64', 'float32', 'float64']

--- a/weld-python/tests/grizzly/core/test_strings.py
+++ b/weld-python/tests/grizzly/core/test_strings.py
@@ -64,6 +64,14 @@ def test_get():
     pandas_result = pd.Series(expect)
     assert pandas_result.equals(grizzly_result)
 
+def test_eq():
+    left = ["hello", "world", "strings", "morestrings"]
+    right = ["hel", "world", "string", "morestrings"]
+    x = gr.GrizzlySeries(left)
+    y = gr.GrizzlySeries(right)
+    assert list(x.eq(y).evaluate().values) == [False, True, False, True]
+    assert list(x.ne(y).evaluate().values) == [True, False, True, False]
+
 def test_strip():
     compare_vs_pandas('strip', ["",
     "   hi   ",

--- a/weld-python/tests/weld/core/test_lazy.py
+++ b/weld-python/tests/weld/core/test_lazy.py
@@ -2,7 +2,7 @@
 Tests for constructing and evaluating lazy operations.
 """
 
-from weld.encoders import PrimitiveWeldEncoder, PrimitiveWeldDecoder
+from weld.encoders.primitives import PrimitiveWeldEncoder, PrimitiveWeldDecoder
 from weld.types import *
 from weld.lazy import *
 

--- a/weld-python/tests/weld/encoders/test_numpy.py
+++ b/weld-python/tests/weld/encoders/test_numpy.py
@@ -99,6 +99,11 @@ def test_float32_vec():
 def test_float64_vec():
     encdec(array('float64'), WeldVec(F64()))
 
+def test_struct_of_vecs():
+    arrays = (array('float32'), array('uint16'), array('uint32'))
+    ty = WeldStruct([WeldVec(F32()), WeldVec(U16()), WeldVec(U32())])
+    encdec(arrays, ty)
+
 def test_type_conversions():
     types = ['bool', 'int8', 'uint8', 'int16', 'uint16',
             'int32', 'uint32', 'int64', 'uint64', 'float32', 'float64']

--- a/weld-python/tests/weld/encoders/test_primitives.py
+++ b/weld-python/tests/weld/encoders/test_primitives.py
@@ -5,7 +5,7 @@ Tests primitive encoders and decoders.
 import ctypes
 
 from .helpers import encdec_factory
-from weld.encoders import PrimitiveWeldEncoder, PrimitiveWeldDecoder
+from weld.encoders.primitives import PrimitiveWeldEncoder, PrimitiveWeldDecoder
 from weld.types import *
 
 encdec = encdec_factory(PrimitiveWeldEncoder, PrimitiveWeldDecoder)

--- a/weld-python/weld/compile.py
+++ b/weld-python/weld/compile.py
@@ -4,10 +4,10 @@ as Python functions.
 
 """
 
-from .core import *
-from .encoders import WeldEncoder, WeldDecoder, PrimitiveWeldEncoder,\
-        PrimitiveWeldDecoder
-from .types import WeldType
+from weld.core import *
+from weld.encoders import WeldEncoder, WeldDecoder
+from weld.encoders.primitives import PrimitiveWeldEncoder, PrimitiveWeldDecoder
+from weld.types import WeldType
 
 import ctypes
 import logging

--- a/weld-python/weld/encoders/__init__.py
+++ b/weld-python/weld/encoders/__init__.py
@@ -1,3 +1,2 @@
 
 from .encoder_base import *
-from .primitives import PrimitiveWeldEncoder, PrimitiveWeldDecoder

--- a/weld-python/weld/encoders/numpy.py
+++ b/weld-python/weld/encoders/numpy.py
@@ -118,15 +118,15 @@ def binop_output_type(left_ty, right_ty, truediv=False):
     Examples
     --------
     >>> binop_output_type(Bool(), Bool())
-    <weld.types.Bool object at ...>
+    bool
     >>> binop_output_type(I8(), U16())
-    <weld.types.I32 object at ...>
+    i32
     >>> binop_output_type(U8(), U16())
-    <weld.types.U16 object at ...>
+    u16
     >>> binop_output_type(F32(), U16())
-    <weld.types.F32 object at ...>
+    f32
     >>> binop_output_type(I8(), U64())
-    <weld.types.F64 object at ...>
+    f64
     """
     if not truediv and left_ty == right_ty:
         return left_ty
@@ -238,13 +238,13 @@ def dtype_to_weld_type(ty):
     Examples
     --------
     >>> dtype_to_weld_type('int32')
-    <weld.types.I32 object at 0x...>
+    i32
     >>> dtype_to_weld_type('float')
-    <weld.types.F64 object at 0x...>
+    f64
     >>> dtype_to_weld_type('i8')
-    <weld.types.I64 object at 0x...>
+    i64
     >>> dtype_to_weld_type(np.int16)
-    <weld.types.I16 object at 0x...>
+    i16
 
     Parameters
     ----------

--- a/weld-python/weld/encoders/numpy.py
+++ b/weld-python/weld/encoders/numpy.py
@@ -17,7 +17,7 @@ directly since they only involve a pointer copy.
 import ctypes
 import numpy as np
 
-from .encoder_base import *
+from weld.encoders.struct import StructWeldEncoder, StructWeldDecoder
 from weld.types import *
 
 # We just need this for the path.
@@ -295,7 +295,11 @@ class StringConversionFuncs(object):
         return result
 
 
-class NumPyWeldEncoder(WeldEncoder):
+class NumPyWeldEncoder(StructWeldEncoder):
+    """
+    Encodes NumPy arrays as Weld arrays.
+
+    """
 
     @staticmethod
     def _convert_1d_array(array, check_type=None):
@@ -353,7 +357,7 @@ class NumPyWeldEncoder(WeldEncoder):
             return False
         return True
 
-    def encode(self, obj, ty):
+    def encode_element(self, obj, ty):
         if NumPyWeldEncoder._is_string_array(obj):
             assert ty == WeldVec(WeldVec(I8()))
             return StringConversionFuncs.numpy_string_array_to_weld(obj)
@@ -365,9 +369,12 @@ class NumPyWeldEncoder(WeldEncoder):
         else:
             raise TypeError("Unexpected type {} in NumPy encoder".format(type(obj)))
 
-class NumPyWeldDecoder(WeldDecoder):
-    """ Decodes an encoded Weld array into a NumPy array.
+class NumPyWeldDecoder(StructWeldDecoder):
+    """
+    Decodes an encoded Weld array into a NumPy array.
 
+    Examples
+    --------
     >>> arr = np.array([1,2,3], dtype='int32')
     >>> encoded = NumPyWeldEncoder().encode(arr, WeldVec(I32()))
     >>> NumPyWeldDecoder().decode(ctypes.pointer(encoded), WeldVec(I32()))
@@ -457,7 +464,7 @@ class NumPyWeldDecoder(WeldDecoder):
                     return True
         return False
 
-    def decode(self, obj, restype, context=None):
+    def decode_element(self, obj, restype, context=None):
         # A 1D NumPy array
         obj = obj.contents
         if NumPyWeldDecoder._is_string_array(restype):

--- a/weld-python/weld/encoders/struct.py
+++ b/weld-python/weld/encoders/struct.py
@@ -1,0 +1,78 @@
+"""
+Implements an encoder mixin for tuples of values.
+
+Tuples are encoded as Weld Structs. Weld structs are decoded back into
+Python tuples. This encoder takes another encoder to encode or decode
+individual elements.
+
+"""
+
+from abc import abstractmethod
+from weld.encoders import WeldEncoder, WeldDecoder
+from weld.types import WeldStruct
+
+import ctypes
+
+class StructWeldEncoder(WeldEncoder):
+    """
+    An encoder mixin for structs, to be subclassed by another encoders.
+
+    Subclasses should encode their own types in 'encode_element()' instead
+    of 'encode()'.
+
+    """
+
+    @abstractmethod
+    def encode_element(self, obj, target_type):
+        """
+        Encodes a single non-struct element.
+
+        Subclasses' 'encode()' implementation should go here.
+
+        """
+        pass
+
+    def encode(self, obj, target_type):
+        if isinstance(target_type, WeldStruct):
+            encoder = target_type.ctype_class
+            struct = encoder()
+            for (i, (field, weld_ty)) in enumerate(zip(\
+                    obj, target_type.field_types)):
+                encoded = self.encode(field, weld_ty)
+                setattr(struct, "_" + str(i), encoded)
+            return struct
+        else:
+            return self.encode_element(obj, target_type)
+
+class StructWeldDecoder(WeldDecoder):
+    """
+    A decoder abstract class for structs.
+
+    Subclasses should encode their own types in 'decode_element()' instead
+    of 'decode()'.
+
+    """
+
+    @abstractmethod
+    def decode_element(self, obj, restype, context=None):
+        """
+        Decodes a single non-struct element.
+
+        Subclasses' 'decode()' implementation should go here.
+
+        """
+        pass
+
+    def decode(self, obj, restype, context=None):
+        if isinstance(restype, WeldStruct):
+            struct = obj.contents
+            ctype_class = restype.ctype_class
+            result = []
+            for (i, (weld_ty, (cfield, cty))) in enumerate(zip(\
+                    restype.field_types, ctype_class._fields_)):
+                ofs = getattr(ctype_class, cfield).offset
+                p = ctypes.pointer(cty.from_buffer(struct, ofs))
+                result.append(self.decode(p, weld_ty))
+            return tuple(result)
+        else:
+            return self.decode_element(obj, restype, context)

--- a/weld-python/weld/grizzly/__init__.py
+++ b/weld-python/weld/grizzly/__init__.py
@@ -1,2 +1,3 @@
 
+from weld.grizzly.core.frame import GrizzlyDataFrame
 from weld.grizzly.core.series import GrizzlySeries

--- a/weld-python/weld/grizzly/core/forwarding.py
+++ b/weld-python/weld/grizzly/core/forwarding.py
@@ -6,6 +6,7 @@ The `Forwarding` class can be used as a mixin.
 """
 
 import inspect
+import warnings
 
 class Forwarding(object):
     @classmethod

--- a/weld-python/weld/grizzly/core/forwarding.py
+++ b/weld-python/weld/grizzly/core/forwarding.py
@@ -1,0 +1,70 @@
+"""
+Implements method forwarding from one class to another.
+
+The `Forwarding` class can be used as a mixin.
+
+"""
+
+import inspect
+
+class Forwarding(object):
+    @classmethod
+    def _get_class_that_defined_method(cls, meth):
+        """
+        Returns the class that defines the requested method.
+
+        For methods that are defined outside of a particular set of
+        Grizzly-defined classes, Grizzly will first evaluate lazy results
+        before forwarding the data to the requested class.
+
+        """
+        if inspect.ismethod(meth):
+            for cls in inspect.getmro(meth.__self__.__class__):
+                if cls.__dict__.get(meth.__name__) is meth:
+                    return cls
+        if inspect.isfunction(meth):
+            return getattr(inspect.getmodule(meth),
+                           meth.__qualname__.split('.<locals>', 1)[0].rsplit('.', 1)[0])
+
+    @classmethod
+    def _requires_forwarding(cls, meth):
+        defined_in = cls._get_class_that_defined_method(meth)
+        if defined_in is not None and defined_in is not cls:
+            return True
+        else:
+            return False
+
+    @classmethod
+    def _forward(cls, to_cls):
+        from functools import wraps
+        def forward_decorator(func):
+            @wraps(func)
+            def forwarding_wrapper(self, *args, **kwargs):
+                self.evaluate()
+                result = func(self, *args, **kwargs)
+                # Unsupported functions will return Series -- try to
+                # switch back to GrizzlySeries.
+                if not isinstance(result, cls) and isinstance(result, to_cls):
+                    try_convert = cls(data=result.values, index=result.index)
+                    if not isinstance(try_convert, cls):
+                        warnings.warn("Unsupported operation '{}' produced unsupported Series: falling back to Pandas".format(
+                            func.__name__))
+                    return try_convert
+                return result
+            return forwarding_wrapper
+        return forward_decorator
+
+    @classmethod
+    def add_forwarding_methods(cls, to_cls):
+        """
+        Add forwarding methods from this class to `to_cls`.
+
+        """
+        methods = dir(cls)
+        for meth in methods:
+            if meth.startswith("_"):
+                # We only want to do this for API methods.
+                continue
+            attr = getattr(cls, meth)
+            if cls._requires_forwarding(attr):
+                setattr(cls, meth, cls._forward(to_cls)(attr))

--- a/weld-python/weld/grizzly/core/frame.py
+++ b/weld-python/weld/grizzly/core/frame.py
@@ -1,0 +1,172 @@
+"""
+A Weld wrapper for pandas.DataFrame.
+
+
+    List of things this needs to support:
+
+    1. Access to each column as a Series.
+    2. Access to each row as a vector-of-structs
+    3. Alignment of operations along columns
+
+    E.g, how do we implement element-wise ops over DataFrames?
+
+    Each DataFrame has a Weld type of Struct(Vec, Vec, ...)
+
+    Each operation will update one or more vectors.
+
+    let col1 = ...;
+    let col2 = ...;
+    ...
+    {col1, col2, ...}
+
+    Binary ops:
+    DataFrame + Series: match column name, if no name, align to first column
+        # This is different from pandas, it seems
+    DataFrame + DataFrame: match column name
+    DataFrame + scalar: apply to each value.
+
+    Name -> Slot (Name can be anything, slot is an int refering to the slot in the struct)
+
+    merge indices
+        names = Name -> (SlotLeft, SlotRight)
+        names = sortbykey(names)
+
+    for (name, i) in enumerate(names):
+        new_data[i] = Op(data[SlotLeft], data[SlotRight])
+        new_index[name] = i
+
+    ^ indexing logic is implemented in Python, processing logic is implemented
+    in Weld. Combines flexibility with speed.
+
+    What about indexing along rows? Grizzly doesn't support this. Too hard to
+    support arbitrary row indexing with good performance. Also hard to parallelize
+    things when you allow random row-based indexing (Why? Because need
+    to do a lookup to match indexes, so every operation becomes a join)
+
+    - a: Int64Index[0, 1, 2, 4], 0, 1, 2, 3
+    - b: Int64Index[0, 1, 3, 4], 0, 1, 2, 3
+    Need to do a join on these indices...
+
+    Row index alignment instead happens with explicit joins.
+    1) Convert to DataFrame with an index as a column
+    2) Apply filters to each DataFrame
+    3) Join the dataframes on the index
+    4) Perform task.
+
+"""
+
+import numpy as np
+import pandas as pd
+
+import weld.encoders.numpy as wenp
+import weld.grizzly.weld.agg as weldagg
+
+from weld.lazy import PhysicalValue, WeldLazy, WeldNode, identity
+from weld.grizzly.core.forwarding import Forwarding
+from weld.grizzly.core.generic import GrizzlyBase
+from weld.grizzly.core.indexes import ColumnIndex
+from weld.grizzly.core.series import GrizzlySeries
+from weld.types import *
+
+class GrizzlyDataFrame(Forwarding, GrizzlyBase):
+    """
+    An API-compatible DataFrame backed by Weld.
+
+    Examples
+    --------
+
+    >>> df = GrizzlyDataFrame({'name': ['mike', 'sam', 'sally'], 'age': [20, 22, 56]})
+    >>> df
+        name  age
+    0   mike   20
+    1    sam   22
+    2  sally   56
+
+    """
+
+    # Indicates that the length of a DataFrame is not known. Certain operations on DataFrames
+    # with this length are disallowed, since Grizzly (like Pandas) assumes each column in a DataFrame
+    # is of the same length.
+    UNKNOWN_LENGTH = -1
+
+    _encoder = wenp.NumPyWeldEncoder()
+    _decoder = wenp.NumPyWeldDecoder()
+
+    @property
+    def weld_value(self):
+        # TODO: Construct the Weld value. This is a 'MakeStruct' of each series in slot order.
+        pass
+
+    def is_value(self):
+        return self.pandas_df is not None or\
+                all([child.is_identity for child in self.children]) or hasattr(self, "_evaluating")
+
+    def evaluate(self):
+        pass
+
+    def to_pandas(self, copy=False):
+        pass
+
+    def __init__(self, data, columns=None, _length=UNKNOWN_LENGTH, _fastpath=False):
+        if _fastpath:
+            assert all([isinstance(d, GrizzlySeries) for d in data])
+            assert isinstance(columns, ColumnIndex)
+            self.data = data
+            self.columns = columns
+            self.length = _length
+            self.pandas_df = None
+            return
+
+        self.data = []
+        column_index = []
+        # Keep a reference to the Pandas DataFrame. This should not consume any extra memory, since GrizzlySeries
+        # just keep references ot the same values. The only exception is for string data, where a copy will be created
+        # to force use of the 'S' dtype.
+        #
+        # TODO(shoumik): Convert string data to dtype 'S' here so it doesn't get copied when wrapping the Series as
+        # GrizzlySeries.
+        self.pandas_df = pd.DataFrame(data, columns=columns)
+        self.length = len(self.pandas_df)
+        for (i, col) in enumerate(self.pandas_df):
+            grizzly_series = GrizzlySeries(self.pandas_df[col], name=self.pandas_df[col].name)
+            if not isinstance(grizzly_series, GrizzlySeries):
+                raise TypeError("Unsupported Series in DataFrame: {}".format(self.pandas_df[col]))
+            self.data.append(grizzly_series)
+            column_index.append(col)
+
+        self.columns = ColumnIndex(column_index)
+
+    def _require_known_length(self):
+        if self.length == UNKNOWN_LENGTH:
+            raise GrizzlyError("function {} disallowed on DataFrame of unknown length: try calling 'evaluate()' first".format(
+                func))
+
+    def __getitem__(self, key):
+        return self.data[self.columns[key]]
+
+    """
+    Disabling the below because we need to know the length of a Series before adding it to a DataFrame.
+    def __setitem__(self, key, value):
+        self.require_known_length(self, __setitem__)
+        if not isinstance(value, GrizzlySeries):
+            value = GrizzlySeries(value)
+            if not isinstance(value, GrizzlySeries):
+                raise TypeError("Unsupported Series in DataFrame: {}".format(value))
+
+        self.columns.append(key)
+        assert self.columns[key] == len(self.data)
+        self.data.append(value)
+    """
+
+    def __str__(self):
+        if self.pandas_df is not None:
+            return str(self.pandas_df)
+        else:
+            return None
+
+    def __repr__(self):
+        if self.pandas_df is not None:
+            return repr(self.pandas_df)
+        else:
+            return None
+

--- a/weld-python/weld/grizzly/core/frame.py
+++ b/weld-python/weld/grizzly/core/frame.py
@@ -75,7 +75,7 @@ class GrizzlyDataFrame(Forwarding, GrizzlyBase):
         >>> df = GrizzlyDataFrame({'name': ['sam', 'sally'], 'age': [25, 50]})
         >>> df.is_value
         True
-        >>> df = df.add(df)
+        >>> df = df.eq(df)
         >>> df.is_value
         False
 
@@ -248,7 +248,7 @@ class GrizzlyDataFrame(Forwarding, GrizzlyBase):
                 nans[:] = np.nan
                 new_data.append(GrizzlySeries(nans))
             else:
-                new_data.append(self.data[left_slot] + other.data[right_slot])
+                new_data.append(series_op(self.data[left_slot], other.data[right_slot]))
         return GrizzlyDataFrame(new_data,
                 columns=ColumnIndex(new_cols),
                 _length=self.length,
@@ -276,19 +276,22 @@ class GrizzlyDataFrame(Forwarding, GrizzlyBase):
         return self.truediv(other)
 
     def eq(self, other):
-        return self._compare_binop_impl(other, GrizzlySeries.eq)
+        return self._arithmetic_binop_impl(other, GrizzlySeries.eq)
+
+    def ne(self, other):
+        return self._arithmetic_binop_impl(other, GrizzlySeries.ne)
 
     def ge(self, other):
-        return self._compare_binop_impl(other, GrizzlySeries.ge)
+        return self._arithmetic_binop_impl(other, GrizzlySeries.ge)
 
     def gt(self, other):
-        return self._compare_binop_impl(other, GrizzlySeries.gt)
+        return self._arithmetic_binop_impl(other, GrizzlySeries.gt)
 
     def le(self, other):
-        return self._compare_binop_impl(other, GrizzlySeries.le)
+        return self._arithmetic_binop_impl(other, GrizzlySeries.le)
 
     def lt(self, other):
-        return self._compare_binop_impl(other, GrizzlySeries.lt)
+        return self._arithmetic_binop_impl(other, GrizzlySeries.lt)
 
     def __add__(self, other):
         return self.add(other)
@@ -310,6 +313,9 @@ class GrizzlyDataFrame(Forwarding, GrizzlyBase):
 
     def __eq__(self, other):
         return self.eq(other)
+
+    def __ne__(self, other):
+        return self.e(other)
 
     def __ge__(self, other):
         return self.ge(other)

--- a/weld-python/weld/grizzly/core/generic.py
+++ b/weld-python/weld/grizzly/core/generic.py
@@ -78,5 +78,32 @@ class GrizzlyBase(ABC):
         """
         return self.weld_value.code
 
+    @classmethod
+    def scalar_ty(cls, value, cast_ty):
+        """
+        Returns the scalar Weld type of a scalar Python value. If the value is not a scalar,
+        returns None. For primitive 'int' values, returns 'cast_ty'.
+
+        This returns 'None' if the value type is not supported.
+
+        Parameters
+        ----------
+        value : any
+            value whose dtype to obtain.
+
+        Returns
+        -------
+        WeldType
+
+        """
+        if hasattr(value, 'dtype') and hasattr(value, 'shape') and value.shape == ():
+            return wenp.dtype_to_weld_type(value.dtype)
+        if isinstance(value, int):
+            return cast_ty
+        if isinstance(value, float):
+            return F64()
+        if isinstance(value, bool):
+            return Bool()
+
 
 

--- a/weld-python/weld/grizzly/core/generic.py
+++ b/weld-python/weld/grizzly/core/generic.py
@@ -16,6 +16,14 @@ class GrizzlyBase(ABC):
         """
         pass
 
+    @property
+    @abstractmethod
+    def is_value(self):
+        """
+        Returns whether this collection wraps a physical value rather than
+        a computation.
+        """
+        pass
 
     @abstractmethod
     def evaluate(self):
@@ -29,7 +37,6 @@ class GrizzlyBase(ABC):
 
         """
         pass
-
 
     @abstractmethod
     def to_pandas(self, copy=False):
@@ -48,7 +55,6 @@ class GrizzlyBase(ABC):
         """
         pass
 
-
     @property
     def children(self):
         """
@@ -65,13 +71,6 @@ class GrizzlyBase(ABC):
         """
         return self.weld_value.output_type
 
-    @property
-    def is_value(self):
-        """
-        Returns whether this collection wraps a physical value rather than
-        a computation.
-        """
-        return self.weld_value.is_identity or hasattr(self, "evaluating_")
 
     @property
     def code(self):

--- a/weld-python/weld/grizzly/core/generic.py
+++ b/weld-python/weld/grizzly/core/generic.py
@@ -71,7 +71,6 @@ class GrizzlyBase(ABC):
         """
         return self.weld_value.output_type
 
-
     @property
     def code(self):
         """

--- a/weld-python/weld/grizzly/core/generic.py
+++ b/weld-python/weld/grizzly/core/generic.py
@@ -1,0 +1,84 @@
+"""
+Base class for Grizzly collection types.
+
+"""
+
+from abc import ABC, abstractmethod
+
+class GrizzlyBase(ABC):
+
+    @property
+    @abstractmethod
+    def weld_value(self):
+        """
+        Returns the WeldLazy represention of this object.
+
+        """
+        pass
+
+
+    @abstractmethod
+    def evaluate(self):
+        """
+        Evaluates this collection and returns itself.
+
+        Evaluation reduces the currently stored computation to a physical value
+        by compiling and running a Weld program. If this collection refers
+        to a physical value and no computation, no program is compiled, and this
+        method returns `self` unmodified.
+
+        """
+        pass
+
+
+    @abstractmethod
+    def to_pandas(self, copy=False):
+        """
+        Evaluates this computation and coerces it into a pandas object.
+
+        This is guaranteed to be 0-copy if `self.is_value == True`. Otherwise,
+        some allocation may occur. Regardless, `self` and the returned value
+        will always have the same underlying data unless `copy = True`.
+
+        Parameters
+        ----------
+        copy : boolean, optional
+            Specifies whether the new collection should copy data from self
+
+        """
+        pass
+
+
+    @property
+    def children(self):
+        """
+        Returns the Weld children of this value.
+        """
+        return self.weld_value.children
+
+    @property
+    def output_type(self):
+        """
+        Returns the Weld output type of this collection.
+
+        The output type is always a `WeldVec` of some type.
+        """
+        return self.weld_value.output_type
+
+    @property
+    def is_value(self):
+        """
+        Returns whether this collection wraps a physical value rather than
+        a computation.
+        """
+        return self.weld_value.is_identity or hasattr(self, "evaluating_")
+
+    @property
+    def code(self):
+        """
+        Returns the Weld code for this computation.
+        """
+        return self.weld_value.code
+
+
+

--- a/weld-python/weld/grizzly/core/indexes/__init__.py
+++ b/weld-python/weld/grizzly/core/indexes/__init__.py
@@ -1,0 +1,2 @@
+
+from weld.grizzly.core.indexes.column import ColumnIndex

--- a/weld-python/weld/grizzly/core/indexes/base.py
+++ b/weld-python/weld/grizzly/core/indexes/base.py
@@ -1,0 +1,9 @@
+
+from abc import ABC
+
+class Index(ABC):
+    """
+    Base class for an index in Grizzly.
+
+    """
+    pass

--- a/weld-python/weld/grizzly/core/indexes/column.py
+++ b/weld-python/weld/grizzly/core/indexes/column.py
@@ -40,6 +40,9 @@ class ColumnIndex(Index):
             columns = list(columns)
         if slots is not None:
             assert len(columns) == len(slots)
+            sorted_slots = sorted(slots)
+            # Make sure each slot is occupied/there are no "holes".
+            assert sorted_slots == list(range(sorted_slots[-1]))
         else:
             slots = range(len(columns))
 
@@ -77,6 +80,34 @@ class ColumnIndex(Index):
             columns = sorted(list(set(self.columns).union(other.columns)))
             for name in columns:
                 yield (name, self.index.get(name), other.index.get(name))
+
+    def __getitem__(self, key):
+        """
+        Get the slot for a paritcular column name.
+
+        Examples
+        --------
+        >>> a = ColumnIndex(["name", "age"])
+        >>> a["age"]
+        1
+
+        """
+        return self.index[key]
+
+    def append(self, key):
+        """
+        Add a new column to the index. The slot is set to be `len(columns) - 1`.
+
+        Examples
+        --------
+        >>> a = ColumnIndex(["name", "age"])
+        >>> a.append("income")
+        >>> a["income"]
+        2
+
+        """
+        self.index[key] = len(self.columns)
+        self.columns.append(key)
 
     def __eq__(self, other):
         """

--- a/weld-python/weld/grizzly/core/indexes/column.py
+++ b/weld-python/weld/grizzly/core/indexes/column.py
@@ -1,0 +1,102 @@
+"""
+Index used for access columns in Grizzly.
+
+"""
+
+from weld.grizzly.core.indexes.base import Index
+
+class ColumnIndex(Index):
+    """
+    An index used for columns in a Grizzly DataFrame.
+
+    Each index value is a Python object. For operations between two DataFrames
+    with the same ColumnIndex, the result will also have the same index. For
+    operations between two DataFrames with different ColumnIndex, the output
+    will have a join of the two ColumnIndex, sorted by the index values.
+
+    Two ColumnIndex are equal if their index names are equal and have the same
+    order.
+
+    Parameters
+    ----------
+    columns : iterable
+        column names.
+    slots : iterable of int or None
+        slots associated with each column. If provided, the length must be
+        len(columns). This is used for underlying data access only; index
+        equality depends only on the column names and ordering.
+
+
+    Examples
+    --------
+    >>> index = ColumnIndex(["name", "age"])
+    >>> index
+    ColumnIndex(['name', 'age'])
+
+    """
+
+    def __init__(self, columns, slots=None):
+        if not isinstance(columns, list):
+            columns = list(columns)
+        if slots is not None:
+            assert len(columns) == len(slots)
+        else:
+            slots = range(len(columns))
+
+        # The original column order.
+        self.columns = columns
+        # The mapping from columns to slots.
+        self.index = dict(zip(columns, slots))
+
+    def zip(self, other):
+        """
+        Zips this index with 'other', returning an iterator of `(name,
+        slot_in_self, slot_in_other)`. The slot may be `None` if the name does
+        not appear in either column.
+
+        The result columns are ordered in a way consistent with how DataFrame
+        columns should be be ordered (i.e., same order `self` if `self ==
+        other`, and sorted by the union of columns from `self` and `other`
+        otherwise).
+
+        Examples
+        --------
+        >>> a = ColumnIndex(["name", "age"])
+        >>> b = ColumnIndex(["name", "age"])
+        >>> list(a.zip(b))
+        [('name', 0, 0), ('age', 1, 1)]
+        >>> b = ColumnIndex(["age", "income", "name"])
+        >>> list(a.zip(b))
+        [('age', 1, 0), ('income', None, 1), ('name', 0, 2)]
+
+        """
+        if self == other:
+            for name in self.columns:
+                yield (name, self.index[name], other.index[name])
+        else:
+            columns = sorted(list(set(self.columns).union(other.columns)))
+            for name in columns:
+                yield (name, self.index.get(name), other.index.get(name))
+
+    def __eq__(self, other):
+        """
+        Compare equality depending on column names.
+
+        Examples
+        --------
+        >>> a = ColumnIndex(["name", "age"])
+        >>> a == ColumnIndex(["name", "age"])
+        True
+        >>> a == ColumnIndex(["age", "name"])
+        False
+        >>> a == ColumnIndex(["name", "age", "income"])
+        False
+
+        """
+        return isinstance(other, ColumnIndex) and self.columns == other.columns
+
+    def __str__(self):
+        return "ColumnIndex({})".format(self.index)
+
+    def __repr__(self):
+        return "ColumnIndex({})".format(self.columns)

--- a/weld-python/weld/grizzly/core/series.py
+++ b/weld-python/weld/grizzly/core/series.py
@@ -37,6 +37,27 @@ class GrizzlySeries(Forwarding, GrizzlyBase, pd.Series):
     regular pandas behavior. Similarly, `GrizzlySeries` that are initialized with
     features that Grizzly does not understand are initialized as `pd.Series`.
 
+    Implementation Notes
+    --------------------
+
+    A Series in Grizzly is a 1D array of a single data type. Transformations on
+    Series can result in scalar values, which are directly evaluated and
+    returned as scalars, as other Series that encapsulate lazy Weld
+    computations, or as DataFrames (currently unsupported).
+
+    A Series always has a known type: unlike pandas Series, which are wrappers
+    around Python object, Series with heterogeneous types (i.e., Series with
+    `dtype=object`) are disallowed. Series that are not evaluated/store a lazy
+    compuations also always have a known type.
+
+    Internally, most Series are backed by NumPy arrays, which themselves are
+    stored as contiguous C arrays. The main exception is string data. Grizzly
+    operates exclusively over UTF-8 encoded data, and most string operations
+    will create a copy of the input data upon evaluation. Strings are currently
+    encoded as NumPy arrays with the 'S' dtype: this may change in the future
+    (the 'S' dtype forces memory usage per string to match the length of the
+    largest string in the array, which is clearly suboptimal).
+
     Parameters
     ----------
 
@@ -44,6 +65,8 @@ class GrizzlySeries(Forwarding, GrizzlyBase, pd.Series):
         Contains data stored in the series.
     dtype : numpy.dtype or str
         Data type of the values.
+    name : str
+        A name to give the series.
 
     Examples
     --------

--- a/weld-python/weld/grizzly/core/series.py
+++ b/weld-python/weld/grizzly/core/series.py
@@ -623,10 +623,16 @@ class GrizzlySeries(Forwarding, GrizzlyBase):
             right_ty = other.elem_type
             rightval = other.weld_value
 
-        if isinstance(left_ty, (WeldVec, WeldStruct)) or isinstance(right_ty, (WeldVec, WeldStruct)):
+        is_string = isinstance(left_ty, WeldVec)
+        if op != "==" and op != "!=" and is_string:
             raise TypeError("Unsupported operand type(s) for '{}': {} and {}".format(op, left_ty, right_ty))
 
-        cast_type = wenp.binop_output_type(left_ty, right_ty, truediv)
+        # Don't cast if we're dealing with strings.
+        if is_string:
+            cast_type = ""
+        else:
+            cast_type = wenp.binop_output_type(left_ty, right_ty, truediv)
+
         output_type = cast_type if weld_elem_type is None else weld_elem_type
         lazy = binary_map(op,
                 left_type=str(left_ty),
@@ -771,6 +777,22 @@ class GrizzlySeries(Forwarding, GrizzlyBase):
         """
         return self._compare_binop_impl(other, '==')
 
+    def ne(self, other):
+        """
+        Performs an element-wise not-equal comparison.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([10, 20, 30])
+        >>> s.eq(10).evaluate()
+        0    False
+        1     True
+        2     True
+        dtype: bool
+
+        """
+        return self._compare_binop_impl(other, '!=')
+
     def ge(self, other):
         """
         Performs an element-wise '>=' comparison.
@@ -855,6 +877,9 @@ class GrizzlySeries(Forwarding, GrizzlyBase):
 
     def __eq__(self, other):
         return self.eq(other)
+
+    def __ne__(self, other):
+        return self.ne(other)
 
     def __ge__(self, other):
         return self.ge(other)

--- a/weld-python/weld/grizzly/core/series.py
+++ b/weld-python/weld/grizzly/core/series.py
@@ -590,6 +590,23 @@ class GrizzlySeries(Forwarding, GrizzlyBase):
     def _arithmetic_binop_impl(self, other, op, truediv=False, weld_elem_type=None):
         """
         Performs the operation on two `Series` elementwise.
+
+        Parameters
+        ----------
+        other: scalar or GrizzlySeries
+            the RHS operand
+        op: str
+            the operator to apply.
+        truediv: bool, optional
+            is this a truediv?
+        weld_elem_type: WeldType or None
+            the element type produced by this operation. None
+            means it is inferred based on Numpy's type conversion rules.
+
+        Returns
+        -------
+        GrizzlySeries
+
         """
         left_ty = self.elem_type
         scalar_ty = GrizzlySeries.scalar_ty(other, left_ty)
@@ -605,6 +622,9 @@ class GrizzlySeries(Forwarding, GrizzlyBase):
                 raise GrizzlyError("RHS of binary operator must be a GrizzlySeries")
             right_ty = other.elem_type
             rightval = other.weld_value
+
+        if isinstance(left_ty, (WeldVec, WeldStruct)) or isinstance(right_ty, (WeldVec, WeldStruct)):
+            raise TypeError("Unsupported operand type(s) for '{}': {} and {}".format(op, left_ty, right_ty))
 
         cast_type = wenp.binop_output_type(left_ty, right_ty, truediv)
         output_type = cast_type if weld_elem_type is None else weld_elem_type
@@ -624,39 +644,195 @@ class GrizzlySeries(Forwarding, GrizzlyBase):
         return self._arithmetic_binop_impl(other, op, weld_elem_type=Bool())
 
     def add(self, other):
+        """
+        Performs an element-wise addition.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([10, 20, 30])
+        >>> s.add(10).evaluate()
+        0    20
+        1    30
+        2    40
+        dtype: int64
+
+        """
         return self._arithmetic_binop_impl(other, '+')
 
     def sub(self, other):
+        """
+        Performs an element-wise subtraction.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([10, 20, 30])
+        >>> s.sub(10).evaluate()
+        0     0
+        1    10
+        2    20
+        dtype: int64
+
+        """
         return self._arithmetic_binop_impl(other, '-')
 
     def mod(self, other):
+        """
+        Performs an element-wise modulo.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([10, 25, 31])
+        >>> s.mod(10).evaluate()
+        0    0
+        1    5
+        2    1
+        dtype: int64
+
+        """
         return self._arithmetic_binop_impl(other, '%')
 
     def mul(self, other):
+        """
+        Performs an element-wise multiplication.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([10, 25, 31])
+        >>> s.mul(10).evaluate()
+        0    100
+        1    250
+        2    310
+        dtype: int64
+
+        """
         return self._arithmetic_binop_impl(other, '*')
 
     def truediv(self, other):
+        """
+        Performs an element-wise "true" division.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([10, 20, 30])
+        >>> s.truediv(10).evaluate()
+        0    1.0
+        1    2.0
+        2    3.0
+        dtype: float64
+
+        """
         return self._arithmetic_binop_impl(other, '/', truediv=True)
 
     def divide(self, other):
+        """
+        Performs an element-wise "true" division.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([10, 20, 30])
+        >>> s.divide(10).evaluate()
+        0    1.0
+        1    2.0
+        2    3.0
+        dtype: float64
+
+        """
         return self.truediv(other)
 
     def div(self, other):
+        """
+        Performs an element-wise "true" division.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([10, 20, 30])
+        >>> s.div(10).evaluate()
+        0    1.0
+        1    2.0
+        2    3.0
+        dtype: float64
+
+        """
         return self.truediv(other)
 
     def eq(self, other):
+        """
+        Performs an element-wise equality comparison.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([10, 20, 30])
+        >>> s.eq(10).evaluate()
+        0     True
+        1    False
+        2    False
+        dtype: bool
+
+        """
         return self._compare_binop_impl(other, '==')
 
     def ge(self, other):
+        """
+        Performs an element-wise '>=' comparison.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([10, 20, 30])
+        >>> s.ge(20).evaluate()
+        0    False
+        1     True
+        2     True
+        dtype: bool
+
+        """
         return self._compare_binop_impl(other, '>=')
 
     def gt(self, other):
+        """
+        Performs an element-wise '>' comparison.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([10, 20, 30])
+        >>> s.gt(20).evaluate()
+        0    False
+        1    False
+        2     True
+        dtype: bool
+
+        """
         return self._compare_binop_impl(other, '>')
 
     def le(self, other):
+        """
+        Performs an element-wise '<=' comparison.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([10, 20, 30])
+        >>> s.le(20).evaluate()
+        0     True
+        1     True
+        2    False
+        dtype: bool
+
+        """
         return self._compare_binop_impl(other, '<=')
 
     def lt(self, other):
+        """
+        Performs an element-wise '<' comparison.
+
+        Examples
+        --------
+        >>> s = GrizzlySeries([10, 20, 30])
+        >>> s.lt(20).evaluate()
+        0     True
+        1    False
+        2    False
+        dtype: bool
+
+        """
         return self._compare_binop_impl(other, '<')
 
     def __add__(self, other):

--- a/weld-python/weld/grizzly/core/series.py
+++ b/weld-python/weld/grizzly/core/series.py
@@ -48,6 +48,10 @@ class GrizzlySeries(Forwarding, GrizzlyBase):
     (the 'S' dtype forces memory usage per string to match the length of the
     largest string in the array, which is clearly suboptimal).
 
+    Unlike pandas Series, GrizzlySeries do not support alignment of index
+    values for performance reasons. To align the indices of two Series, consider
+    using a DataFrame with a join operator.
+
     Parameters
     ----------
 

--- a/weld-python/weld/grizzly/core/series.py
+++ b/weld-python/weld/grizzly/core/series.py
@@ -784,7 +784,7 @@ class GrizzlySeries(Forwarding, GrizzlyBase):
         Examples
         --------
         >>> s = GrizzlySeries([10, 20, 30])
-        >>> s.eq(10).evaluate()
+        >>> s.ne(10).evaluate()
         0    False
         1     True
         2     True

--- a/weld-python/weld/grizzly/core/series.py
+++ b/weld-python/weld/grizzly/core/series.py
@@ -583,33 +583,6 @@ class GrizzlySeries(Forwarding, GrizzlyBase):
 
     # ---------------------- Operators ------------------------------
 
-    @classmethod
-    def scalar_ty(cls, value, cast_ty):
-        """
-        Returns the scalar Weld type of a scalar Python value. If the value is not a scalar,
-        returns None. For primitive 'int' values, returns 'cast_ty'.
-
-        This returns 'None' if the value type is not supported.
-
-        Parameters
-        ----------
-        value : any
-            value whose dtype to obtain.
-
-        Returns
-        -------
-        np.dtype
-
-        """
-        if hasattr(value, 'dtype') and hasattr(value, 'shape') and value.shape == ():
-            return wenp.dtype_to_weld_type(value.dtype)
-        if isinstance(value, int):
-            return cast_ty
-        if isinstance(value, float):
-            return F64()
-        if isinstance(value, bool):
-            return Bool()
-
     def _arithmetic_binop_impl(self, other, op, truediv=False, weld_elem_type=None):
         """
         Performs the operation on two `Series` elementwise.

--- a/weld-python/weld/grizzly/weld/ops.py
+++ b/weld-python/weld/grizzly/weld/ops.py
@@ -36,6 +36,22 @@ def _binary_apply(op, leftval, rightval, cast_type, infix=True):
                 op=op, leftval=leftval, rightval=rightval, cast_type=cast_type)
 
 @weld.lazy.weldfunc
+def make_struct(*args):
+    """
+    Constructs a struct with the provided args.
+
+    Examples
+    --------
+    >>> make_struct("weldlazy1", "2", "3").code
+    '{weldlazy1, 2, 3}'
+    >>> make_struct("weldlazy1").code
+    '{weldlazy1}'
+
+    """
+    assert len(args) > 0
+    return "{" + ", ".join(args) + "}"
+
+@weld.lazy.weldfunc
 def unary_map(op, ty, value):
     """
     Constructs a Weld string to apply a unary function to a vector.

--- a/weld-python/weld/types.py
+++ b/weld-python/weld/types.py
@@ -22,6 +22,9 @@ class WeldType(ABC):
         """
         pass
 
+    def __repr__(self):
+        return str(self)
+
     def __eq__(self, other):
         return str(self) == str(other)
 


### PR DESCRIPTION
Implements the foundations of a API-compatible DataFrame backed by Weld.

DataFrames are dictionary-like containers of Series of the same length. Each Series can be a different data type. Operations on DataFrames align on column name. Unlike pandas, DataFrame operations do not align on row indexes. This will likely be the permanent behavior o Grizzly, as implementing row-based indexing requires forgoing many data-parallel optimizations.

This patch adds the foundation of the `DataFrame` class: evaluating Weld computations, converting Grizzly DataFrames to Pandas DataFrames, and basic binary operations. It also adds a new class, `ColumnIndex`, that facilitates aligning columns when performing operations between DataFrames.

## Examples

```python
>>> df = GrizzlyDataFrame({'name': ['mike', 'sam', 'sally'], 'age': [20, 22, 56]})
>>> df
    name  age
0   mike   20
1    sam   22
2  sally   56
>>> df2 = GrizzlyDataFrame({'nom': ['jacques', 'kelly', 'marie'], 'age': [50, 60, 70]})
>>> df.add(df2).to_pandas()
   age  name  nom
0   70   NaN  NaN
1   82   NaN  NaN
2  126   NaN  NaN
```

## Other Changes in this patch

This patch makes some other restructuring changes. Namely
* Forwarding calls automatically to Pandas is disabled for now. Users should explicitly use `to_pandas()`.
* `GrizzlySeries` no longer subclasses `Series`. The main purpose of this was method forwarding; without this feature, subclassing just adds unnecessary constraints.
* Adds the ability to deserialize structs of NumPy vectors in the `NumPyWeldEncoder`.